### PR TITLE
[MAINTENANCE] Remove public decorator from anything BatchRequest related

### DIFF
--- a/great_expectations/datasource/fluent/batch_request.py
+++ b/great_expectations/datasource/fluent/batch_request.py
@@ -12,7 +12,6 @@ from typing import (
     Union,
 )
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.pydantic import Field, StrictStr
 from great_expectations.compatibility.pydantic import json as pydantic_json
@@ -47,7 +46,6 @@ if TYPE_CHECKING:
 BatchParameters: TypeAlias = Dict[StrictStr, Any]
 
 
-@public_api
 class BatchRequest(pydantic.GenericModel, Generic[PartitionerT]):
     """A BatchRequest is the way to specify which data Great Expectations will validate.
 
@@ -101,7 +99,6 @@ class BatchRequest(pydantic.GenericModel, Generic[PartitionerT]):
         """A built-in slice that can be used to filter a list of batches by index."""
         return parse_batch_slice(batch_slice=self._batch_slice_input)
 
-    @public_api
     def update_batch_slice(self, value: Optional[BatchSlice] = None) -> None:
         """Updates the batch_slice on this BatchRequest.
 
@@ -139,7 +136,6 @@ class BatchRequest(pydantic.GenericModel, Generic[PartitionerT]):
             raise TypeError("BatchParameters keys must all be strings.")  # noqa: TRY003
         return options
 
-    @public_api
     @override
     def json(  # noqa: PLR0913
         self,
@@ -172,7 +168,6 @@ class BatchRequest(pydantic.GenericModel, Generic[PartitionerT]):
             **dumps_kwargs,
         )
 
-    @public_api
     @override
     def dict(  # noqa: PLR0913
         self,

--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -17,7 +17,6 @@ from typing import (
 )
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.partitioners import (
@@ -129,7 +128,6 @@ class _FilePathDataAsset(DataAsset[DatasourceT, RegexPartitioner], Generic[Datas
             option_keys += tuple(partitioner.param_names)
         return option_keys
 
-    @public_api
     @override
     def build_batch_request(
         self,

--- a/great_expectations/datasource/fluent/pandas_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_datasource.py
@@ -171,7 +171,6 @@ work-around, until "type" naming convention and method for obtaining 'reader_met
         )
         return batch_list
 
-    @public_api
     @override
     def build_batch_request(
         self,
@@ -384,7 +383,6 @@ class DataFrameAsset(_PandasDataAsset, Generic[_PandasDataFrameT]):
             """Pandas DataFrameAsset does not implement "_get_reader_options_include()" method, because DataFrame is already available."""  # noqa: E501
         )
 
-    @public_api
     # TODO: <Alex>05/31/2023: Upon removal of deprecated "dataframe" argument to "PandasDatasource.add_dataframe_asset()", its validation code must be deleted.</Alex>  # noqa: E501
     @new_argument(
         argument_name="dataframe",

--- a/great_expectations/datasource/fluent/spark_datasource.py
+++ b/great_expectations/datasource/fluent/spark_datasource.py
@@ -200,7 +200,6 @@ class DataFrameAsset(DataAsset, Generic[_SparkDataFrameT]):
             """Spark DataFrameAsset does not implement "_get_reader_options_include()" method, because DataFrame is already available."""  # noqa: E501
         )
 
-    @public_api
     @new_argument(
         argument_name="dataframe",
         message='The "dataframe" argument is no longer part of "PandasDatasource.add_dataframe_asset()" method call; instead, "dataframe" is the required argument to "DataFrameAsset.build_batch_request()" method.',  # noqa: E501

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -591,7 +591,6 @@ class _SQLAsset(DataAsset[DatasourceT, Partitioner], Generic[DatasourceT]):
             self.sort_batches(batch_list, sql_partitioner)
         return batch_list[batch_request.batch_slice]
 
-    @public_api
     @override
     def build_batch_request(
         self,


### PR DESCRIPTION
This still gets used internally a bunch, so just removing it from the public api.
fwiw `invoke print-public-api | grep -i request` now comes up empty. This doesn't deal with references in docs.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
