### PR TITLE
[MAINTENANCE] Improve mechanism to share results between checkpoint actions

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -98,10 +98,11 @@ class ActionContext:
         return [action_result for action, action_result in self._data if action.__class__ is class_]
 
     def dict(self) -> dict:
+        # Method is only used in legacy Checkpoint and should be removed
         data = {}
         for action, action_result in self._data:
-            data[action["name"]] = action_result
-            data[action["name"]]["class"] = action["action"]["class_name"]
+            data[action["name"]] = action_result  # type: ignore[index]
+            data[action["name"]]["class"] = action["action"]["class_name"]  # type: ignore[index]
         return data
 
 
@@ -351,6 +352,7 @@ class SlackNotificationAction(DataDocsAction):
             # To send a notification with a link to the validation result, we need to have created the validation  # noqa: E501
             # result in cloud. If the user has configured the store action after the notification action, they will  # noqa: E501
             # get a warning that no link will be provided. See the __init__ method for ActionListValidationOperator.  # noqa: E501
+            action_context = action_context or ActionContext()
             store_validation_results = action_context.filter_results_by_class(
                 StoreValidationResultAction
             )

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -99,7 +99,7 @@ class ActionContext:
         self._data.append((action, action_result))
 
     def filter_results(self, class_: Type[ValidationAction]) -> list[dict]:
-        return [action_result for action, action_result in self._data if action.__class__ is class_]
+        return [action_result for action, action_result in self._data if isinstance(action, class_)]
 
 
 @public_api
@@ -352,12 +352,11 @@ class SlackNotificationAction(DataDocsAction):
             store_validation_results = action_context.filter_results(
                 class_=StoreValidationResultAction
             )
-            if store_validation_results:
-                for payload in store_validation_results:
-                    if "validation_result_url" in payload:
-                        validation_result_urls.append(
-                            payload["store_validation_result"]["validation_result_url"]
-                        )
+            for payload in store_validation_results:
+                if "validation_result_url" in payload:
+                    validation_result_urls.append(
+                        payload["store_validation_result"]["validation_result_url"]
+                    )
 
         result = {"slack_notification_result": "none required"}
         if self._is_enabled(success=validation_success):

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -94,7 +94,7 @@ class ActionContext:
     def update(self, action: ValidationAction, action_result: dict) -> None:
         self._data.append((action, action_result))
 
-    def filter_results_by_class(self, class_: Type[ValidationAction]) -> list[dict]:
+    def filter_results(self, class_: Type[ValidationAction]) -> list[dict]:
         return [action_result for action, action_result in self._data if action.__class__ is class_]
 
     def dict(self) -> dict:
@@ -333,7 +333,7 @@ class SlackNotificationAction(DataDocsAction):
         validation_success = validation_result_suite.success
         data_docs_pages = None
         if action_context:
-            data_docs_pages = action_context.filter_results_by_class(UpdateDataDocsAction)
+            data_docs_pages = action_context.filter_results(class_=UpdateDataDocsAction)
 
         # Assemble complete GX Cloud URL for a specific validation result
         data_docs_urls: list[dict[str, str]] = self._get_docs_sites_urls(
@@ -353,8 +353,8 @@ class SlackNotificationAction(DataDocsAction):
             # result in cloud. If the user has configured the store action after the notification action, they will  # noqa: E501
             # get a warning that no link will be provided. See the __init__ method for ActionListValidationOperator.  # noqa: E501
             action_context = action_context or ActionContext()
-            store_validation_results = action_context.filter_results_by_class(
-                StoreValidationResultAction
+            store_validation_results = action_context.filter_results(
+                class_=StoreValidationResultAction
             )
             if store_validation_results:
                 for payload in store_validation_results:
@@ -583,7 +583,7 @@ class MicrosoftTeamsNotificationAction(ValidationAction):
 
         data_docs_pages = None
         if action_context:
-            data_docs_pages = action_context.filter_results_by_class(UpdateDataDocsAction)
+            data_docs_pages = action_context.filter_results(class_=UpdateDataDocsAction)
 
         if self._is_enabled(success=validation_success):
             query = self.renderer.render(
@@ -876,7 +876,7 @@ class EmailAction(ValidationAction):
 
         data_docs_pages = None
         if action_context:
-            data_docs_pages = action_context.filter_results_by_class(UpdateDataDocsAction)
+            data_docs_pages = action_context.filter_results(class_=UpdateDataDocsAction)
 
         if self._is_enabled(success=validation_success):
             title, html = self.renderer.render(

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -91,19 +91,15 @@ class ActionContext:
     def __init__(self) -> None:
         self._data: list[tuple[ValidationAction, dict]] = []
 
+    @property
+    def data(self) -> list[tuple[ValidationAction, dict]]:
+        return self._data
+
     def update(self, action: ValidationAction, action_result: dict) -> None:
         self._data.append((action, action_result))
 
     def filter_results(self, class_: Type[ValidationAction]) -> list[dict]:
         return [action_result for action, action_result in self._data if action.__class__ is class_]
-
-    def dict(self) -> dict:
-        # Method is only used in legacy Checkpoint and should be removed
-        data = {}
-        for action, action_result in self._data:
-            data[action["name"]] = action_result  # type: ignore[index]
-            data[action["name"]]["class"] = action["action"]["class_name"]  # type: ignore[index]
-        return data
 
 
 @public_api

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -89,13 +89,20 @@ class ActionContext:
     """
 
     def __init__(self) -> None:
-        self._data: list[tuple[Type[ValidationAction], dict]] = []
+        self._data: list[tuple[ValidationAction, dict]] = []
 
     def update(self, action: ValidationAction, action_result: dict) -> None:
-        self._data.append((action.__class__, action_result))
+        self._data.append((action, action_result))
 
     def filter_results_by_class(self, class_: Type[ValidationAction]) -> list[dict]:
-        return [payload for action_class, payload in self._data if action_class is class_]
+        return [payload for action, payload in self._data if action.__class__ is class_]
+
+    def dict(self) -> dict:
+        data = {}
+        for action, action_result in self._data:
+            data[action["name"]] = action_result
+            data[action["name"]]["class"] = action["action"]["class_name"]
+        return data
 
 
 @public_api

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -95,7 +95,7 @@ class ActionContext:
         self._data.append((action, action_result))
 
     def filter_results_by_class(self, class_: Type[ValidationAction]) -> list[dict]:
-        return [payload for action, payload in self._data if action.__class__ is class_]
+        return [action_result for action, action_result in self._data if action.__class__ is class_]
 
     def dict(self) -> dict:
         data = {}

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -186,7 +186,9 @@ class ValidationAction(BaseModel):
         """  # noqa: E501
 
     # NOTE: To be promoted to 'run' after V1 development (JIRA: V1-271)
-    def v1_run(self, checkpoint_result: CheckpointResult) -> str | dict:
+    def v1_run(
+        self, checkpoint_result: CheckpointResult, action_context: ActionContext
+    ) -> str | dict:
         raise NotImplementedError
 
     def _is_enabled(self, success: bool) -> bool:
@@ -430,7 +432,7 @@ class PagerdutyAlertAction(ValidationAction):
     severity: Literal["critical", "error", "warning", "info"] = "critical"
 
     @override
-    def v1_run(self, checkpoint_result: CheckpointResult) -> dict:
+    def v1_run(self, checkpoint_result: CheckpointResult, action_context: ActionContext) -> dict:
         success = checkpoint_result.success or False
         checkpoint_name = checkpoint_result.checkpoint_config.name
         summary = f"Great Expectations Checkpoint {checkpoint_name} has "
@@ -639,7 +641,7 @@ class OpsgenieAlertAction(ValidationAction):
         return renderer
 
     @override
-    def v1_run(self, checkpoint_result: CheckpointResult) -> dict:
+    def v1_run(self, checkpoint_result: CheckpointResult, action_context: ActionContext) -> dict:
         validation_success = checkpoint_result.success or False
         checkpoint_name = checkpoint_result.checkpoint_config.name
 
@@ -809,7 +811,9 @@ class EmailAction(ValidationAction):
         return values
 
     @override
-    def v1_run(self, checkpoint_result: CheckpointResult) -> str | dict:
+    def v1_run(
+        self, checkpoint_result: CheckpointResult, action_context: ActionContext
+    ) -> str | dict:
         success = checkpoint_result.success or False
         if not self._is_enabled(success=success):
             return {"email_result": ""}
@@ -995,7 +999,7 @@ class UpdateDataDocsAction(DataDocsAction):
     site_names: List[str] = []
 
     @override
-    def v1_run(self, checkpoint_result: CheckpointResult) -> dict:
+    def v1_run(self, checkpoint_result: CheckpointResult, action_context: ActionContext) -> dict:
         action_results: dict[ValidationResultIdentifier, dict] = {}
         for result_identifier, result in checkpoint_result.run_results.items():
             suite_name = result.suite_name
@@ -1096,7 +1100,7 @@ class SNSNotificationAction(ValidationAction):
     sns_message_subject: Optional[str]
 
     @override
-    def v1_run(self, checkpoint_result: CheckpointResult) -> str:
+    def v1_run(self, checkpoint_result: CheckpointResult, action_context: ActionContext) -> str:
         return send_sns_notification(
             sns_topic_arn=self.sns_topic_arn,
             sns_subject=self.sns_message_subject or checkpoint_result.name,
@@ -1146,7 +1150,7 @@ class APINotificationAction(ValidationAction):
     url: str
 
     @override
-    def v1_run(self, checkpoint_result: CheckpointResult) -> str:
+    def v1_run(self, checkpoint_result: CheckpointResult, action_context: ActionContext) -> str:
         aggregate_payload = []
         for run_id, run_result in checkpoint_result.run_results.items():
             suite_name = run_result.suite_name

--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, c
 import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
 from great_expectations.checkpoint.actions import (
+    ActionContext,
     EmailAction,
     MicrosoftTeamsNotificationAction,
     OpsgenieAlertAction,
@@ -219,10 +220,13 @@ class Checkpoint(BaseModel):
         self,
         checkpoint_result: CheckpointResult,
     ) -> None:
+        action_context = ActionContext()
         for action in self.actions:
-            action.v1_run(
+            action_result = action.v1_run(
                 checkpoint_result=checkpoint_result,
+                action_context=action_context,
             )
+            action_context.update(action=action, action_result=action_result)
 
     @public_api
     def save(self) -> None:

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from typing import TYPE_CHECKING, Optional
 
 import great_expectations.exceptions as gx_exceptions
+from great_expectations.checkpoint.actions import ActionContext
 from great_expectations.checkpoint.util import send_slack_notification
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_asset.util import parse_result_format
@@ -395,7 +396,7 @@ class ActionListValidationOperator(ValidationOperator):
         :param run_id:
         :return: a dictionary: {action name -> result returned by the action}
         """
-        batch_actions_results = {}
+        action_context = ActionContext()
         for action in self.action_list:
             # NOTE: Eugene: 2019-09-23: log the info about the batch and the expectation suite
             name = action["name"]
@@ -416,7 +417,7 @@ class ActionListValidationOperator(ValidationOperator):
                 action_result = self.actions[name].run(
                     validation_result_suite_identifier=validation_result_id,
                     validation_result_suite=batch_validation_result,
-                    payload=batch_actions_results,
+                    action_context=action_context,
                     expectation_suite_identifier=expectation_suite_identifier,
                     checkpoint_identifier=checkpoint_identifier,
                 )
@@ -435,14 +436,13 @@ class ActionListValidationOperator(ValidationOperator):
                     transformed_result = action_result
 
                 # add action_result
-                batch_actions_results[action["name"]] = transformed_result
-                batch_actions_results[action["name"]]["class"] = action["action"]["class_name"]
+                action_context.update(action=action, action_result=transformed_result)
 
             except Exception as e:
                 logger.exception(f"Error running action with name {action['name']}")
                 raise e  # noqa: TRY201
 
-        return batch_actions_results
+        return action_context.dict()
 
 
 class WarningAndFailureExpectationSuitesValidationOperator(ActionListValidationOperator):

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -442,7 +442,12 @@ class ActionListValidationOperator(ValidationOperator):
                 logger.exception(f"Error running action with name {action['name']}")
                 raise e  # noqa: TRY201
 
-        return action_context.dict()
+        action_data = {}
+        for action, action_result in action_context.data:
+            action_data[action["name"]] = action_result
+            action_data[action["name"]]["class"] = action["action"]["class_name"]
+
+        return action_data
 
 
 class WarningAndFailureExpectationSuitesValidationOperator(ActionListValidationOperator):

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -1040,7 +1040,8 @@ class TestV1ActionRun:
             sns_message_subject="Subject",
         )
 
-        assert "Successfully posted results" in action.v1_run(checkpoint_result=checkpoint_result)
+        result = action.v1_run(checkpoint_result=checkpoint_result)
+        assert "Successfully posted results" in result["result"]
 
     @pytest.mark.unit
     def test_UpdateDataDocsAction_run(

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -507,7 +507,7 @@ class TestCheckpointResult:
             result = checkpoint.run()
 
         assert mock_run.call_count == len(actions)
-        mock_run.assert_called_with(checkpoint_result=result)
+        mock_run.assert_called_with(checkpoint_result=result, action_context=mock.ANY)
 
     @pytest.mark.unit
     def test_checkpoint_run_passes_through_runtime_params(


### PR DESCRIPTION
Currently use a black-box dict called `payload`. Let's provide a bit more here in the way of naming and utility methods

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
