### PR TITLE
[MAINTENANCE] Make `SerializableDataContext.create` private

### DIFF
--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -12,11 +12,12 @@ import traceback
 from glob import glob
 from io import StringIO
 from subprocess import CalledProcessError, CompletedProcess, check_output, run
-from typing import Dict, Final, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Final, List, Optional, Tuple
 
 import click
 import pkg_resources  # noqa: TID251 # TODO: switch to importlib.metadata or importlib.resources
 
+import great_expectations as gx
 from great_expectations.compatibility import pydantic
 from great_expectations.core.expectation_diagnostics.expectation_doctor import (
     ExpectationDoctor,
@@ -24,11 +25,13 @@ from great_expectations.core.expectation_diagnostics.expectation_doctor import (
 from great_expectations.core.expectation_diagnostics.supporting_types import (
     ExpectationBackendTestResultCounts,
 )
-from great_expectations.data_context.data_context.file_data_context import (
-    FileDataContext,
-)
 from great_expectations.exceptions.exceptions import ExpectationNotFoundError
 from great_expectations.expectations.expectation import Expectation
+
+if TYPE_CHECKING:
+    from great_expectations.data_context.data_context.file_data_context import (
+        FileDataContext,
+    )
 
 logger = logging.getLogger(__name__)
 chandler = logging.StreamHandler(stream=sys.stdout)
@@ -707,7 +710,7 @@ def _disable_progress_bars() -> Tuple[str, FileDataContext]:
         os.path.sep, "tmp", f"gx-context-{os.getpid()}"
     )
     os.makedirs(context_dir)  # noqa: PTH103
-    context = FileDataContext.create(context_dir)
+    context = gx.get_context(mode="file", context_root_dir=context_dir)
     context.variables.progress_bars = {
         "globally": False,
         "metric_calculations": False,

--- a/docs/docusaurus/docs/core/installation_and_setup/manage_data_contexts.md
+++ b/docs/docusaurus/docs/core/installation_and_setup/manage_data_contexts.md
@@ -80,18 +80,18 @@ Run the following code to initialize your Filesystem Data Context in an empty fo
 
 ### Create a Data Context
 
-You provide the path for your empty folder to the GX library's `FileDataContext.create(...)` method as the `project_root_dir` parameter.  Because you are providing a path to an empty folder, `FileDataContext.create(...)` initializes a Filesystem Data Context in that location.
+You provide the path for your empty folder to the GX library's `gx.get_context` method as the `project_root_dir` parameter.  Because you are providing a path to an empty folder, `gx.get_context` initializes a Filesystem Data Context in that location.
 
-For convenience, the `FileDataContext.create(...)` method instantiates and returns the newly initialized Data Context, which you can keep in a Python variable.
+For convenience, the `gx.get_context` method instantiates and returns the newly initialized Data Context, which you can keep in a Python variable.
 
 ```python title="Python" name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py initialize_filesystem_data_context"
 ```
 
 :::info What if the folder is not empty?
 
-If the `project_root_dir` provided to the `FileDataContext.create(...)` method points to a folder that does not already have a Data Context present, the `FileDataContext.create(...)` method initializes a Filesystem Data Context in that location even if other files and folders are present.  This allows you to initialize a Filesystem Data Context in a folder that contains your Data Assets or other project related contents.
+If the `project_root_dir` provided to the `gx.get_context` method points to a folder that does not already have a Data Context present, `gx.get_context` initializes a Filesystem Data Context in that location even if other files and folders are present.  This allows you to initialize a Filesystem Data Context in a folder that contains your Data Assets or other project related contents.
 
-If a Data Context already exists in `project_root_dir`, the `FileDataContext.create(...)` method will not re-initialize it.  Instead, `FileDataContext.create(...)` instantiates and returns the existing Data Context.
+If a Data Context already exists in `project_root_dir`, the `gx.get_context` method will not re-initialize it.  Instead, `gx.get_context` instantiates and returns the existing Data Context.
 
 :::
 

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py
@@ -14,7 +14,7 @@ yaml: YAMLHandler = YAMLHandler()
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py get_context">
 import great_expectations as gx
 
-context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
+context = gx.get_context(mode="file", project_root_dir=full_path_to_project_directory)
 # </snippet>
 
 # NOTE: The following code is only for testing and depends on an environment

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py
@@ -15,7 +15,7 @@ yaml = YAMLHandler()
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py get_context">
 import great_expectations as gx
 
-context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
+context = gx.get_context(mode="file", project_root_dir=full_path_to_project_directory)
 # </snippet>
 
 

--- a/docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py
+++ b/docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py
@@ -7,6 +7,7 @@ pytest -v --docs-tests -k "how_to_initialize_a_filesystem_data_context_in_python
 
 import pathlib
 
+import great_expectations as gx
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
 )
@@ -25,7 +26,7 @@ path_to_empty_folder = project_root_dir
 # <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py initialize_filesystem_data_context">
 from great_expectations.data_context import FileDataContext
 
-context = FileDataContext.create(project_root_dir=path_to_empty_folder)
+context = gx.get_context(mode="file", project_root_dir=path_to_empty_folder)
 # </snippet>
 
 assert context

--- a/docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py
+++ b/docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py
@@ -19,7 +19,7 @@ path_to_project_root = "./my_project/"
 
 project_root_dir = pathlib.Path.cwd().absolute()
 path_to_context_root_folder = project_root_dir / FileDataContext.GX_DIR
-context = gx.data_context.FileDataContext.create(project_root_dir=project_root_dir)
+context = gx.get_context(mode="file", project_root_dir=project_root_dir)
 assert context
 assert context.root_directory == str(path_to_context_root_folder)
 

--- a/docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py
+++ b/docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py
@@ -16,7 +16,7 @@ yaml: YAMLHandler = YAMLHandler()
 # <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py imports">
 import great_expectations as gx
 
-context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
+context = gx.get_context(mode="file", project_root_dir=full_path_to_project_directory)
 # </snippet>
 
 # parse great_expectations.yml for comparison

--- a/docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py
+++ b/docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py
@@ -23,7 +23,7 @@ AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 # <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py imports">
 import great_expectations as gx
 
-context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
+context = gx.get_context(mode="file", project_root_dir=full_path_to_project_directory)
 # </snippet>
 
 # parse great_expectations.yml for comparison

--- a/docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py
+++ b/docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py
@@ -17,7 +17,7 @@ CONNECTION_STRING = get_redshift_connection_url()
 # <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py imports">
 import great_expectations as gx
 
-context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
+context = gx.get_context(mode="file", project_root_dir=full_path_to_project_directory)
 # </snippet>
 
 # parse great_expectations.yml for comparison

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, ClassVar, Optional, Union
 from ruamel.yaml import YAML
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
@@ -164,9 +163,8 @@ class SerializableDataContext(AbstractDataContext):
             and context_config_usage_stats.usage_statistics_url != global_usage_stats_url
         )
 
-    @public_api
     @classmethod
-    def create(
+    def _create(
         cls,
         project_root_dir: Optional[PathStr] = None,
         runtime_environment: Optional[dict] = None,

--- a/great_expectations/data_context/migrator/file_migrator.py
+++ b/great_expectations/data_context/migrator/file_migrator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import great_expectations as gx
 from great_expectations.data_context.data_context.file_data_context import (
@@ -76,9 +76,7 @@ class FileMigrator:
 
     def _scaffold_filesystem(self) -> FileDataContext:
         path = pathlib.Path.cwd().absolute()
-        target_context = cast(
-            FileDataContext, gx.get_context(mode="file", project_root_dir=str(path))
-        )
+        target_context = gx.get_context(mode="file", project_root_dir=str(path))
         logger.info("Scaffolded necessary directories for a file-backed context")
 
         return target_context

--- a/great_expectations/data_context/migrator/file_migrator.py
+++ b/great_expectations/data_context/migrator/file_migrator.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 from typing import TYPE_CHECKING, cast
 
+import great_expectations as gx
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
 )
@@ -75,7 +76,9 @@ class FileMigrator:
 
     def _scaffold_filesystem(self) -> FileDataContext:
         path = pathlib.Path.cwd().absolute()
-        target_context = cast(FileDataContext, FileDataContext.create(project_root_dir=str(path)))
+        target_context = cast(
+            FileDataContext, gx.get_context(mode="file", project_root_dir=str(path))
+        )
         logger.info("Scaffolded necessary directories for a file-backed context")
 
         return target_context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -764,7 +764,7 @@ def empty_data_context(
     os.makedirs(asset_config_path, exist_ok=True)  # noqa: PTH103
     assert context.list_datasources() == []
     project_manager.set_project(context)
-    return context  # type: ignore[return-value]
+    return context
 
 
 @pytest.fixture(scope="function")
@@ -824,7 +824,7 @@ def data_context_with_connection_to_metrics_db(
 
     context._save_project_config()
     project_manager.set_project(context)
-    return context  # type: ignore[return-value]
+    return context
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -758,7 +758,7 @@ def empty_data_context(
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
     project_path = str(project_path)
-    context = gx.data_context.FileDataContext.create(project_path)
+    context = gx.get_context(mode="file", project_root_dir=project_path)
     context_path = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
     asset_config_path = os.path.join(context_path, "expectations")  # noqa: PTH118
     os.makedirs(asset_config_path, exist_ok=True)  # noqa: PTH103
@@ -793,7 +793,7 @@ def data_context_with_connection_to_metrics_db(
     project_path = tmp_path / "test_configuration"
     project_path.mkdir()
     project_path = str(project_path)
-    context = gx.data_context.FileDataContext.create(project_path)
+    context = gx.get_context(mode="file", project_root_dir=project_path)
     context_path = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
     asset_config_path = os.path.join(context_path, "expectations")  # noqa: PTH118
     os.makedirs(asset_config_path, exist_ok=True)  # noqa: PTH103
@@ -1409,7 +1409,7 @@ def empty_data_context_stats_enabled(tmp_path_factory, monkeypatch):
     # Re-enable GE_USAGE_STATS
     monkeypatch.delenv("GE_USAGE_STATS", raising=False)
     project_path = str(tmp_path_factory.mktemp("empty_data_context"))
-    context = gx.data_context.FileDataContext.create(project_path)
+    context = gx.get_context(mode="file", project_root_dir=project_path)
     context_path = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
     asset_config_path = os.path.join(context_path, "expectations")  # noqa: PTH118
     os.makedirs(asset_config_path, exist_ok=True)  # noqa: PTH103
@@ -1742,7 +1742,7 @@ def v20_project_directory(tmp_path_factory):
 def data_context_parameterized_expectation_suite_no_checkpoint_store(tmp_path_factory):
     """
     This data_context is *manually* created to have the config we want, vs
-    created with DataContext.create()
+    created with gx.get_context()
     """
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
@@ -1774,7 +1774,7 @@ def data_context_parameterized_expectation_suite_no_checkpoint_store(tmp_path_fa
 def data_context_parameterized_expectation_suite(tmp_path_factory):
     """
     This data_context is *manually* created to have the config we want, vs
-    created with DataContext.create()
+    created with gx.get_context()
     """
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
@@ -1806,7 +1806,7 @@ def data_context_parameterized_expectation_suite(tmp_path_factory):
 def data_context_simple_expectation_suite(tmp_path_factory):
     """
     This data_context is *manually* created to have the config we want, vs
-    created with DataContext.create()
+    created with gx.get_context()
     """
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -518,14 +518,13 @@ def test_data_context_create_does_not_raise_error_or_warning_if_ge_dir_exists(
 @pytest.fixture()
 def empty_context(tmp_path_factory) -> FileDataContext:
     project_path = str(tmp_path_factory.mktemp("data_context"))
-    gx.get_context(mode="file", project_root_dir=project_path)
     ge_dir = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
+    context = get_context(context_root_dir=ge_dir)
+    assert isinstance(context, FileDataContext)
     assert os.path.isdir(ge_dir)  # noqa: PTH112
     assert os.path.isfile(  # noqa: PTH113
         os.path.join(ge_dir, FileDataContext.GX_YML)  # noqa: PTH118
     )
-    context = gx.get_context(context_root_dir=ge_dir)
-    assert isinstance(context, FileDataContext)
     return context
 
 
@@ -699,6 +698,108 @@ def test_data_context_is_project_initialized_returns_false_when_config_variable_
 
 
 @pytest.mark.filesystem
+def test_data_context_create_raises_warning_and_leaves_existing_yml_untouched(
+    tmp_path_factory,
+):
+    project_path = str(tmp_path_factory.mktemp("data_context"))
+    gx.get_context(mode="file", project_root_dir=project_path)
+    ge_yml = os.path.join(project_path, "gx/great_expectations.yml")  # noqa: PTH118
+    with open(ge_yml, "a") as ff:
+        ff.write("# LOOK I WAS MODIFIED")
+
+    gx.get_context(mode="file", project_root_dir=project_path)
+
+    with open(ge_yml) as ff:
+        obs = ff.read()
+    assert "# LOOK I WAS MODIFIED" in obs
+
+
+@pytest.mark.filesystem
+def test_data_context_create_makes_uncommitted_dirs_when_all_are_missing(
+    tmp_path_factory,
+):
+    project_path = str(tmp_path_factory.mktemp("data_context"))
+    gx.get_context(mode="file", project_root_dir=project_path)
+
+    # mangle the existing setup
+    ge_dir = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
+    uncommitted_dir = os.path.join(ge_dir, "uncommitted")  # noqa: PTH118
+    shutil.rmtree(uncommitted_dir)
+
+    # re-run create to simulate onboarding
+    gx.get_context(mode="file", project_root_dir=project_path)
+    obs = gen_directory_tree_str(ge_dir)
+
+    assert os.path.isdir(  # noqa: PTH112
+        uncommitted_dir
+    ), "No uncommitted directory created"
+    assert (
+        obs
+        == """\
+gx/
+    .gitignore
+    great_expectations.yml
+    checkpoints/
+    expectations/
+        .ge_store_backend_id
+    plugins/
+        custom_data_docs/
+            renderers/
+            styles/
+                data_docs_custom_styles.css
+            views/
+    profilers/
+    uncommitted/
+        config_variables.yml
+        data_docs/
+        validations/
+            .ge_store_backend_id
+    validation_definitions/
+"""
+    )
+
+
+@pytest.mark.filesystem
+def test_data_context_create_does_nothing_if_all_uncommitted_dirs_exist(
+    tmp_path_factory,
+):
+    expected = """\
+gx/
+    .gitignore
+    great_expectations.yml
+    checkpoints/
+    expectations/
+        .ge_store_backend_id
+    plugins/
+        custom_data_docs/
+            renderers/
+            styles/
+                data_docs_custom_styles.css
+            views/
+    profilers/
+    uncommitted/
+        config_variables.yml
+        data_docs/
+        validations/
+            .ge_store_backend_id
+    validation_definitions/
+"""
+    project_path = str(tmp_path_factory.mktemp("stuff"))
+    ge_dir = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118
+
+    gx.get_context(mode="file", project_root_dir=project_path)
+    fixture = gen_directory_tree_str(ge_dir)
+
+    assert fixture == expected
+
+    # re-run create to simulate onboarding
+    gx.get_context(mode="file", project_root_dir=project_path)
+
+    obs = gen_directory_tree_str(ge_dir)
+    assert obs == expected
+
+
+@pytest.mark.filesystem
 def test_data_context_do_all_uncommitted_dirs_exist(tmp_path_factory):
     expected = """\
 uncommitted/
@@ -757,6 +858,9 @@ def test_data_context_create_does_not_overwrite_existing_config_variables_yml(
     # modify config variables
     with open(config_vars_yml, "a") as ff:
         ff.write("# LOOK I WAS MODIFIED")
+
+    # re-run create to simulate onboarding
+    gx.get_context(mode="file", project_root_dir=project_path)
 
     with open(config_vars_yml) as ff:
         obs = ff.read()

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 import pytest
 
+import great_expectations as gx
 from great_expectations.core.config_provider import _ConfigurationSubstitutor
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import get_context
@@ -605,7 +606,8 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
     """  # noqa: E501
 
     project_path = str(tmp_path_factory.mktemp("data_context"))
-    context = FileDataContext.create(
+    context = gx.get_context(
+        mode="file",
         project_root_dir=project_path,
     )
 

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -239,11 +239,9 @@ def test_existing_local_data_docs_urls_returns_url_on_project_with_no_datasource
     datasource is not configured, and docs are not built.
     """
     empty_directory = str(tmp_path_factory.mktemp("another_empty_project"))
-    FileDataContext.create(empty_directory)
     context = get_context(
-        context_root_dir=os.path.join(  # noqa: PTH118
-            empty_directory, FileDataContext.GX_DIR
-        )
+        mode="file",
+        project_root_dir=empty_directory,
     )
 
     obs = context.get_docs_sites_urls(only_if_exists=False)
@@ -256,7 +254,6 @@ def test_existing_local_data_docs_urls_returns_single_url_from_customized_local_
     tmp_path_factory,
 ):
     empty_directory = str(tmp_path_factory.mktemp("yo_yo"))
-    FileDataContext.create(empty_directory)
     ge_dir = os.path.join(empty_directory, FileDataContext.GX_DIR)  # noqa: PTH118
     context = get_context(context_root_dir=ge_dir)
 
@@ -290,7 +287,6 @@ def test_existing_local_data_docs_urls_returns_multiple_urls_from_customized_loc
     tmp_path_factory,
 ):
     empty_directory = str(tmp_path_factory.mktemp("yo_yo_ma"))
-    FileDataContext.create(empty_directory)
     ge_dir = os.path.join(empty_directory, FileDataContext.GX_DIR)  # noqa: PTH118
     context = get_context(context_root_dir=ge_dir)
 
@@ -340,7 +336,6 @@ def test_build_data_docs_skipping_index_does_not_build_index(
 ):
     # TODO What's the latest and greatest way to use configs rather than my hackery?
     empty_directory = str(tmp_path_factory.mktemp("empty"))
-    FileDataContext.create(empty_directory)
     ge_dir = os.path.join(empty_directory, FileDataContext.GX_DIR)  # noqa: PTH118
     context = get_context(context_root_dir=ge_dir)
     config = context.get_config()

--- a/tests/data_context/test_data_context_store_configs.py
+++ b/tests/data_context/test_data_context_store_configs.py
@@ -64,14 +64,6 @@ def totally_empty_data_context(tmp_path_factory):
 
 
 @pytest.mark.filesystem
-def test_create(tmp_path_factory):
-    project_path = str(tmp_path_factory.mktemp("path_001"))
-    context = gx.data_context.FileDataContext.create(project_path)
-
-    assert isinstance(context, gx.data_context.FileDataContext)
-
-
-@pytest.mark.filesystem
 def test_add_store(totally_empty_data_context):
     assert len(totally_empty_data_context.stores.keys()) == 6
 
@@ -89,7 +81,7 @@ def test_add_store(totally_empty_data_context):
 @pytest.mark.filesystem
 def test_default_config_yml_stores(tmp_path_factory):
     project_path = str(tmp_path_factory.mktemp("totally_empty_data_context"))
-    context = gx.data_context.FileDataContext.create(project_path)
+    context = gx.get_context(project_root_dir=project_path)
 
     assert set(context.stores.keys()) == {
         "expectations_store",

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -150,14 +150,6 @@ def test_cloud_context_env(set_up_cloud_envs, empty_ge_cloud_data_context_config
 
 
 @pytest.mark.cloud
-def test_cloud_context_disabled(set_up_cloud_envs, tmp_path: pathlib.Path):
-    project_path = tmp_path / "empty_data_context"
-    project_path.mkdir()
-    with working_directory(project_path):
-        assert isinstance(gx.get_context(cloud_mode=False), FileDataContext)
-
-
-@pytest.mark.cloud
 def test_cloud_missing_env_throws_exception(clear_env_vars, empty_ge_cloud_data_context_config):
     with pytest.raises(GXCloudConfigurationError):
         gx.get_context(cloud_mode=True)

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -71,7 +71,6 @@ def test_base_context(clear_env_vars):
 def test_base_context__with_overridden_yml(tmp_path: pathlib.Path, clear_env_vars):
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
-    gx.data_context.FileDataContext.create(project_path)
     context_path = project_path / FileDataContext.GX_DIR
     context = gx.get_context(context_root_dir=context_path)
     assert isinstance(context, FileDataContext)
@@ -99,22 +98,12 @@ def test_base_context__with_overridden_yml(tmp_path: pathlib.Path, clear_env_var
 
 
 @pytest.mark.unit
-def test_data_context(tmp_path: pathlib.Path, clear_env_vars):
-    project_path = tmp_path / "empty_data_context"
-    project_path.mkdir()
-    FileDataContext.create(project_path)
-    with working_directory(project_path):
-        assert isinstance(gx.get_context(), FileDataContext)
-
-
-@pytest.mark.unit
 def test_data_context_root_dir_returns_data_context(
     tmp_path: pathlib.Path,
     clear_env_vars,
 ):
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
-    gx.data_context.FileDataContext.create(project_path)
     context_path = project_path / FileDataContext.GX_DIR
     assert isinstance(gx.get_context(context_root_dir=str(context_path)), FileDataContext)
 
@@ -164,7 +153,6 @@ def test_cloud_context_env(set_up_cloud_envs, empty_ge_cloud_data_context_config
 def test_cloud_context_disabled(set_up_cloud_envs, tmp_path: pathlib.Path):
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
-    gx.data_context.FileDataContext.create(project_path)
     with working_directory(project_path):
         assert isinstance(gx.get_context(cloud_mode=False), FileDataContext)
 

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -204,7 +204,7 @@ def file_dc_config_dir_init(tmp_path: pathlib.Path) -> pathlib.Path:
     """
     gx_yml = tmp_path / FileDataContext.GX_DIR / FileDataContext.GX_YML
     assert gx_yml.exists() is False
-    FileDataContext.create(tmp_path)
+    gx.get_context(mode="file", project_root_dir=tmp_path)
     assert gx_yml.exists()
 
     tmp_gx_dir = gx_yml.parent.absolute()

--- a/tests/datasource/fluent/test_config.py
+++ b/tests/datasource/fluent/test_config.py
@@ -20,6 +20,7 @@ from typing import (  # TODO: revert use of cast
 
 import pytest
 
+import great_expectations as gx
 from great_expectations.compatibility import pydantic
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.partitioners import PartitionerYearAndMonth
@@ -859,7 +860,7 @@ def file_dc_config_dir_init(tmp_path: pathlib.Path) -> pathlib.Path:
     """
     gx_yml = tmp_path / FileDataContext.GX_DIR / FileDataContext.GX_YML
     assert gx_yml.exists() is False
-    FileDataContext.create(tmp_path)
+    gx.get_context(mode="file", project_root_dir=tmp_path)
     assert gx_yml.exists()
 
     tmp_gx_dir = gx_yml.parent.absolute()


### PR DESCRIPTION
Users should not be calling this method - they can access it through `gx.get_context`, our canonical way for context creation. Note that this method utilizes `create`'s scaffolding capabilities under the hood.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
