### PR TITLE
[MAINTENANCE] ruff `0.3.7`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
         exclude: tests/test_fixtures/database_key_test*
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.5"
+    rev: "v0.3.7"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -3,6 +3,6 @@ cookiecutter==2.1.1  # Project templating
 mypy==1.7.1            # Type checker
 pydantic>=1.0        # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
-ruff==0.3.5        # Linting / code style / formatting
+ruff==0.3.7        # Linting / code style / formatting
 twine==3.7.1         # Packaging
 wheel==0.38.1        # Packaging

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_have_diff.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_have_diff.py
@@ -73,7 +73,7 @@ class ExpectQueriedColumnPairValuesToHaveDiff(QueryExpectation):
         query_result = metrics.get("query.column_pair")
         query_result = [tuple(element.values()) for element in query_result]
 
-        success = (sum([(abs(x[0]) == diff) for x in query_result]) / len(query_result)) >= mostly
+        success = (sum((abs(x[0]) == diff) for x in query_result) / len(query_result)) >= mostly
 
         return {
             "success": success,

--- a/contrib/time_series_expectations/time_series_expectations/generator.py
+++ b/contrib/time_series_expectations/time_series_expectations/generator.py
@@ -33,11 +33,9 @@ def generate_annual_seasonality(
     """Generate an annual seasonality component for a time series."""
 
     return sum(
-        [
-            alpha * np.cos(2 * np.pi * (i + 1) * time / 365)
-            + beta * np.sin(2 * np.pi * (i + 1) * time / 365)
-            for i, (alpha, beta) in enumerate(annual_seasonality_params)
-        ]
+        alpha * np.cos(2 * np.pi * (i + 1) * time / 365)
+        + beta * np.sin(2 * np.pi * (i + 1) * time / 365)
+        for i, (alpha, beta) in enumerate(annual_seasonality_params)
     )
 
 

--- a/contrib/time_series_expectations/time_series_expectations/generator/daily_time_series_generator.py
+++ b/contrib/time_series_expectations/time_series_expectations/generator/daily_time_series_generator.py
@@ -45,11 +45,9 @@ class DailyTimeSeriesGenerator(TimeSeriesGenerator):
         """Generate an annual seasonality component for a time series."""
 
         return sum(
-            [
-                alpha * np.cos(2 * np.pi * (i + 1) * date_range / 365)
-                + beta * np.sin(2 * np.pi * (i + 1) * date_range / 365)
-                for i, (alpha, beta) in enumerate(annual_seasonality_params)
-            ]
+            alpha * np.cos(2 * np.pi * (i + 1) * date_range / 365)
+            + beta * np.sin(2 * np.pi * (i + 1) * date_range / 365)
+            for i, (alpha, beta) in enumerate(annual_seasonality_params)
         )
 
     def _generate_posneg_pareto(

--- a/contrib/time_series_expectations/time_series_expectations/generator/hourly_time_series_generator.py
+++ b/contrib/time_series_expectations/time_series_expectations/generator/hourly_time_series_generator.py
@@ -21,11 +21,9 @@ class HourlyTimeSeriesGenerator(DailyTimeSeriesGenerator):
         """Generate an annual seasonality component for a time series."""
 
         return sum(
-            [
-                alpha * np.cos(2 * np.pi * (i + 1) * time_range / 24)
-                + beta * np.sin(2 * np.pi * (i + 1) * time_range / 24)
-                for i, (alpha, beta) in enumerate(hourly_seasonality_params)
-            ]
+            alpha * np.cos(2 * np.pi * (i + 1) * time_range / 24)
+            + beta * np.sin(2 * np.pi * (i + 1) * time_range / 24)
+            for i, (alpha, beta) in enumerate(hourly_seasonality_params)
         )
 
     def _generate_hourly_time_series(

--- a/great_expectations/core/expectation_diagnostics/expectation_doctor.py
+++ b/great_expectations/core/expectation_diagnostics/expectation_doctor.py
@@ -340,7 +340,7 @@ class ExpectationDoctor:
         _total_passed = 0
         _total_failed = 0
         _num_backends = 0
-        _num_engines = sum([x for x in execution_engines.values() if x])
+        _num_engines = sum(x for x in execution_engines.values() if x)
         for result in backend_test_result_counts:
             _num_backends += 1
             _total_passed += result.num_passed

--- a/great_expectations/rule_based_profiler/builder.py
+++ b/great_expectations/rule_based_profiler/builder.py
@@ -93,13 +93,11 @@ class Builder(SerializableDictDot):
     ) -> None:
         arg: Any
         num_supplied_batch_specification_args: int = sum(
-            [
-                0 if arg is None else 1
-                for arg in (
-                    batch_list,
-                    batch_request,
-                )
-            ]
+            0 if arg is None else 1
+            for arg in (
+                batch_list,
+                batch_request,
+            )
         )
         if num_supplied_batch_specification_args > 1:
             raise gx_exceptions.ProfilerConfigurationError(  # noqa: TRY003

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -2,5 +2,5 @@ adr-tools-python==1.0.3
 invoke>=2.0.0
 mypy==1.9.0
 pre-commit>=2.21.0
-ruff==0.3.5
+ruff==0.3.7
 tomli>=2.0.1

--- a/tasks.py
+++ b/tasks.py
@@ -154,11 +154,15 @@ def lint(
     ctx.run(" ".join(cmds), echo=True, pty=pty)
 
 
-@invoke.task(help={"path": _PATH_HELP_DESC, "unsafe": "Enable potentially unsafe fixes."})
-def fix(ctx: Context, path: str = ".", unsafe: bool = False):
-    """Automatically fix all possible code issues."""
-    lint(ctx, path=path, unsafe_fixes=unsafe)
-    format(ctx, path=path, sort_=True)
+@invoke.task(help={"path": _PATH_HELP_DESC, "safe-only": "Only apply 'safe' fixes."})
+def fix(ctx: Context, path: str = ".", safe_only: bool = False):
+    """
+    Automatically fix all possible code issues.
+    Applies unsafe fixes by default.
+    """
+    unsafe_fixes = not safe_only
+    lint(ctx, path=path, fmt_=False, fix=True, unsafe_fixes=unsafe_fixes)
+    format(ctx, path=path, check=False, sort_=True)
 
 
 @invoke.task(help={"path": _PATH_HELP_DESC})

--- a/tasks.py
+++ b/tasks.py
@@ -156,9 +156,10 @@ def lint(
 
 @invoke.task(help={"path": _PATH_HELP_DESC, "safe-only": "Only apply 'safe' fixes."})
 def fix(ctx: Context, path: str = ".", safe_only: bool = False):
-    """
+    """gikt
     Automatically fix all possible code issues.
     Applies unsafe fixes by default.
+    https://docs.astral.sh/ruff/linter/#fix-safety
     """
     unsafe_fixes = not safe_only
     lint(ctx, path=path, fmt_=False, fix=True, unsafe_fixes=unsafe_fixes)

--- a/tasks.py
+++ b/tasks.py
@@ -162,7 +162,7 @@ def fix(ctx: Context, path: str = ".", safe_only: bool = False):
     """
     unsafe_fixes = not safe_only
     lint(ctx, path=path, fmt_=False, fix=True, unsafe_fixes=unsafe_fixes)
-    format(ctx, path=path, check=False, sort_=True)
+    format(ctx, path=path, check=False, sort_=False)
 
 
 @invoke.task(help={"path": _PATH_HELP_DESC})

--- a/tasks.py
+++ b/tasks.py
@@ -156,7 +156,7 @@ def lint(
 
 @invoke.task(help={"path": _PATH_HELP_DESC, "safe-only": "Only apply 'safe' fixes."})
 def fix(ctx: Context, path: str = ".", safe_only: bool = False):
-    """gikt
+    """
     Automatically fix all possible code issues.
     Applies unsafe fixes by default.
     https://docs.astral.sh/ruff/linter/#fix-safety

--- a/tasks.py
+++ b/tasks.py
@@ -125,6 +125,7 @@ def format(
         "path": _PATH_HELP_DESC,
         "fmt": "Disable formatting. Runs by default.",
         "fix": "Attempt to automatically fix lint violations.",
+        "unsafe-fixes": "Enable potentially unsafe fixes.",
         "watch": "Run in watch mode by re-running whenever files change.",
         "pty": _PTY_HELP_DESC,
     }
@@ -134,6 +135,7 @@ def lint(
     path: str = ".",
     fmt_: bool = True,
     fix: bool = False,
+    unsafe_fixes: bool = False,
     watch: bool = False,
     pty: bool = True,
 ):
@@ -145,15 +147,17 @@ def lint(
     cmds = ["ruff", "check", path]
     if fix:
         cmds.append("--fix")
+    if unsafe_fixes:
+        cmds.append("--unsafe-fixes")
     if watch:
         cmds.append("--watch")
     ctx.run(" ".join(cmds), echo=True, pty=pty)
 
 
-@invoke.task(help={"path": _PATH_HELP_DESC})
-def fix(ctx: Context, path: str = "."):
+@invoke.task(help={"path": _PATH_HELP_DESC, "unsafe": "Enable potentially unsafe fixes."})
+def fix(ctx: Context, path: str = ".", unsafe: bool = False):
     """Automatically fix all possible code issues."""
-    lint(ctx, path=path, fix=True)
+    lint(ctx, path=path, unsafe_fixes=unsafe)
     format(ctx, path=path, sort_=True)
 
 


### PR DESCRIPTION
* Update from ruff `0.3.5` -> `0.3.7`
  * Applied auto-fix for new rules
* Add option to use `--unsafe-fixes` with our `invoke lint` task.
* Make `invoke fix` use `--unsafe-fixes` by default.

https://github.com/astral-sh/ruff/releases/tag/v0.3.7
https://github.com/astral-sh/ruff/releases/tag/v0.3.6
