### PR TITLE
[MAINTENANCE] Enable SIM110

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
         exclude: tests/test_fixtures/database_key_test*
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.7"
+    rev: "v0.4.2"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -3,6 +3,6 @@ cookiecutter==2.1.1  # Project templating
 mypy==1.7.1            # Type checker
 pydantic>=1.0        # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
-ruff==0.3.7        # Linting / code style / formatting
+ruff==0.4.2        # Linting / code style / formatting
 twine==3.7.1         # Packaging
 wheel==0.38.1        # Packaging

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_after_split_to_be_in_set.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_after_split_to_be_in_set.py
@@ -17,11 +17,7 @@ from great_expectations.expectations.metrics import (
 def are_values_after_split_in_value_set(val: str, delimiter: str, value_set: List[str]) -> bool:
     all_split_values = [v.strip() for v in val.split(delimiter)]
 
-    for val in all_split_values:
-        if val not in value_set:
-            return False
-
-    return True
+    return all(val in value_set for val in all_split_values)
 
 
 # This class defines a Metric to support your Expectation.

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_contain_special_characters.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_contain_special_characters.py
@@ -48,10 +48,7 @@ class ColumnValuesToNotContainSpecialCharacters(ColumnMapMetricProvider):
                 char for char in special_characters if char not in allowed_characters
             ]
 
-            for c in special_characters:
-                if c in str(val):
-                    return False
-            return True
+            return all(c not in str(val) for c in special_characters)
 
         return column.apply(not_contain_special_character, args=(list(string.punctuation)))
 
@@ -63,10 +60,7 @@ class ColumnValuesToNotContainSpecialCharacters(ColumnMapMetricProvider):
                 char for char in list(string.punctuation) if char not in allowed_characters
             ]
 
-            for c in special_characters:
-                if c in str(val):
-                    return False
-            return True
+            return all(c not in str(val) for c in special_characters)
 
         # Register the UDF
         not_contain_special_character_udf = F.udf(

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_ip_address_in_network.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_ip_address_in_network.py
@@ -15,10 +15,7 @@ from great_expectations.expectations.metrics import (
 
 
 def is_ip_address_in_network(addr: str, ip_network) -> bool:
-    for ipn in ip_network:
-        if ipaddress.ip_address(addr) in ipaddress.ip_network(ipn):
-            return True
-    return False
+    return any(ipaddress.ip_address(addr) in ipaddress.ip_network(ipn) for ipn in ip_network)
 
 
 # This class defines a Metric to support your Expectation.

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_powerful_number.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_powerful_number.py
@@ -14,10 +14,7 @@ def is_valid_powerful_number(num: str) -> bool:
         n = int(num)
         unique_factors = {f for f in primefac(n)}
 
-        for p in unique_factors:
-            if n % (p * p) != 0:
-                return False
-        return True
+        return all(n % (p * p) == 0 for p in unique_factors)
     except ValueError:
         return False
 

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_square_free_number.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_square_free_number.py
@@ -15,10 +15,7 @@ def is_valid_square_free_number(num: str) -> bool:
         n = int(num)
         n_sqrt = (int)(math.sqrt(n))
 
-        for root in range(2, n_sqrt + 1):
-            if n % (root * root) == 0:
-                return False
-        return True
+        return all(n % (root * root) != 0 for root in range(2, n_sqrt + 1))
     except ValueError:
         return False
 

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -235,11 +235,7 @@ class StoreBackend(metaclass=ABCMeta):
         raise NotImplementedError
 
     def is_ignored_key(self, key):
-        for ignored in self.IGNORED_FILES:
-            if ignored in key:
-                return True
-
-        return False
+        return any(ignored in key for ignored in self.IGNORED_FILES)
 
     @property
     def config(self) -> dict:

--- a/great_expectations/datasource/fluent/databricks_sql_datasource.py
+++ b/great_expectations/datasource/fluent/databricks_sql_datasource.py
@@ -171,10 +171,7 @@ class DatabricksTableAsset(SqlTableAsset):
             True if the target string is bracketed by quotes.
         """
         # TODO: what todo with regular quotes? Error? Warn? "Fix"?
-        for quote in ["`"]:
-            if target.startswith(quote) and target.endswith(quote):
-                return True
-        return False
+        return any(target.startswith(quote) and target.endswith(quote) for quote in ["`"])
 
 
 @public_api

--- a/great_expectations/datasource/fluent/databricks_sql_datasource.py
+++ b/great_expectations/datasource/fluent/databricks_sql_datasource.py
@@ -171,7 +171,7 @@ class DatabricksTableAsset(SqlTableAsset):
             True if the target string is bracketed by quotes.
         """
         # TODO: what todo with regular quotes? Error? Warn? "Fix"?
-        return any(target.startswith(quote) and target.endswith(quote) for quote in ["`"])
+        return target.startswith("`") and target.endswith("`")
 
 
 @public_api

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -868,10 +868,7 @@ class TableAsset(_SQLAsset):
         Returns:
             True if the target string is bracketed by quotes.
         """
-        for quote in ["'", '"']:
-            if target.startswith(quote) and target.endswith(quote):
-                return True
-        return False
+        return any(target.startswith(quote) and target.endswith(quote) for quote in ["'", '"'])
 
 
 def _warn_for_more_specific_datasource_type(connection_string: str) -> None:

--- a/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
@@ -229,10 +229,7 @@ class MetricListMetricRetriever(MetricRetriever):
         Returns:
             bool: True if all the metric types in the list are valid, False otherwise.
         """  # noqa: E501
-        for metric in metric_list:
-            if metric not in MetricTypes:
-                return False
-        return True
+        return all(metric in MetricTypes for metric in metric_list)
 
     def _column_metrics_in_metric_list(self, metric_list: List[MetricTypes]) -> bool:
         """Helper method to check whether any column metrics are present in the metric list.
@@ -250,7 +247,4 @@ class MetricListMetricRetriever(MetricRetriever):
             MetricTypes.COLUMN_MEAN,
             MetricTypes.COLUMN_NULL_COUNT,
         ]
-        for metric in column_metrics:
-            if metric in metric_list:
-                return True
-        return False
+        return any(metric in metric_list for metric in column_metrics)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,7 +334,6 @@ lint.ignore = [
     "SIM105", # suppressible-exception
     "SIM117", # multiple-with-statements
     "SIM201", # negate-equal-op
-    "SIM110", # reimplemented-builtin
     "SIM910", # dict-get-with-none-default
     "SIM401", # if-else-block-instead-of-dict-get
     "SIM115", # open-file-with-context-handler

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -2,5 +2,5 @@ adr-tools-python==1.0.3
 invoke>=2.0.0
 mypy==1.9.0
 pre-commit>=2.21.0
-ruff==0.3.7
+ruff==0.4.2
 tomli>=2.0.1

--- a/scripts/check_for_technical_terms.py
+++ b/scripts/check_for_technical_terms.py
@@ -125,10 +125,7 @@ def remove_but_not_in(line_working_contents, phrase):
 
 
 def phrase_in_line(line_working_contents, phrase):
-    for possible_phrase in phrase.one_of_these:
-        if possible_phrase in line_working_contents:
-            return True
-    return False
+    return any(possible_phrase in line_working_contents for possible_phrase in phrase.one_of_these)
 
 
 def phrase_is_tagged_in_line(line_working_contents, phrase):


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/reimplemented-builtin/

# reimplemented-builtin (SIM110)

Derived from the **flake8-simplify** linter.

Fix is sometimes available.

## What it does
Checks for `for` loops that can be replaced with a builtin function, like
`any` or `all`.

## Why is this bad?
Using a builtin function is more concise and readable. Builtins are also
more efficient than `for` loops.

## Example
```python
for item in iterable:
    if predicate(item):
        return True
return False
```

Use instead:
```python
return any(predicate(item) for item in iterable)
```

## References
- [Python documentation: `any`](https://docs.python.org/3/library/functions.html#any)
- [Python documentation: `all`](https://docs.python.org/3/library/functions.html#all)