### PR TITLE
[MAINTENANCE] Enable `run_id` overrides for `Checkpoint` and `ValidationDefinition`

### DIFF
--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -161,8 +161,9 @@ class Checkpoint(BaseModel):
         self,
         batch_parameters: Dict[str, Any] | None = None,
         expectation_parameters: Dict[str, Any] | None = None,
+        run_id: RunIdentifier | None = None,
     ) -> CheckpointResult:
-        run_id = RunIdentifier(run_time=dt.datetime.now(dt.timezone.utc))
+        run_id = run_id or RunIdentifier(run_time=dt.datetime.now(dt.timezone.utc))
         run_results = self._run_validation_definitions(
             batch_parameters=batch_parameters,
             expectation_parameters=expectation_parameters,
@@ -192,6 +193,7 @@ class Checkpoint(BaseModel):
                 batch_parameters=batch_parameters,
                 suite_parameters=expectation_parameters,
                 result_format=result_format,
+                run_id=run_id,
             )
             key = self._build_result_key(
                 validation_definition=validation_definition,

--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
     )
 
 CheckpointAction: TypeAlias = Union[
-    EmailAction,
     MicrosoftTeamsNotificationAction,
     OpsgenieAlertAction,
     PagerdutyAlertAction,
@@ -47,6 +46,9 @@ CheckpointAction: TypeAlias = Union[
     SNSNotificationAction,
     StoreValidationResultAction,
     UpdateDataDocsAction,
+    # NOTE: Currently placed last as the root validator emits warnings
+    #       that aren't relevant to end users (unless they are using the action).
+    EmailAction,
 ]
 
 

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -209,6 +209,7 @@ class ValidationDefinition(BaseModel):
             result_format=result_format,
         )
         results = validator.validate_expectation_suite(self.suite, suite_parameters)
+        results.meta["run_id"] = run_id
 
         (
             expectation_suite_identifier,

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -201,6 +201,7 @@ class ValidationDefinition(BaseModel):
         batch_parameters: Optional[BatchParameters] = None,
         suite_parameters: Optional[dict[str, Any]] = None,
         result_format: ResultFormat = ResultFormat.SUMMARY,
+        run_id: RunIdentifier | None = None,
     ) -> ExpectationSuiteValidationResult:
         validator = Validator(
             batch_definition=self.batch_definition,
@@ -212,7 +213,9 @@ class ValidationDefinition(BaseModel):
         (
             expectation_suite_identifier,
             validation_result_id,
-        ) = self._get_expectation_suite_and_validation_result_ids(validator)
+        ) = self._get_expectation_suite_and_validation_result_ids(
+            validator=validator, run_id=run_id
+        )
 
         ref = self._validation_results_store.store_validation_results(
             suite_validation_result=results,
@@ -230,6 +233,7 @@ class ValidationDefinition(BaseModel):
     def _get_expectation_suite_and_validation_result_ids(
         self,
         validator: Validator,
+        run_id: RunIdentifier | None = None,
     ) -> (
         tuple[GXCloudIdentifier, GXCloudIdentifier]
         | tuple[ExpectationSuiteIdentifier, ValidationResultIdentifier]
@@ -246,8 +250,10 @@ class ValidationDefinition(BaseModel):
             )
             return expectation_suite_identifier, validation_result_id
         else:
-            run_time = datetime.datetime.now(tz=datetime.timezone.utc)
-            run_id = RunIdentifier(run_time=run_time)
+            if not run_id:
+                run_time = datetime.datetime.now(tz=datetime.timezone.utc)
+                run_id = RunIdentifier(run_time=run_time)
+
             expectation_suite_identifier = ExpectationSuiteIdentifier(name=self.suite.name)
             validation_result_id = ValidationResultIdentifier(
                 batch_identifier=validator.active_batch_id,

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -210,6 +210,8 @@ class ValidationDefinition(BaseModel):
         )
         results = validator.validate_expectation_suite(self.suite, suite_parameters)
 
+        # NOTE: We should promote this to a top-level field of the result.
+        #       Meta should be reserved for user-defined information.
         if run_id:
             results.meta["run_id"] = run_id
 

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -209,7 +209,9 @@ class ValidationDefinition(BaseModel):
             result_format=result_format,
         )
         results = validator.validate_expectation_suite(self.suite, suite_parameters)
-        results.meta["run_id"] = run_id
+
+        if run_id:
+            results.meta["run_id"] = run_id
 
         (
             expectation_suite_identifier,

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -255,10 +255,9 @@ class ValidationDefinition(BaseModel):
             )
             return expectation_suite_identifier, validation_result_id
         else:
-            if not run_id:
-                run_time = datetime.datetime.now(tz=datetime.timezone.utc)
-                run_id = RunIdentifier(run_time=run_time)
-
+            run_id = run_id or RunIdentifier(
+                run_time=datetime.datetime.now(tz=datetime.timezone.utc)
+            )
             expectation_suite_identifier = ExpectationSuiteIdentifier(name=self.suite.name)
             validation_result_id = ValidationResultIdentifier(
                 batch_identifier=validator.active_batch_id,

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -95,7 +95,7 @@ class ValidationResultsPageRenderer(Renderer):
     ):
         # Gather run identifiers
         run_name, run_time = self._parse_run_values(validation_results)
-        expectation_suite_name = validation_results.meta["expectation_suite_name"]
+        expectation_suite_name = validation_results.suite_name
         batch_kwargs = (
             validation_results.meta.get("batch_kwargs", {})
             or validation_results.meta.get("batch_spec", {})
@@ -356,7 +356,7 @@ class ValidationResultsPageRenderer(Renderer):
     @classmethod
     def _render_validation_header(cls, validation_results):
         success = validation_results.success
-        expectation_suite_name = validation_results.meta["expectation_suite_name"]
+        expectation_suite_name = validation_results.suite_name
         expectation_suite_path_components = (
             [".." for _ in range(len(expectation_suite_name.split(".")) + 3)]
             + ["expectations"]

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -554,6 +554,7 @@ class TestCheckpointResult:
             batch_parameters=batch_parameters,
             suite_parameters=expectation_parameters,
             result_format=ResultFormat.SUMMARY,
+            run_id=mock.ANY,
         )
 
     @pytest.mark.unit


### PR DESCRIPTION
Users should be able to pass a custom `run_id` for validation workflows.

PR also contains some misc fixes around metadata to enable proper rendering. Finally, there is an update to the type annotation of `Checkpoint` to suppress a warning we see in the root validator of `EmailAction` (not the best practice but we'll return to resolve this soon).

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
