### PR TITLE
[DOCS] Remove Feedback Widget from Landing Pages

### DIFF
--- a/docs/docusaurus/docs/core/create_expectations/create_expectations.md
+++ b/docs/docusaurus/docs/core/create_expectations/create_expectations.md
@@ -1,12 +1,17 @@
 ---
 title: 'Create and manage Expectations and Expectation Suites'
 description: Create and manage Expectations and Expectation Suites.
+hide_feedback_survey: true
+hide_title: true
 ---
 
 import LinkCardGrid from '@site/src/components/LinkCardGrid';
 import LinkCard from '@site/src/components/LinkCard';
+import OverviewCard from '@site/src/components/OverviewCard';
 
-<p class="DocItem__header-description">Create, edit, and implement Expectations and Expectation Suites. An Expectation is a verifiable assertion about your data, and an  Expectation Suite is a collection of Expectations that describe the ideal state of a set of data.</p>
+<OverviewCard title={frontMatter.title}>
+  Create, edit, and implement Expectations and Expectation Suites. An Expectation is a verifiable assertion about your data, and an Expectation Suite is a collection of Expectations that describe the ideal state of a set of data.
+</OverviewCard>
 
 ## Manage Expectations
 

--- a/docs/docusaurus/docs/core/manage_and_access_data/manage_and_access_data.md
+++ b/docs/docusaurus/docs/core/manage_and_access_data/manage_and_access_data.md
@@ -94,7 +94,3 @@ Retrieve, view, and delete GX's data objects, or use them to retrieve data for u
   />
 
 </LinkCardGrid>
-
-## Next steps
-
-- [Create Expectations](/core/manage_and_access_data/manage_data_assets.md)

--- a/docs/docusaurus/docs/core/manage_and_access_data/manage_and_access_data.md
+++ b/docs/docusaurus/docs/core/manage_and_access_data/manage_and_access_data.md
@@ -55,9 +55,9 @@ Connect GX to data stored on filesystems, databases, or in memory.  Then tell GX
 
 </LinkCardGrid>
 
-## Manage GX's data objects
+## Manage data objects
 
-Retrieve, view, and delete GX's data objects, or use them to retrieve data for use within GX.
+Retrieve, view, and delete data objects, or use them to retrieve data for use within GX.
 
 <LinkCardGrid>
 

--- a/docs/docusaurus/docs/core/validate_data/validate_data.md
+++ b/docs/docusaurus/docs/core/validate_data/validate_data.md
@@ -3,7 +3,6 @@ title: "Validate Data"
 hide_feedback_survey: true
 ---
 
-import OverviewCard from '@site/src/components/OverviewCard';
 import LinkCardGrid from '@site/src/components/LinkCardGrid';
 import LinkCard from '@site/src/components/LinkCard';
 import OverviewCard from '@site/src/components/OverviewCard';
@@ -13,7 +12,6 @@ import InProgress from '../_core_components/_in_progress.md';
 <OverviewCard title={frontMatter.title}>
   Create, edit, and implement Validation Definitions and Checkpoints.
 </OverviewCard>
-
 
 ## Manage Validation Definitions
 

--- a/docs/docusaurus/docs/core/validate_data/validate_data.md
+++ b/docs/docusaurus/docs/core/validate_data/validate_data.md
@@ -1,14 +1,18 @@
 ---
 title: "Validate Data"
+hide_feedback_survey: true
 ---
 
 import OverviewCard from '@site/src/components/OverviewCard';
 import LinkCardGrid from '@site/src/components/LinkCardGrid';
 import LinkCard from '@site/src/components/LinkCard';
+import OverviewCard from '@site/src/components/OverviewCard';
 
 import InProgress from '../_core_components/_in_progress.md';
 
-Create, edit, and implement Validation Definitions and Checkpoints. A Validation Definition associates data with an Expectation Suite and can be used in data testing and exploration. A Checkpoint executes one or more Validation Definitions and then performs a set of Actions based on the Validation Results each Validation Definition returns.
+<OverviewCard title={frontMatter.title}>
+  Create, edit, and implement Validation Definitions and Checkpoints.
+</OverviewCard>
 
 
 ## Manage Validation Definitions
@@ -65,6 +69,68 @@ Use Validation Definitions to associate data with Expectation Suites for Checkpo
     icon="/img/expectation_icon.svg" 
   />
   
+</LinkCardGrid>
 
+## Manage Checkpoints
 
+A Checkpoint executes one or more Validation Definitions and then performs a set of Actions based on the Validation Results each Validation Definition returns.
+
+<LinkCardGrid>
+  
+  <LinkCard 
+      topIcon 
+      label="Create a Checkpoint"
+      description="Create a Checkpoint."
+      to="/core/validate_data/validation_definitions/manage_validation_definitions#create-a-validation-definition" 
+      icon="/img/expectation_icon.svg" 
+  />
+
+  <LinkCard 
+    topIcon 
+    label="List available Checkpoints"
+    description="List available Checkpoints."
+    to="/core/validate_data/checkpoints/manage_checkpoints#list-available-checkpoints" 
+    icon="/img/expectation_icon.svg" 
+  />
+
+  <LinkCard 
+    topIcon 
+    label="Get a Checkpoint by name"
+    description="Get a Checkpoint by name."
+    to="/core/validate_data/checkpoints/manage_checkpoints#get-a-checkpoint-by-name" 
+    icon="/img/expectation_icon.svg" 
+  />
+
+  <LinkCard 
+    topIcon 
+    label="Get Checkpoints by attributes"
+    description="/core/validate_data/checkpoints/manage_checkpoints#get-checkpoints-by-attributes."
+    to="/core/validate_data/checkpoints/manage_checkpoints#get-checkpoints-by-attributes" 
+    icon="/img/expectation_icon.svg" 
+  />
+
+  <LinkCard 
+    topIcon 
+    label="Update a Checkpoint"
+    description="Update a Checkpoint."
+    to="/core/validate_data/checkpoints/manage_checkpoints#update-a-checkpoint" 
+    icon="/img/expectation_icon.svg" 
+  />
+
+  <LinkCard 
+    topIcon 
+    label="Delete a Checkpoint"
+    description="Delete a Checkpoint."
+    to="/core/validate_data/checkpoints/manage_checkpoints#delete-a-checkpoint" 
+    icon="/img/expectation_icon.svg" 
+  />
+
+  <LinkCard 
+    topIcon 
+    label="Run a Checkpoint"
+    description="Run a Checkpoint."
+    to="/core/validate_data/checkpoints/manage_checkpoints#run-a-checkpoint" 
+    icon="/img/expectation_icon.svg" 
+  />
+  
 </LinkCardGrid>


### PR DESCRIPTION
[DOC-667](https://greatexpectations.atlassian.net/browse/DOC-667) requests the removal of the feedback widget from all online documentation landing pages. This PR implements the requested changes. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated


[DOC-667]: https://greatexpectations.atlassian.net/browse/DOC-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ