### PR TITLE
[BUGFIX] Do not persist interactive batch defs

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -1084,11 +1084,13 @@ class Batch:
                 "We can't validate batches that are attached to datasources without a data context"
             )
 
+        # note: batch definition is created but NOT added to the asset, as it should not persist
         batch_definition = BatchDefinition(
             name="-".join([self.datasource.name, self.data_asset.name, str(uuid.uuid4())]),
             partitioner=self.batch_request.partitioner,
-            batching_regex=self.batch_request.batching_regex,
         )
+        batch_definition.set_data_asset(self.data_asset)
+
         return V1Validator(
             batch_definition=batch_definition,
             batch_parameters=self.batch_request.options,

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -1083,8 +1083,11 @@ class Batch:
             raise ValueError(  # noqa: TRY003
                 "We can't validate batches that are attached to datasources without a data context"
             )
-        batch_definition = self.data_asset.add_batch_definition(
-            name="-".join([self.datasource.name, self.data_asset.name, str(uuid.uuid4())])
+
+        batch_definition = BatchDefinition(
+            name="-".join([self.datasource.name, self.data_asset.name, str(uuid.uuid4())]),
+            partitioner=self.batch_request.partitioner,
+            batching_regex=self.batch_request.batching_regex,
         )
         return V1Validator(
             batch_definition=batch_definition,


### PR DESCRIPTION
Updates the interactive validation flow (via `batch.validate`) to not add `BatchDefinition`s to the asset.

NOTE: The entire flow here is a bit weird, but I think that's a question for another day. Here it is:
* Create a batch definition
* Create a batch from that
* Call batch.validate
* That creates a short-lived batch definition to pass to the validator
The short-lived batch definition is hidden from the user in the interactive flow, so it's not currently the end of the world, but it feels weird. Potential additional work: add batch_definition to the batch (feels bad), or make validator take in batches. But I don't think it's worth doing that right now without really thinking about the model.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
