### PR TITLE
[BUGFIX] `scrapy` compatibility - handle `dir()` inconsistencies

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -366,7 +366,7 @@ class Expectation(metaclass=MetaExpectation):
         expectation_type: str = camel_to_snake(cls.__name__)
 
         for candidate_renderer_fn_name in dir(cls):
-            attr_obj: Callable = getattr(cls, candidate_renderer_fn_name, None)
+            attr_obj: Callable | None = getattr(cls, candidate_renderer_fn_name, None)
             if not hasattr(attr_obj, "_renderer_type"):
                 continue
             register_renderer(

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -367,6 +367,9 @@ class Expectation(metaclass=MetaExpectation):
 
         for candidate_renderer_fn_name in dir(cls):
             attr_obj: Callable | None = getattr(cls, candidate_renderer_fn_name, None)
+            # attrs are not guaranteed to exist https://docs.python.org/3.10/library/functions.html#dir
+            if attr_obj is None:
+                continue
             if not hasattr(attr_obj, "_renderer_type"):
                 continue
             register_renderer(

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -366,7 +366,7 @@ class Expectation(metaclass=MetaExpectation):
         expectation_type: str = camel_to_snake(cls.__name__)
 
         for candidate_renderer_fn_name in dir(cls):
-            attr_obj: Callable = getattr(cls, candidate_renderer_fn_name)
+            attr_obj: Callable = getattr(cls, candidate_renderer_fn_name, None)
             if not hasattr(attr_obj, "_renderer_type"):
                 continue
             register_renderer(


### PR DESCRIPTION
The current code assumes that all attr names returned by `dir(cls)` must actually exist on the class but per official python documentation, this is not guaranteed.
https://docs.python.org/3.10/library/functions.html#dir

Dynamic alteration of classes through metaclasses or other methods can result in `dir(cls)` returning an attribute that is not retrievable by `getattr()` and leads to an error.  

https://github.com/great-expectations/great_expectations/issues/9698#issuecomment-2051252373

## References

- Resolves https://github.com/great-expectations/great_expectations/issues/9698
- https://github.com/great-expectations/great_expectations/discussions/9693
- https://github.com/scrapy/scrapy/issues/6307
