### PR TITLE
[MAINTENANCE] Remove custom `ExpectationSuite` equivalency logic

### DIFF
--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -262,7 +262,6 @@ def test_checkpoint_factory_all(context_fixture_name: str, request: pytest.Fixtu
 
     # Assert
     assert [r.name for r in result] == [checkpoint_a.name, checkpoint_b.name]
-    assert result == [checkpoint_a, checkpoint_b]
 
 
 class TestCheckpointFactoryAnalytics:

--- a/tests/core/factory/test_suite_factory.py
+++ b/tests/core/factory/test_suite_factory.py
@@ -19,10 +19,11 @@ from great_expectations.exceptions import DataContextError
 def test_suite_factory_get_uses_store_get():
     # Arrange
     name = "test-suite"
+    id = "3a758816-64c8-46cb-8f7e-03c12cea1d67"
     store = Mock(spec=ExpectationsStore)
     store.has_key.return_value = True
     key = store.get_key.return_value
-    suite_dict = {"name": name, "id": "3a758816-64c8-46cb-8f7e-03c12cea1d67"}
+    suite_dict = {"name": name, "id": id}
     store.get.return_value = suite_dict
     factory = SuiteFactory(store=store)
     context = Mock(spec=AbstractDataContext)
@@ -33,7 +34,8 @@ def test_suite_factory_get_uses_store_get():
 
     # Assert
     store.get.assert_called_once_with(key=key)
-    assert result == ExpectationSuite(name=name)
+    assert result.name == name
+    assert result.id == id
 
 
 @pytest.mark.unit

--- a/tests/core/factory/test_suite_factory.py
+++ b/tests/core/factory/test_suite_factory.py
@@ -221,7 +221,7 @@ def test_suite_factory_all(context_fixture_name: str, request: pytest.FixtureReq
 
     # Assert
     assert [r.name for r in result] == [suite_a.name, suite_b.name]
-    assert result == [suite_a, suite_b]
+    assert [r.to_dict() for r in result] == [suite_a.to_dict(), suite_b.to_dict()]
 
 
 class TestSuiteFactoryAnalytics:

--- a/tests/core/test_expectation_configuration.py
+++ b/tests/core/test_expectation_configuration.py
@@ -82,30 +82,6 @@ def config7():
 
 
 @pytest.mark.unit
-def test_expectation_configuration_equality(config1, config2, config3, config4):
-    """Equality should depend on all defined properties of a configuration object, but not on whether the *instances*
-    are the same."""  # noqa: E501
-    assert config1 is config1  # no difference  # noqa: PLR0124
-    assert config1 is not config2  # different instances, but same content
-    assert config1 == config2  # different instances, but same content
-    assert not (config1 != config2)  # ne works properly
-    assert config1 != config3  # different meta
-    assert config1 != config3  # ne works properly
-    assert config3 != config4  # different result format
-
-
-@pytest.mark.unit
-def test_expectation_configuration_equivalence(config1, config2, config3, config4, config5):
-    """Equivalence should depend only on properties that affect the result of the expectation."""
-    assert config1.isEquivalentTo(config2, match_type="runtime")  # no difference
-    assert config2.isEquivalentTo(config1, match_type="runtime")
-    assert config1.isEquivalentTo(config3, match_type="runtime")  # different meta
-    assert config1.isEquivalentTo(config4, match_type="success")  # different result format
-    assert not config1.isEquivalentTo(config5, match_type="success")  # different value_set
-    assert config1.isEquivalentTo(config5, match_type="domain")  # different result format
-
-
-@pytest.mark.unit
 def test_expectation_configuration_get_suite_parameter_dependencies():
     # Getting evaluation parameter dependencies relies on pyparsing, but the expectation
     # configuration is responsible for ensuring that it only returns one copy of required metrics.

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -388,11 +388,9 @@ def test_add_expectation(
     domain_success_runtime_suite,
 ):
     assert len(single_expectation_suite.expectations) == 1
-    # assert not single_expectation_suite.isEquivalentTo(baseline_suite)
     single_expectation_suite.add_expectation_configuration(
         exp2, match_type="runtime", overwrite_existing=False
     )
-    # assert single_expectation_suite.isEquivalentTo(baseline_suite)
     assert len(single_expectation_suite.expectations) == 2
 
     # Should raise if overwrite_existing=False and a matching expectation is found
@@ -401,11 +399,9 @@ def test_add_expectation(
             exp4, match_type="domain", overwrite_existing=False
         )
 
-    # assert not single_expectation_suite.isEquivalentTo(different_suite)
     single_expectation_suite.add_expectation_configuration(
         exp4, match_type="domain", overwrite_existing=True
     )
-    # assert single_expectation_suite.isEquivalentTo(different_suite)
     assert len(single_expectation_suite.expectations) == 2
 
     # Should raise if more than one matching expectation is found

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -337,7 +337,6 @@ def test_remove_expectation(
         domain_success_runtime_suite.remove_expectation(exp3, match_type="runtime")
 
     assert domain_success_runtime_suite.find_expectation_indexes(exp1, match_type="domain") == [0]
-    assert domain_success_runtime_suite.isEquivalentTo(single_expectation_suite)
 
 
 @pytest.mark.filesystem
@@ -359,7 +358,6 @@ def test_add_expectation_configurations(
 ):
     expectation_configurations = [exp1, exp2, exp3, exp4, exp5]
     assert len(single_expectation_suite.expectations) == 1
-    assert not single_expectation_suite.isEquivalentTo(different_suite)
     result = single_expectation_suite.add_expectation_configurations(
         expectation_configurations=expectation_configurations,
         match_type="domain",
@@ -379,8 +377,6 @@ def test_add_expectation_configurations(
             overwrite_existing=False,
         )
 
-    assert single_expectation_suite.isEquivalentTo(different_suite)
-
 
 @pytest.mark.filesystem
 def test_add_expectation(
@@ -392,11 +388,11 @@ def test_add_expectation(
     domain_success_runtime_suite,
 ):
     assert len(single_expectation_suite.expectations) == 1
-    assert not single_expectation_suite.isEquivalentTo(baseline_suite)
+    # assert not single_expectation_suite.isEquivalentTo(baseline_suite)
     single_expectation_suite.add_expectation_configuration(
         exp2, match_type="runtime", overwrite_existing=False
     )
-    assert single_expectation_suite.isEquivalentTo(baseline_suite)
+    # assert single_expectation_suite.isEquivalentTo(baseline_suite)
     assert len(single_expectation_suite.expectations) == 2
 
     # Should raise if overwrite_existing=False and a matching expectation is found
@@ -405,11 +401,11 @@ def test_add_expectation(
             exp4, match_type="domain", overwrite_existing=False
         )
 
-    assert not single_expectation_suite.isEquivalentTo(different_suite)
+    # assert not single_expectation_suite.isEquivalentTo(different_suite)
     single_expectation_suite.add_expectation_configuration(
         exp4, match_type="domain", overwrite_existing=True
     )
-    assert single_expectation_suite.isEquivalentTo(different_suite)
+    # assert single_expectation_suite.isEquivalentTo(different_suite)
     assert len(single_expectation_suite.expectations) == 2
 
     # Should raise if more than one matching expectation is found

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -425,7 +425,6 @@ class TestValidationDefinitionSerialization:
         validation_definition = ValidationDefinition.parse_obj(serialized_config)
         assert validation_definition.name == self.validation_definition_name
         assert validation_definition.data == batch_definition
-        assert validation_definition.suite == validation_definition_suite
 
     @pytest.mark.unit
     @pytest.mark.parametrize(

--- a/tests/data_context/store/test_validation_definition_store.py
+++ b/tests/data_context/store/test_validation_definition_store.py
@@ -79,7 +79,14 @@ def test_add(request, store_fixture: str, validation_definition: ValidationDefin
     store.add(key=key, value=validation_definition)
     assert validation_definition.id
 
-    assert store.get(key) == validation_definition
+    actual = store.get(key).dict()
+    expected = validation_definition.dict()
+
+    # Suite equality not supported until migration to Pydantic
+    actual.pop("suite")
+    expected.pop("suite")
+
+    assert actual == expected
 
 
 @pytest.mark.cloud

--- a/tests/data_context/store/test_validation_definition_store.py
+++ b/tests/data_context/store/test_validation_definition_store.py
@@ -79,7 +79,9 @@ def test_add(request, store_fixture: str, validation_definition: ValidationDefin
     store.add(key=key, value=validation_definition)
     assert validation_definition.id
 
-    actual = store.get(key).dict()
+    actual_obj = store.get(key)
+    assert isinstance(actual_obj, ValidationDefinition)
+    actual = actual_obj.dict()
     expected = validation_definition.dict()
 
     # Suite equality not supported until migration to Pydantic

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -495,7 +495,8 @@ def test_add_expectation_suite_success(
 
     suite = context.add_expectation_suite(**kwargs)
 
-    assert suite == expected_suite
+    assert suite.name == expected_suite.name
+    assert suite.expectations == expected_suite.expectations
     assert context.expectations_store.save_count == 1
 
 


### PR DESCRIPTION
The logic we've written to ensure equality between suites is overly complex and unnecessary for 99% of usecases. We can leverage Pydantic's capabilities when we port over the class.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
