### PR TITLE
[DOCS] Fix Overlay Bug on Desktop

### DIFF
--- a/docs/docusaurus/src/theme/DocSidebarItems/index.js
+++ b/docs/docusaurus/src/theme/DocSidebarItems/index.js
@@ -2,11 +2,13 @@ import React from 'react';
 import DocSidebarItems from '@theme-original/DocSidebarItems';
 import {useNavbarMobileSidebar} from "@docusaurus/theme-common/internal";
 import BrowserOnly from "@docusaurus/BrowserOnly";
+const MOBILE_BREAKPOINT = 996;
 
 export default function DocSidebarItemsWrapper(props) {
     const mobileSidebar = useNavbarMobileSidebar();
+
     const handleMobileDocSidebarItemClick = (item) => {
-        if(window.innerWidth > 996) return;
+        if(window.innerWidth > MOBILE_BREAKPOINT) return;
         if (!props.onItemClick) return;
         if (item.type === 'link') {
             mobileSidebar.toggle();

--- a/docs/docusaurus/src/theme/DocSidebarItems/index.js
+++ b/docs/docusaurus/src/theme/DocSidebarItems/index.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import DocSidebarItems from '@theme-original/DocSidebarItems';
 import {useNavbarMobileSidebar} from "@docusaurus/theme-common/internal";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export default function DocSidebarItemsWrapper(props) {
     const mobileSidebar = useNavbarMobileSidebar();
     const handleMobileDocSidebarItemClick = (item) => {
-        if (!props.onItemClick) return
+        if(window.innerWidth > 996) return;
+        if (!props.onItemClick) return;
         if (item.type === 'link') {
             mobileSidebar.toggle();
         }
     }
   return (
-      <DocSidebarItems {...props} onItemClick={handleMobileDocSidebarItemClick} />
+      <BrowserOnly>{() => <DocSidebarItems {...props} onItemClick={handleMobileDocSidebarItemClick} />}</BrowserOnly>
   );
 }


### PR DESCRIPTION
Fix to the bug on [the "make left navigation responsive" PR](https://github.com/great-expectations/great_expectations/pull/9652) that caused the screen to turn gray when clicking a subpage on the menu on desktop. There was some behavior that belongs to mobile (the gray overlay when the sidebar menu opens) that was being applied to desktop as well.
- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
