### PR TITLE
[FEATURE] Add sort_ascending to BatchDefinition fluent API

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -649,31 +649,33 @@ class _SQLAsset(DataAsset):
 
     @public_api
     def add_batch_definition_yearly(
-        self, name: str, column: str, sort_asc: bool = True
+        self, name: str, column: str, sort_ascending: bool = True
     ) -> BatchDefinition:
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerYear(column_name=column),
+            partitioner=PartitionerYear(column_name=column, sort_ascending=sort_ascending),
             batching_regex=None,
         )
 
     @public_api
     def add_batch_definition_monthly(
-        self, name: str, column: str, sort_asc: bool = True
+        self, name: str, column: str, sort_ascending: bool = True
     ) -> BatchDefinition:
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerYearAndMonth(column_name=column),
+            partitioner=PartitionerYearAndMonth(column_name=column, sort_ascending=sort_ascending),
             batching_regex=None,
         )
 
     @public_api
     def add_batch_definition_daily(
-        self, name: str, column: str, sort_asc: bool = True
+        self, name: str, column: str, sort_ascending: bool = True
     ) -> BatchDefinition:
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerYearAndMonthAndDay(column_name=column),
+            partitioner=PartitionerYearAndMonthAndDay(
+                column_name=column, sort_ascending=sort_ascending
+            ),
             batching_regex=None,
         )
 

--- a/tests/datasource/fluent/data_asset/test_sql_asset.py
+++ b/tests/datasource/fluent/data_asset/test_sql_asset.py
@@ -97,55 +97,76 @@ def test_add_batch_definition_fluent_sql__add_batch_definition_whole_table(datas
 
 
 @pytest.mark.unit
-def test_add_batch_definition_fluent_sql__add_batch_definition_yearly(datasource, asset):
-    # arrange
-    name = "batch_def_name"
-    column = "test_column"
-    expected_batch_definition = BatchDefinition(
-        name=name, partitioner=PartitionerYear(column_name=column), batching_regex=None
-    )
-    datasource.add_batch_definition.return_value = expected_batch_definition
-
-    # act
-    batch_definition = asset.add_batch_definition_yearly(name=name, column=column)
-
-    # assert
-    assert batch_definition == expected_batch_definition
-    datasource.add_batch_definition.assert_called_once_with(expected_batch_definition)
-
-
-@pytest.mark.unit
-def test_add_batch_definition_fluent_sql__add_batch_definition_monthly(datasource, asset):
-    # arrange
-    name = "batch_def_name"
-    column = "test_column"
-    expected_batch_definition = BatchDefinition(
-        name=name, partitioner=PartitionerYearAndMonth(column_name=column), batching_regex=None
-    )
-    datasource.add_batch_definition.return_value = expected_batch_definition
-
-    # act
-    batch_definition = asset.add_batch_definition_monthly(name=name, column=column)
-
-    # assert
-    assert batch_definition == expected_batch_definition
-    datasource.add_batch_definition.assert_called_once_with(expected_batch_definition)
-
-
-@pytest.mark.unit
-def test_add_batch_definition_fluent_sql__add_batch_definition_daily(datasource, asset):
+@pytest.mark.parametrize("sort_ascending", (True, False))
+def test_add_batch_definition_fluent_sql__add_batch_definition_yearly(
+    datasource, asset, sort_ascending
+):
     # arrange
     name = "batch_def_name"
     column = "test_column"
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=PartitionerYearAndMonthAndDay(column_name=column),
+        partitioner=PartitionerYear(column_name=column, sort_ascending=sort_ascending),
         batching_regex=None,
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 
     # act
-    batch_definition = asset.add_batch_definition_daily(name=name, column=column)
+    batch_definition = asset.add_batch_definition_yearly(
+        name=name, column=column, sort_ascending=sort_ascending
+    )
+
+    # assert
+    assert batch_definition == expected_batch_definition
+    datasource.add_batch_definition.assert_called_once_with(expected_batch_definition)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("sort_ascending", (True, False))
+def test_add_batch_definition_fluent_sql__add_batch_definition_monthly(
+    datasource, asset, sort_ascending
+):
+    # arrange
+    name = "batch_def_name"
+    column = "test_column"
+    expected_batch_definition = BatchDefinition(
+        name=name,
+        partitioner=PartitionerYearAndMonth(column_name=column, sort_ascending=sort_ascending),
+        batching_regex=None,
+    )
+    datasource.add_batch_definition.return_value = expected_batch_definition
+
+    # act
+    batch_definition = asset.add_batch_definition_monthly(
+        name=name, column=column, sort_ascending=sort_ascending
+    )
+
+    # assert
+    assert batch_definition == expected_batch_definition
+    datasource.add_batch_definition.assert_called_once_with(expected_batch_definition)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("sort_ascending", (True, False))
+def test_add_batch_definition_fluent_sql__add_batch_definition_daily(
+    datasource, asset, sort_ascending
+):
+    # arrange
+    name = "batch_def_name"
+    column = "test_column"
+    expected_batch_definition = BatchDefinition(
+        name=name,
+        partitioner=PartitionerYearAndMonthAndDay(
+            column_name=column, sort_ascending=sort_ascending
+        ),
+        batching_regex=None,
+    )
+    datasource.add_batch_definition.return_value = expected_batch_definition
+
+    # act
+    batch_definition = asset.add_batch_definition_daily(
+        name=name, column=column, sort_ascending=sort_ascending
+    )
 
     # assert
     assert batch_definition == expected_batch_definition


### PR DESCRIPTION
Recent changes added a `sort_ascending: bool` parameter to Partitioners, so this PR allows defining that from the BatchDefinition fluent API.