### PR TITLE
[MAINTENANCE] mypy 1.10

### DIFF
--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -1,6 +1,6 @@
 Click>=7.1.2         # CLI tooling
 cookiecutter==2.1.1  # Project templating
-mypy==1.7.1            # Type checker
+mypy==1.10.0            # Type checker
 pydantic>=1.0        # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
 ruff==0.4.2        # Linting / code style / formatting

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -1,6 +1,6 @@
 adr-tools-python==1.0.3
 invoke>=2.0.0
-mypy==1.9.0
+mypy==1.10
 pre-commit>=2.21.0
 ruff==0.4.2
 tomli>=2.0.1


### PR DESCRIPTION
Update from `mypy` `1.9` -> `1.10`

https://mypy-lang.blogspot.com/2024/04/mypy-110-released.html

The biggest change here is support for `pep-072` `TypeIs` via [typing_extensions](https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.TypeIs) 

https://peps.python.org/pep-0742/
