### PR TITLE
[MAINTENANCE] Export `great_expectations.data_context` types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
           SNOWFLAKE_CI_USER_PASSWORD: ${{secrets.SNOWFLAKE_CI_USER_PASSWORD}}
           LOGGING_LEVEL: DEBUG
           ENVIRONMENT: local
-        run: invoke ci-tests 'cloud' --up-services --verbose
+        run: invoke ci-tests 'cloud' --up-services --verbose W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
   marker-tests:
     needs: [unit-tests, static-analysis]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
           SNOWFLAKE_CI_USER_PASSWORD: ${{secrets.SNOWFLAKE_CI_USER_PASSWORD}}
           LOGGING_LEVEL: DEBUG
           ENVIRONMENT: local
-        run: invoke ci-tests 'cloud' --up-services --verbose W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
+        run: invoke ci-tests 'cloud' --up-services --verbose -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
   marker-tests:
     needs: [unit-tests, static-analysis]

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4373,7 +4373,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         return self._datasources
 
     @property
-    def fluent_datasources(self) -> Dict[str, FluentDatasource]:
+    def fluent_datasources(self) -> Mapping[str, FluentDatasource]:
         return {
             name: ds
             for (name, ds) in self.datasources.items()

--- a/great_expectations/datasource/fluent/config.py
+++ b/great_expectations/datasource/fluent/config.py
@@ -1,4 +1,5 @@
 """POC for loading config."""
+
 from __future__ import annotations
 
 import logging
@@ -13,6 +14,7 @@ from typing import (
     Dict,
     Final,
     List,
+    Mapping,
     Set,
     Tuple,
     Type,
@@ -146,7 +148,7 @@ class GxConfig(FluentBaseModel):
                 f"'{datasource_name}' not found. Available datasources are {self.get_datasource_names()}"
             ) from exc
 
-    def update_datasources(self, datasources: Dict[str, Datasource]) -> None:
+    def update_datasources(self, datasources: Mapping[str, Datasource]) -> None:
         """
         Updates internal list of datasources using supplied datasources dictionary.
 
@@ -267,8 +269,7 @@ class GxConfig(FluentBaseModel):
         encoder: Union[Callable[[Any], Any], None] = ...,
         models_as_dict: bool = ...,
         **yaml_kwargs,
-    ) -> str:
-        ...
+    ) -> str: ...
 
     @overload
     def yaml(
@@ -284,8 +285,7 @@ class GxConfig(FluentBaseModel):
         encoder: Union[Callable[[Any], Any], None] = ...,
         models_as_dict: bool = ...,
         **yaml_kwargs,
-    ) -> pathlib.Path:
-        ...
+    ) -> pathlib.Path: ...
 
     @override
     def yaml(  # noqa: PLR0913

--- a/great_expectations/datasource/fluent/config.py
+++ b/great_expectations/datasource/fluent/config.py
@@ -269,7 +269,8 @@ class GxConfig(FluentBaseModel):
         encoder: Union[Callable[[Any], Any], None] = ...,
         models_as_dict: bool = ...,
         **yaml_kwargs,
-    ) -> str: ...
+    ) -> str:
+        ...
 
     @overload
     def yaml(
@@ -285,7 +286,8 @@ class GxConfig(FluentBaseModel):
         encoder: Union[Callable[[Any], Any], None] = ...,
         models_as_dict: bool = ...,
         **yaml_kwargs,
-    ) -> pathlib.Path: ...
+    ) -> pathlib.Path:
+        ...
 
     @override
     def yaml(  # noqa: PLR0913

--- a/tasks.py
+++ b/tasks.py
@@ -8,6 +8,7 @@ To show all available tasks `invoke --list`
 
 To show task help page `invoke <NAME> --help`
 """
+
 from __future__ import annotations
 
 import logging
@@ -277,7 +278,7 @@ def type_check(  # noqa: PLR0913, PLR0912
         print(f"  Clearing {mypy_cache} ... ", end="")
         try:
             shutil.rmtree(mypy_cache)
-            print("✅"),
+            (print("✅"),)
         except FileNotFoundError as exc:
             print(f"❌\n  {exc}")
 
@@ -995,10 +996,14 @@ def docs_snippet_tests(
 
 
 @invoke.task(
-    help={"pty": _PTY_HELP_DESC},
+    help={
+        "pty": _PTY_HELP_DESC,
+        "reports": "Generate coverage reports to be uploaded to codecov",
+        "W": "Warnings control",
+    },
     iterable=["service_names", "up_services", "verbose"],
 )
-def ci_tests(  # noqa: PLR0913
+def ci_tests(  # noqa: C901 - too complex (9)
     ctx: Context,
     marker: str,
     up_services: bool = False,
@@ -1008,6 +1013,7 @@ def ci_tests(  # noqa: PLR0913
     slowest: int = 5,
     timeout: float = 0.0,  # 0 indicates no timeout
     xdist: bool = False,
+    W: str | None = None,
     pty: bool = True,
 ):
     """
@@ -1037,6 +1043,10 @@ def ci_tests(  # noqa: PLR0913
 
     if verbose:
         pytest_options.append("-vv")
+
+    if W:
+        # https://docs.python.org/3/library/warnings.html#describing-warning-filters
+        pytest_options.append(f"-W={W}")
 
     for test_deps in _get_marker_dependencies(marker):
         if restart_services or up_services:
@@ -1096,8 +1106,7 @@ def service(
             cmds = []
 
             if (
-                service_name == "mercury"
-                and os.environ.get("CI") != "true"  # noqa: TID251
+                service_name == "mercury" and os.environ.get("CI") != "true"  # noqa: TID251
             ):
                 cmds.extend(
                     [

--- a/tasks.py
+++ b/tasks.py
@@ -278,7 +278,7 @@ def type_check(  # noqa: PLR0913, PLR0912
         print(f"  Clearing {mypy_cache} ... ", end="")
         try:
             shutil.rmtree(mypy_cache)
-            (print("✅"),)
+            print("✅")
         except FileNotFoundError as exc:
             print(f"❌\n  {exc}")
 

--- a/tasks.py
+++ b/tasks.py
@@ -1003,7 +1003,7 @@ def docs_snippet_tests(
     },
     iterable=["service_names", "up_services", "verbose"],
 )
-def ci_tests(  # - too complex (9)
+def ci_tests(  # noqa: PLR0913
     ctx: Context,
     marker: str,
     up_services: bool = False,
@@ -1106,8 +1106,7 @@ def service(
             cmds = []
 
             if (
-                service_name == "mercury"
-                and os.environ.get("CI") != "true"  # noqa: TID251
+                service_name == "mercury" and os.environ.get("CI") != "true"  # noqa: TID251
             ):
                 cmds.extend(
                     [

--- a/tasks.py
+++ b/tasks.py
@@ -1003,7 +1003,7 @@ def docs_snippet_tests(
     },
     iterable=["service_names", "up_services", "verbose"],
 )
-def ci_tests(  # noqa: C901 - too complex (9)
+def ci_tests(  # - too complex (9)
     ctx: Context,
     marker: str,
     up_services: bool = False,
@@ -1106,7 +1106,8 @@ def service(
             cmds = []
 
             if (
-                service_name == "mercury" and os.environ.get("CI") != "true"  # noqa: TID251
+                service_name == "mercury"
+                and os.environ.get("CI") != "true"  # noqa: TID251
             ):
                 cmds.extend(
                     [

--- a/tasks.py
+++ b/tasks.py
@@ -1106,7 +1106,8 @@ def service(
             cmds = []
 
             if (
-                service_name == "mercury" and os.environ.get("CI") != "true"  # noqa: TID251
+                service_name == "mercury"
+                and os.environ.get("CI") != "true"  # noqa: TID251
             ):
                 cmds.extend(
                     [


### PR DESCRIPTION
Set the return type of `context.fluent_datasources` to be an immutable `Mapping` to reflect that it should not be modified.

- See https://github.com/great-expectations/great_expectations/issues/9690

We also need to export the types for the `great_expectations.data_context` package so that type-checkers will actually raise warnings about improper usage.

- For more a more in-depth explanation see -> https://github.com/great-expectations/great_expectations/pull/7438