### PR TITLE
[DOCS] Adds clarification of `discard_failed_expectations` to 0.18.x OSS quickstart

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/quickstart.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/quickstart.md
@@ -97,6 +97,8 @@ click 7 "#validate-data"
 
   The second <TechnicalTag tag="expectation" text="Expectation"/> uses explicit kwargs along with the `passenger_count` column.
 
+  The basic workflow when creating an Expectation Suite is to populate it with Expectations that accurately describe the state of the associated data.  Therefore, when an Expectation Suite is saved failed Expectations are not kept by default.  However, the `discard_failed_expectations` parameter of `save_expectation_suite(...)` can be used to override this behavior if you have created Expectations that describe the ideal state of your data rather than its current state.  
+
 ## Validate data
 
 1. Run the following command to define a <TechnicalTag tag="checkpoint" text="Checkpoint"/> and examine the data to determine if it matches the defined <TechnicalTag tag="expectation" text="Expectations"/>:

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/quickstart.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/quickstart.py
@@ -21,7 +21,7 @@ validator.expect_column_values_to_not_be_null("pickup_datetime")
 validator.expect_column_values_to_be_between(
     "passenger_count", min_value=1, max_value=6
 )
-validator.save_expectation_suite()
+validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
 # Validate data


### PR DESCRIPTION
## Description
- Adds clarification of `discard_failed_expectations` to 0.18.x OSS quickstart

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [X] Appropriate tests and docs have been updated
