### PR TITLE
[MAINTENANCE] Ensure Spark can start

### DIFF
--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -270,7 +270,7 @@ class SparkDFExecutionEngine(ExecutionEngine):
         spark_session: pyspark.SparkSession
         try:
             spark_session = pyspark.SparkConnectSession.builder.getOrCreate()
-        except (ModuleNotFoundError, ValueError):
+        except (ModuleNotFoundError, ValueError, KeyError):
             spark_session = pyspark.SparkSession.builder.getOrCreate()
 
         return SparkDFExecutionEngine._get_session_with_spark_config(


### PR DESCRIPTION
Pyspark `3.4.0` raises a `KeyError` in the execution engine when calling `pyspark.SparkConnectSession.builder.getOrCreate()`:
```self = <pyspark.sql.connect.session.SparkSession.Builder object at 0x288d759c0>

    def getOrCreate(self) -> "SparkSession":
>       return SparkSession(connectionString=self._options["spark.remote"])
E       KeyError: 'spark.remote'
```

whereas `pyspark.SparkSession.builder.getOrCreate()` is successful. This PR adds the `KeyError` to the except block in order to allow spark to start up.