### PR TITLE
[MAINTENANCE] Enable SIM300

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
         exclude: tests/test_fixtures/database_key_test*
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.7"
+    rev: "v0.4.2"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -3,6 +3,6 @@ cookiecutter==2.1.1  # Project templating
 mypy==1.7.1            # Type checker
 pydantic>=1.0        # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
-ruff==0.3.7        # Linting / code style / formatting
+ruff==0.4.2        # Linting / code style / formatting
 twine==3.7.1         # Packaging
 wheel==0.38.1        # Packaging

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2583,7 +2583,7 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
     # Try to return the most common values, if possible.
     partial_unexpected_count: Optional[int] = result_format.get("partial_unexpected_count")
     partial_unexpected_counts: Optional[List[Dict[str, Any]]] = None
-    if partial_unexpected_count is not None and 0 < partial_unexpected_count:
+    if partial_unexpected_count is not None and partial_unexpected_count > 0:
         try:
             if not exclude_unexpected_values:
                 partial_unexpected_counts = [

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1902,7 +1902,7 @@ def should_we_generate_this_test(  # noqa: C901, PLR0911, PLR0912, PLR0913
         if backend not in expectation_test_case.only_for:
             if "sqlalchemy" in expectation_test_case.only_for and backend in SQL_DIALECT_NAMES:
                 return True
-            elif "pandas" == backend:
+            elif backend == "pandas":
                 major, minor, *_ = pd.__version__.split(".")
                 if (
                     "pandas_022" in expectation_test_case.only_for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,7 +330,6 @@ lint.ignore = [
     "SIM108", # if-else-block-instead-of-if-exp
     "SIM211", # if-expr-with-false-true
     "SIM102", # collapsible-if
-    "SIM300", # yoda-conditions
     "SIM105", # suppressible-exception
     "SIM117", # multiple-with-statements
     "SIM201", # negate-equal-op

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -2,5 +2,5 @@ adr-tools-python==1.0.3
 invoke>=2.0.0
 mypy==1.9.0
 pre-commit>=2.21.0
-ruff==0.3.7
+ruff==0.4.2
 tomli>=2.0.1

--- a/tasks.py
+++ b/tasks.py
@@ -550,7 +550,7 @@ def type_schema(  # noqa: C901 - too complex
 
         if (
             datasource_dir.name.startswith("Pandas")
-            and _PANDAS_SCHEMA_VERSION != pandas.__version__
+            and pandas.__version__ != _PANDAS_SCHEMA_VERSION
         ):
             print(
                 f"🙈  {name} - was generated with pandas"

--- a/tests/core/test_evaluation_parameters.py
+++ b/tests/core/test_evaluation_parameters.py
@@ -303,7 +303,7 @@ def test_deduplicate_suite_parameter_dependencies():
         deduplicated["profile"][0]["metric_kwargs_id"]["column=norm"]
     )
 
-    assert {
+    assert deduplicated == {
         "profile": [
             {
                 "metric_kwargs_id": {
@@ -314,7 +314,7 @@ def test_deduplicate_suite_parameter_dependencies():
                 }
             }
         ]
-    } == deduplicated
+    }
 
 
 @pytest.mark.filesystem

--- a/tests/core/test_expectation_configuration.py
+++ b/tests/core/test_expectation_configuration.py
@@ -136,7 +136,7 @@ def test_expectation_configuration_get_suite_parameter_dependencies():
         dependencies["profile"][0]["metric_kwargs_id"]["column=norm"]
     )
 
-    assert {
+    assert dependencies == {
         "profile": [
             {
                 "metric_kwargs_id": {
@@ -147,7 +147,7 @@ def test_expectation_configuration_get_suite_parameter_dependencies():
                 }
             }
         ]
-    } == dependencies
+    }
 
 
 @pytest.mark.unit

--- a/tests/data_context/store/test_database_store_backend.py
+++ b/tests/data_context/store/test_database_store_backend.py
@@ -37,7 +37,7 @@ def test_database_store_backend_schema_spec(caplog, sa, test_backends):
     key = ("2",)
 
     store_backend.set(key, "hello")
-    assert "hello" == store_backend.get(key)
+    assert store_backend.get(key) == "hello"
 
     # clean up values
     with store_backend.engine.begin() as connection:
@@ -63,11 +63,11 @@ def test_database_store_backend_get_url_for_key(caplog, sa, test_backends):
 
     # existing key
     key = ("1",)
-    assert "postgresql://test_ci/1" == store_backend.get_url_for_key(key)
+    assert store_backend.get_url_for_key(key) == "postgresql://test_ci/1"
 
     # non-existing key : should still work
     key = ("not_here",)
-    assert "postgresql://test_ci/not_here" == store_backend.get_url_for_key(key)
+    assert store_backend.get_url_for_key(key) == "postgresql://test_ci/not_here"
 
 
 def test_database_store_backend_duplicate_key_violation(caplog, sa, test_backends):
@@ -89,11 +89,11 @@ def test_database_store_backend_duplicate_key_violation(caplog, sa, test_backend
     key = ("1", "2", "3")
 
     store_backend.set(key, "hello")
-    assert "hello" == store_backend.get(key)
+    assert store_backend.get(key) == "hello"
 
     # default behavior doesn't throw an error because the key is updated
     store_backend.set(key, "hello")
-    assert "hello" == store_backend.get(key)
+    assert store_backend.get(key) == "hello"
 
     assert len(caplog.messages) == 0
     caplog.set_level(logging.INFO, "great_expectations")
@@ -121,11 +121,11 @@ def test_database_store_backend_url_instantiation(caplog, sa, test_backends):
 
     # existing key
     key = ("1",)
-    assert "postgresql://test_ci/1" == store_backend.get_url_for_key(key)
+    assert store_backend.get_url_for_key(key) == "postgresql://test_ci/1"
 
     # non-existing key : should still work
     key = ("not_here",)
-    assert "postgresql://test_ci/not_here" == store_backend.get_url_for_key(key)
+    assert store_backend.get_url_for_key(key) == "postgresql://test_ci/not_here"
 
     db_hostname = os.getenv("GE_TEST_LOCAL_DB_HOSTNAME", "localhost")
     store_backend = DatabaseStoreBackend(
@@ -136,11 +136,11 @@ def test_database_store_backend_url_instantiation(caplog, sa, test_backends):
 
     # existing key
     key = ("1",)
-    assert "postgresql://test_ci/1" == store_backend.get_url_for_key(key)
+    assert store_backend.get_url_for_key(key) == "postgresql://test_ci/1"
 
     # non-existing key : should still work
     key = ("not_here",)
-    assert "postgresql://test_ci/not_here" == store_backend.get_url_for_key(key)
+    assert store_backend.get_url_for_key(key) == "postgresql://test_ci/not_here"
 
 
 def test_database_store_backend_id_initialization(caplog, sa, test_backends):

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -395,7 +395,7 @@ def test__normalize_absolute_or_relative_path(tmp_path_factory, basic_data_conte
     )
 
     assert test_dir not in context._normalize_absolute_or_relative_path("/yikes")
-    assert "/yikes" == context._normalize_absolute_or_relative_path("/yikes")
+    assert context._normalize_absolute_or_relative_path("/yikes") == "/yikes"
 
 
 @pytest.mark.filesystem

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -152,7 +152,7 @@ def test__normalize_absolute_or_relative_path(tmp_path_factory, basic_data_conte
         "test__normalize_absolute_or_relative_path__dir"
         not in context._normalize_absolute_or_relative_path("/yikes")
     )
-    assert "/yikes" == context._normalize_absolute_or_relative_path("/yikes")
+    assert context._normalize_absolute_or_relative_path("/yikes") == "/yikes"
 
 
 @pytest.mark.filesystem

--- a/tests/data_context/test_templates.py
+++ b/tests/data_context/test_templates.py
@@ -117,7 +117,7 @@ def test_project_optional_config_comment_matches_default(
     Make sure that the templates built on data_context.types.base.DataContextConfigDefaults match the desired default.
     """  # noqa: E501
 
-    assert templates.PROJECT_OPTIONAL_CONFIG_COMMENT == project_optional_config_comment
+    assert project_optional_config_comment == templates.PROJECT_OPTIONAL_CONFIG_COMMENT
 
 
 @pytest.mark.unit
@@ -127,4 +127,4 @@ def test_project_help_comment_matches_default(project_help_comment):
     Make sure that the templates built on data_context.types.base.DataContextConfigDefaults match the desired default.
     """  # noqa: E501
 
-    assert templates.PROJECT_HELP_COMMENT == project_help_comment
+    assert project_help_comment == templates.PROJECT_HELP_COMMENT

--- a/tests/datasource/fluent/test_config.py
+++ b/tests/datasource/fluent/test_config.py
@@ -767,7 +767,7 @@ def test_yaml_config_round_trip_ordering(
 ):
     dumped: str = from_yaml_gx_config.yaml()
 
-    assert PG_CONFIG_YAML_STR == dumped
+    assert dumped == PG_CONFIG_YAML_STR
 
 
 @pytest.mark.xfail(reason="Custom Sorter serialization logic needs to be implemented")

--- a/tests/datasource/fluent/test_metadatasource.py
+++ b/tests/datasource/fluent/test_metadatasource.py
@@ -411,13 +411,13 @@ def context_with_fluent_datasource(
     context_config_data: Tuple[AbstractDataContext, pathlib.Path, pathlib.Path],
 ) -> Tuple[AbstractDataContext, pathlib.Path, pathlib.Path]:
     context, config_file_path, data_dir = context_config_data
-    assert 0 == len(context.datasources)
+    assert len(context.datasources) == 0
     context.data_sources.add_pandas_filesystem(
         name=DEFAULT_CRUD_DATASOURCE_NAME,
         base_directory=data_dir,
         data_context_root_directory=config_file_path.parent,
     )
-    assert 1 == len(context.datasources)
+    assert len(context.datasources) == 1
     assert_fluent_datasource_content(
         config_file_path=config_file_path,
         fluent_datasource_config={

--- a/tests/datasource/fluent/test_pandas_datasource.py
+++ b/tests/datasource/fluent/test_pandas_datasource.py
@@ -212,13 +212,13 @@ class TestDynamicPandasAssets:
             )
 
         errors_dict = exc_info.value.errors()
-        assert {
+        assert errors_dict[  # the extra keyword error will always be the last error
+            -1  # we don't care about any other errors for this test
+        ] == {
             "loc": ("invalid_keyword_arg",),
             "msg": "extra fields not permitted",
             "type": "value_error.extra",
-        } == errors_dict[  # the extra keyword error will always be the last error
-            -1  # we don't care about any other errors for this test
-        ]
+        }
 
     @pytest.mark.parametrize(
         ["asset_model", "extra_kwargs"],

--- a/tests/datasource/fluent/test_pandas_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_pandas_filesystem_datasource.py
@@ -210,13 +210,13 @@ class TestDynamicPandasAssets:
             )
 
         errors_dict = exc_info.value.errors()
-        assert {
+        assert errors_dict[  # the extra keyword error will always be the last error
+            -1  # we don't care about any other errors for this test
+        ] == {
             "loc": ("invalid_keyword_arg",),
             "msg": "extra fields not permitted",
             "type": "value_error.extra",
-        } == errors_dict[  # the extra keyword error will always be the last error
-            -1  # we don't care about any other errors for this test
-        ]
+        }
 
     @pytest.mark.parametrize(
         ["asset_model", "extra_kwargs"],
@@ -341,13 +341,13 @@ def test_invalid_connect_options(
 
     error_dicts = exc_info.value.errors()
     print(pf(error_dicts))
-    assert [
+    assert error_dicts == [
         {
             "loc": ("glob_foobar",),
             "msg": "extra fields not permitted",
             "type": "value_error.extra",
         }
-    ] == error_dicts
+    ]
 
 
 @pytest.mark.unit
@@ -375,13 +375,13 @@ def test_invalid_connect_options_value(
     if isinstance(exc_info.value, pydantic.ValidationError):
         error_dicts = exc_info.value.errors()
         print(pf(error_dicts))
-        assert [
+        assert error_dicts == [
             {
                 "loc": ("glob_directive",),
                 "msg": "str type expected",
                 "type": "type_error.str",
             }
-        ] == error_dicts
+        ]
 
 
 @pytest.mark.unit

--- a/tests/datasource/fluent/test_pandas_s3_datasource.py
+++ b/tests/datasource/fluent/test_pandas_s3_datasource.py
@@ -150,13 +150,13 @@ def test_invalid_connect_options(pandas_s3_datasource: PandasS3Datasource, aws_c
 
     error_dicts = exc_info.value.errors()
     print(pf(error_dicts))
-    assert [
+    assert error_dicts == [
         {
             "loc": ("extra_field",),
             "msg": "extra fields not permitted",
             "type": "value_error.extra",
         }
-    ] == error_dicts
+    ]
 
 
 @pytest.mark.unit

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -438,7 +438,7 @@ def test_datasource_gets_batch_list_with_fully_specified_batch_parameters(
                 options={"month": month, "year": year}, partitioner=partitioner
             )
         )
-        assert 1 == len(batches)
+        assert len(batches) == 1
         assert batches[0].metadata == {"month": month, "year": year}
 
 

--- a/tests/datasource/fluent/test_schemas.py
+++ b/tests/datasource/fluent/test_schemas.py
@@ -48,7 +48,7 @@ def _models_and_schema_dirs() -> (
 
 
 @pytest.mark.skipif(
-    PYTHON_VERSION > min_supported_python(),
+    min_supported_python() < PYTHON_VERSION,
     reason=f"_sort_any_of() keys needs to be fixed for py {PYTHON_VERSION}",
 )
 @pytest.mark.timeout(

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -92,7 +92,7 @@ def test_regex_pattern_string_parameter_builder_instantiation_with_defaults(
 
     assert regex_pattern_string_parameter.threshold == 1.0
     assert regex_pattern_string_parameter.candidate_regexes == candidate_regexes
-    assert regex_pattern_string_parameter.CANDIDATE_REGEX == candidate_regexes
+    assert candidate_regexes == regex_pattern_string_parameter.CANDIDATE_REGEX
 
 
 @mock.patch("great_expectations.data_context.data_context.EphemeralDataContext")
@@ -115,7 +115,7 @@ def test_regex_pattern_string_parameter_builder_instantiation_override_defaults(
     )
     assert regex_pattern_string_parameter.threshold == 0.5
     assert regex_pattern_string_parameter.candidate_regexes == candidate_regexes
-    assert regex_pattern_string_parameter.CANDIDATE_REGEX != candidate_regexes
+    assert candidate_regexes != regex_pattern_string_parameter.CANDIDATE_REGEX
 
 
 @pytest.mark.slow  # 1.34s
@@ -218,7 +218,7 @@ def test_regex_pattern_string_parameter_builder_bobby_multiple_matches(
         data_context=data_context,
     )
 
-    assert regex_parameter.CANDIDATE_REGEX != candidate_regexes
+    assert candidate_regexes != regex_parameter.CANDIDATE_REGEX
     assert regex_parameter.candidate_regexes == candidate_regexes
     assert regex_parameter.threshold == 0.9
 

--- a/tests/validator/test_validation_statistics.py
+++ b/tests/validator/test_validation_statistics.py
@@ -18,9 +18,9 @@ def test_stats_no_expectations():
     assert None is actual.success_percent
     assert True is actual.success
     # the rest is boring
-    assert 0 == actual.successful_expectations
-    assert 0 == actual.evaluated_expectations
-    assert 0 == actual.unsuccessful_expectations
+    assert actual.successful_expectations == 0
+    assert actual.evaluated_expectations == 0
+    assert actual.unsuccessful_expectations == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/yoda-conditions/

# yoda-conditions (SIM300)

Derived from the **flake8-simplify** linter.

Fix is sometimes available.

## What it does
Checks for conditions that position a constant on the left-hand side of the
comparison operator, rather than the right-hand side.

## Why is this bad?
These conditions (sometimes referred to as "Yoda conditions") are less
readable than conditions that place the variable on the left-hand side of
the comparison operator.

In some languages, Yoda conditions are used to prevent accidental
assignment in conditions (i.e., accidental uses of the `=` operator,
instead of the `==` operator). However, Python does not allow assignments
in conditions unless using the `:=` operator, so Yoda conditions provide
no benefit in this regard.

## Example
```python
if "Foo" == foo:
    ...
```

Use instead:
```python
if foo == "Foo":
    ...
```

## References
- [Python documentation: Comparisons](https://docs.python.org/3/reference/expressions.html#comparisons)
- [Python documentation: Assignment statements](https://docs.python.org/3/reference/simple_stmts.html#assignment-statements)
