### PR TITLE
[MAINTENANCE] Pin `snowflake-sqlalchemy` due to `1.5.2` runtime bug

### DIFF
--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,4 +1,4 @@
 pandas<2.2.0; python_version >= "3.9"
 snowflake-connector-python>=2.5.0; python_version < "3.11"
 snowflake-connector-python>2.9.0; python_version >= "3.11" # earlier versions fail to build on 3.11
-snowflake-sqlalchemy>=1.2.3;!=1.5.2 # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485
+snowflake-sqlalchemy>=1.2.3,!=1.5.2 # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485

--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,4 +1,4 @@
 pandas<2.2.0; python_version >= "3.9"
 snowflake-connector-python>=2.5.0; python_version < "3.11"
 snowflake-connector-python>2.9.0; python_version >= "3.11" # earlier versions fail to build on 3.11
-snowflake-sqlalchemy>=1.2.3
+snowflake-sqlalchemy>=1.2.3,<1.5.2 # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485

--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,4 +1,4 @@
 pandas<2.2.0; python_version >= "3.9"
 snowflake-connector-python>=2.5.0; python_version < "3.11"
 snowflake-connector-python>2.9.0; python_version >= "3.11" # earlier versions fail to build on 3.11
-snowflake-sqlalchemy>=1.2.3,!1.5.2 # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485
+snowflake-sqlalchemy>=1.2.3;!=1.5.2 # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485

--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,4 +1,4 @@
 pandas<2.2.0; python_version >= "3.9"
 snowflake-connector-python>=2.5.0; python_version < "3.11"
 snowflake-connector-python>2.9.0; python_version >= "3.11" # earlier versions fail to build on 3.11
-snowflake-sqlalchemy>=1.2.3,<1.5.2 # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485
+snowflake-sqlalchemy>=1.2.3,!1.5.2 # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485


### PR DESCRIPTION
Seeing test issues in CI due to issue with latest release of `snowflake-sqlalchemy`: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/485

```
FAILED tests/datasource/fluent/integration/test_sql_datasources.py::TestTableIdentifiers::test_checkpoint_run[snowflake-py38_i143f351df6474fb9979c9f9e063a4551-quoted_upper] - great_expectations.datasource.fluent.interfaces.TestConnectionError: Attempt to connect to datasource failed with the following error message: Unable to create a SQLAlchemy engine due to the following exception: cannot import name 'string_types' from 'sqlalchemy.util.compat' (/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/sqlalchemy/util/compat.py)
```

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
