### PR TITLE
[BUGFIX] Set application query param for SnowflakeDatasource

### DIFF
--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -869,7 +869,7 @@ The following are some of the connection strings that are available for differen
 - MySQL: `mysql+pymysql://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>`
 - PostgreSQL: `postgresql+psycopg2://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>`
 - Redshift: `postgresql+psycopg2://<USER_NAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>?sslmode=<SSLMODE>`
-- Snowflake: `snowflake://<USER_NAME>:<PASSWORD>@<ACCOUNT_NAME>/<DATABASE_NAME>/<SCHEMA_NAME>?warehouse=<WAREHOUSE_NAME>&role=<ROLE_NAME>&application=great_expectations_oss`
+- Snowflake: `snowflake://<USER_NAME>:<PASSWORD>@<ACCOUNT_NAME>/<DATABASE_NAME>/<SCHEMA_NAME>?warehouse=<WAREHOUSE_NAME>&role=<ROLE_NAME>`
 - SQLite: `sqlite:///<PATH_TO_DB_FILE>`
 - Trino: `trino://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<CATALOG>/<SCHEMA>`
 

--- a/great_expectations/datasource/fluent/constants.py
+++ b/great_expectations/datasource/fluent/constants.py
@@ -24,3 +24,7 @@ DEFAULT_PANDAS_DATASOURCE_NAME: Final[str] = "default_pandas_datasource"
 DEFAULT_PANDAS_DATA_ASSET_NAME: Final[str] = "#ephemeral_pandas_asset"
 
 _IN_MEMORY_DATA_ASSET_TYPE: Final[str] = "dataframe"
+
+SNOWFLAKE_PARTNER_APPLICATION_OSS: Final[str] = "great_expectations_oss"
+# TODO: Change this value to "great_expectations_cloud" once configured in Snowflake partner account
+SNOWFLAKE_PARTNER_APPLICATION_CLOUD: Final[str] = "great_expectations_oss"

--- a/great_expectations/datasource/fluent/constants.py
+++ b/great_expectations/datasource/fluent/constants.py
@@ -25,6 +25,5 @@ DEFAULT_PANDAS_DATA_ASSET_NAME: Final[str] = "#ephemeral_pandas_asset"
 
 _IN_MEMORY_DATA_ASSET_TYPE: Final[str] = "dataframe"
 
-SNOWFLAKE_PARTNER_APPLICATION_OSS: Final[str] = "great_expectations_oss"
-# TODO: Change this value to "great_expectations_cloud" once configured in Snowflake partner account
-SNOWFLAKE_PARTNER_APPLICATION_CLOUD: Final[str] = "great_expectations_oss"
+SNOWFLAKE_PARTNER_APPLICATION_OSS: Final[str] = "great_expectations_core"
+SNOWFLAKE_PARTNER_APPLICATION_CLOUD: Final[str] = "great_expectations_platform"

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -130,23 +130,22 @@ class SnowflakeDatasource(SQLDatasource):
             values["connection_string"] = connection_details
         return values
 
-    @pydantic.root_validator
-    def _check_xor_input_args(cls, values: dict) -> dict:
+    @pydantic.validator("connection_string")
+    def _check_connection_string(
+        cls, connection_string: ConnectionDetails | ConfigStr | SnowflakeDsn
+    ) -> ConnectionDetails | ConfigStr | SnowflakeDsn:
         # keeping this validator isn't strictly necessary, but it provides a better error message
-        connection_string: str | ConnectionDetails | None = values.get(
-            "connection_string"
-        )
-        if connection_string:
-            # Method 1 - connection string
-            if isinstance(connection_string, (str, ConfigStr)):
-                return values
-            # Method 2 - individual args (account, user, and password are bare minimum)
-            elif isinstance(connection_string, ConnectionDetails) and bool(
-                connection_string.account
-                and connection_string.user
-                and connection_string.password
-            ):
-                return values
+
+        # Method 1 - connection string
+        if isinstance(connection_string, (str, ConfigStr)):
+            return connection_string
+        # Method 2 - individual args (account, user, and password are bare minimum)
+        elif isinstance(connection_string, ConnectionDetails) and bool(
+            connection_string.account
+            and connection_string.user
+            and connection_string.password
+        ):
+            return connection_string
         raise ValueError(
             "Must provide either a connection string or a combination of account, user, and password."
         )

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -129,7 +129,7 @@ class SnowflakeDatasource(SQLDatasource):
 
         if values.get("connection_string") and connection_details:
             raise ValueError(
-                "Cannot provide both a connection string or a combination of account, user, and password."
+                "Cannot provide both a connection string and a combination of account, user, and password."
             )
 
         if connection_details:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -213,11 +213,14 @@ class SnowflakeDatasource(SQLDatasource):
         return gx_exec_engine
 
     def _get_snowflake_partner_application(self) -> str:
+        """
+        This is used to set the application query parameter in the Snowflake connection URL, which provides attribution
+        to GX for the Snowflake Partner program.
+        """
+
         # This import is here to avoid a circular import
         from great_expectations.data_context import CloudDataContext
 
-        # This is used to set the application query parameter, which provides attribution to GX
-        # for the Snowflake Partner program.
         if isinstance(self._data_context, CloudDataContext):
             # TODO: Change this value to "great_expectations_cloud" once configured in Snowflake partner account
             return SNOWFLAKE_PARTNER_APPLICATION_CLOUD

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -222,7 +222,6 @@ class SnowflakeDatasource(SQLDatasource):
         from great_expectations.data_context import CloudDataContext
 
         if isinstance(self._data_context, CloudDataContext):
-            # TODO: Change this value to "great_expectations_cloud" once configured in Snowflake partner account
             return SNOWFLAKE_PARTNER_APPLICATION_CLOUD
         return SNOWFLAKE_PARTNER_APPLICATION_OSS
 

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -136,22 +136,23 @@ class SnowflakeDatasource(SQLDatasource):
             values["connection_string"] = connection_details
         return values
 
-    @pydantic.validator("connection_string")
-    def _check_connection_string(
-        cls, connection_string: ConnectionDetails | ConfigStr | SnowflakeDsn
-    ) -> ConnectionDetails | ConfigStr | SnowflakeDsn:
+    @pydantic.root_validator
+    def _check_connection_string(cls, values: dict) -> dict:
         # keeping this validator isn't strictly necessary, but it provides a better error message
-
-        # Method 1 - connection string
-        if isinstance(connection_string, (str, ConfigStr)):
-            return connection_string
-        # Method 2 - individual args (account, user, and password are bare minimum)
-        elif isinstance(connection_string, ConnectionDetails) and bool(
-            connection_string.account
-            and connection_string.user
-            and connection_string.password
-        ):
-            return connection_string
+        connection_string: str | ConfigStr | ConnectionDetails | None = values.get(
+            "connection_string"
+        )
+        if connection_string:
+            # Method 1 - connection string
+            if isinstance(connection_string, (str, ConfigStr)):
+                return values
+            # Method 2 - individual args (account, user, and password are bare minimum)
+            elif isinstance(connection_string, ConnectionDetails) and bool(
+                connection_string.account
+                and connection_string.user
+                and connection_string.password
+            ):
+                return values
         raise ValueError(
             "Must provide either a connection string or a combination of account, user, and password."
         )

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -126,6 +126,12 @@ class SnowflakeDatasource(SQLDatasource):
         for field_name in tuple(values.keys()):
             if field_name in connection_detail_fields:
                 connection_details[field_name] = values.pop(field_name)
+
+        if values.get("connection_string") and connection_details:
+            raise ValueError(
+                "Cannot provide both a connection string or a combination of account, user, and password."
+            )
+
         if connection_details:
             values["connection_string"] = connection_details
         return values

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -234,9 +234,12 @@ class SnowflakeDatasource(SQLDatasource):
                 connection_string: str | dict = model_dict.pop("connection_string")
 
                 if isinstance(connection_string, str):
+                    url = sa.engine.url.make_url(connection_string)
+                    url = url.update_query_dict(
+                        query_parameters={"application": snowflake_partner_application}
+                    )
                     self._engine = sa.create_engine(
-                        connection_string,
-                        connect_args={"application": snowflake_partner_application},
+                        url,
                         **kwargs,
                     )
                 else:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -13,8 +13,10 @@ from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
     _check_config_substitutions_needed,
 )
-from great_expectations.datasource.fluent.constants import SNOWFLAKE_PARTNER_APPLICATION_CLOUD, \
-    SNOWFLAKE_PARTNER_APPLICATION_OSS
+from great_expectations.datasource.fluent.constants import (
+    SNOWFLAKE_PARTNER_APPLICATION_CLOUD,
+    SNOWFLAKE_PARTNER_APPLICATION_OSS,
+)
 from great_expectations.datasource.fluent.sql_datasource import (
     FluentBaseModel,
     SQLDatasource,
@@ -239,7 +241,9 @@ class SnowflakeDatasource(SQLDatasource):
                 if isinstance(connection_string, str):
                     url = sa.engine.url.make_url(connection_string)
                     url = url.update_query_dict(
-                        query_parameters={"application": self._get_snowflake_partner_application()}
+                        query_parameters={
+                            "application": self._get_snowflake_partner_application()
+                        }
                     )
                     self._engine = sa.create_engine(
                         url,

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -241,7 +241,9 @@ class SnowflakeDatasource(SQLDatasource):
                     )
                 else:
                     self._engine = self._build_engine_with_connect_args(
-                        application=snowflake_partner_application, **connection_string
+                        application=snowflake_partner_application,
+                        **connection_string,
+                        **kwargs,
                     )
 
             except Exception as e:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -13,6 +13,8 @@ from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
     _check_config_substitutions_needed,
 )
+from great_expectations.datasource.fluent.constants import SNOWFLAKE_PARTNER_APPLICATION_CLOUD, \
+    SNOWFLAKE_PARTNER_APPLICATION_OSS
 from great_expectations.datasource.fluent.sql_datasource import (
     FluentBaseModel,
     SQLDatasource,
@@ -208,19 +210,19 @@ class SnowflakeDatasource(SQLDatasource):
         self._execution_engine = gx_exec_engine
         return gx_exec_engine
 
-    @override
-    def get_engine(self) -> sqlalchemy.Engine:
+    def _get_snowflake_partner_application(self) -> str:
         # This import is here to avoid a circular import
         from great_expectations.data_context import CloudDataContext
 
         # This is used to set the application query parameter, which provides attribution to GX
         # for the Snowflake Partner program.
         if isinstance(self._data_context, CloudDataContext):
-            # TODO: Change this value to ""great_expectations_cloud" once configured in Snowflake partner account
-            snowflake_partner_application = "great_expectations_oss"
-        else:
-            snowflake_partner_application = "great_expectations_oss"
+            # TODO: Change this value to "great_expectations_cloud" once configured in Snowflake partner account
+            return SNOWFLAKE_PARTNER_APPLICATION_CLOUD
+        return SNOWFLAKE_PARTNER_APPLICATION_OSS
 
+    @override
+    def get_engine(self) -> sqlalchemy.Engine:
         if self.connection_string != self._cached_connection_string or not self._engine:
             try:
                 model_dict = self.dict(
@@ -237,7 +239,7 @@ class SnowflakeDatasource(SQLDatasource):
                 if isinstance(connection_string, str):
                     url = sa.engine.url.make_url(connection_string)
                     url = url.update_query_dict(
-                        query_parameters={"application": snowflake_partner_application}
+                        query_parameters={"application": self._get_snowflake_partner_application()}
                     )
                     self._engine = sa.create_engine(
                         url,
@@ -245,7 +247,7 @@ class SnowflakeDatasource(SQLDatasource):
                     )
                 else:
                     self._engine = self._build_engine_with_connect_args(
-                        application=snowflake_partner_application,
+                        application=self._get_snowflake_partner_application(),
                         **connection_string,
                         **kwargs,
                     )

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -5,7 +5,6 @@ import datetime
 import hashlib
 import logging
 import math
-import os
 import random
 import re
 import string
@@ -317,7 +316,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         self._connection_string = connection_string
         self._url = url
         self._create_temp_table = create_temp_table
-        os.environ["SF_PARTNER"] = "great_expectations_oss"  # noqa: TID251
 
         # sqlite/mssql temp tables only persist within a connection, so we need to keep the connection alive by
         # keeping a reference to it.

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -118,7 +118,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "expected string or bytes-like object",
+                    "msg": "expected string or bytes-like object,- got 'dict'",
                     "type": "type_error",
                 },
                 {
@@ -145,7 +145,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "expected string or bytes-like object",
+                    "msg": "expected string or bytes-like object,- got 'dict'",
                     "type": "type_error",
                 },
                 {

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -118,7 +118,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "expected string or bytes-like object,- got 'dict'",
+                    "msg": "expected string or bytes-like object, got 'dict'",
                     "type": "type_error",
                 },
                 {
@@ -145,7 +145,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "expected string or bytes-like object,- got 'dict'",
+                    "msg": "expected string or bytes-like object, got 'dict'",
                     "type": "type_error",
                 },
                 {

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -169,7 +169,7 @@ def test_conflicting_connection_string_and_args_raises_error(
     connect_args: dict,
     expected_errors: list[dict],
 ):
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(pydantic.ValidationError) as exc_info:
         _ = SnowflakeDatasource(
             name="my_sf_ds", connection_string=connection_string, **connect_args
         )

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -214,7 +214,6 @@ def test_get_execution_engine_succeeds():
     datasource.get_execution_engine()
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize(
     "connection_string",
     [

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -100,7 +100,9 @@ def test_conflicting_connection_string_and_args_raises_error(
     connection_string: ConfigStr | SnowflakeDsn | None | dict, connect_args: dict
 ):
     with pytest.raises(ValueError):
-        _ = SnowflakeDatasource(connection_string=connection_string, **connect_args)
+        _ = SnowflakeDatasource(
+            name="my_sf_ds", connection_string=connection_string, **connect_args
+        )
 
 
 @pytest.mark.unit

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -79,7 +79,7 @@ def test_valid_config(
     "connection_string, connect_args",
     [
         pytest.param(
-            "snowflake://<user_login_name>:<password>@<account_identifier>",
+            "snowflake://my_user:password@my_account?numpy=True",
             {"account": "my_account", "user": "my_user", "password": "123456"},
             id="both connection_string and connect_args",
         ),

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from sys import version_info as python_version
+
 import pytest
 import sqlalchemy as sa
 from pytest import param
@@ -118,7 +120,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "expected string or bytes-like object, got 'dict'",
+                    "msg": f"""expected string or bytes-like object{'' if python_version < (3, 11) else ', got "dict"'}""",
                     "type": "type_error",
                 },
                 {
@@ -145,7 +147,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "expected string or bytes-like object, got 'dict'",
+                    "msg": f"""expected string or bytes-like object{'' if python_version < (3, 11) else ', got "dict"'}""",
                     "type": "type_error",
                 },
                 {

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -120,7 +120,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": f"""expected string or bytes-like object{'' if python_version < (3, 11) else ', got "dict"'}""",
+                    "msg": f"""expected string or bytes-like object{"" if python_version < (3, 11) else ", got 'dict'"}""",
                     "type": "type_error",
                 },
                 {
@@ -147,7 +147,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": f"""expected string or bytes-like object{'' if python_version < (3, 11) else ', got "dict"'}""",
+                    "msg": f"""expected string or bytes-like object{"" if python_version < (3, 11) else ", got 'dict'"}""",
                     "type": "type_error",
                 },
                 {

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -243,7 +243,7 @@ def test_get_execution_engine_succeeds():
         ),
         param(
             "empty_cloud_context_fluent",
-            "great_expectations_cloud",
+            "great_expectations_oss",
             id="cloud context",
             marks=pytest.mark.cloud,
         ),

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -214,6 +214,7 @@ def test_get_execution_engine_succeeds():
     datasource.get_execution_engine()
 
 
+@pytest.mark.snowflake
 @pytest.mark.parametrize(
     "connection_string",
     [
@@ -238,13 +239,11 @@ def test_get_execution_engine_succeeds():
             "empty_file_context",
             "great_expectations_oss",
             id="file context",
-            marks=pytest.mark.filesystem,
         ),
         param(
             "empty_cloud_context_fluent",
             "great_expectations_oss",
             id="cloud context",
-            marks=pytest.mark.cloud,
         ),
     ],
 )

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -310,12 +310,12 @@ def test_get_execution_engine_succeeds():
     [
         param(
             "empty_file_context",
-            "great_expectations_oss",
+            "great_expectations_core",
             id="file context",
         ),
         param(
             "empty_cloud_context_fluent",
-            "great_expectations_oss",
+            "great_expectations_platform",
             id="cloud context",
         ),
     ],

--- a/tests/integration/docusaurus/connecting_to_your_data/database/snowflake_python_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/snowflake_python_example.py
@@ -13,7 +13,7 @@ sfDatabase = os.environ.get("SNOWFLAKE_DATABASE")
 sfSchema = os.environ.get("SNOWFLAKE_SCHEMA")
 sfWarehouse = os.environ.get("SNOWFLAKE_WAREHOUSE")
 
-CONNECTION_STRING = f"snowflake://{sfUser}:{sfPswd}@{sfAccount}/{sfDatabase}/{sfSchema}?warehouse={sfWarehouse}&application=great_expectations_oss"
+CONNECTION_STRING = f"snowflake://{sfUser}:{sfPswd}@{sfAccount}/{sfDatabase}/{sfSchema}?warehouse={sfWarehouse}"
 
 context = gx.get_context()
 
@@ -23,7 +23,7 @@ datasource_config = {
     "class_name": "Datasource",
     "execution_engine": {
         "class_name": "SqlAlchemyExecutionEngine",
-        "connection_string": "snowflake://<USER_NAME>:<PASSWORD>@<ACCOUNT_NAME>/<DATABASE_NAME>/<SCHEMA_NAME>?warehouse=<WAREHOUSE_NAME>&role=<ROLE_NAME>&application=great_expectations_oss",
+        "connection_string": "snowflake://<USER_NAME>:<PASSWORD>@<ACCOUNT_NAME>/<DATABASE_NAME>/<SCHEMA_NAME>?warehouse=<WAREHOUSE_NAME>&role=<ROLE_NAME>",
     },
     "data_connectors": {
         "default_runtime_data_connector_name": {


### PR DESCRIPTION
- Set application query param for SnowflakeDatasource when creating engine. This is to ensure GX gets attribution for the Snowflake Partner program
- This was attempted previously by setting the `SF_PARTNER` env var, which would typically be picked up by the Snowflake connecter to set the application query param. However, since GX uses snowflake-sqlalchemy to connect to Snowflake, the env var gets superseded, with attribution going to snowflake-sqlalchemy. 

- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
