### PR TITLE
[MAINTENANCE] Ensure that V1 Validator works with Cloud rendered content

### DIFF
--- a/great_expectations/validator/v1_validator.py
+++ b/great_expectations/validator/v1_validator.py
@@ -82,6 +82,12 @@ class Validator:
     def active_batch_id(self) -> Optional[str]:
         return self._wrapped_validator.active_batch_id
 
+    @property
+    def _include_rendered_content(self) -> bool:
+        from great_expectations import project_manager
+
+        return project_manager.is_using_cloud()
+
     @cached_property
     def _wrapped_validator(self) -> OldValidator:
         batch_request = self._batch_definition.build_batch_request(
@@ -103,5 +109,9 @@ class Validator:
             configurations=processed_expectation_configs,
             runtime_configuration={"result_format": self.result_format.value},
         )
+
+        if self._include_rendered_content:
+            for result in results:
+                result.render()
 
         return results


### PR DESCRIPTION
Previously, we didn't support rendered content with the V1 validator - this PR should fix things 

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
