### PR TITLE
[MAINTENANCE] Rename core partitioners

### DIFF
--- a/docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py
+++ b/docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py
@@ -2,7 +2,7 @@ import pathlib
 import tempfile
 
 import great_expectations as gx
-from great_expectations.core.partitioners import PartitionerYearAndMonth
+from great_expectations.core.partitioners import ColumnPartitionerMonthly
 
 temp_dir = tempfile.TemporaryDirectory()
 full_path_to_project_directory = pathlib.Path(temp_dir.name).resolve()
@@ -39,7 +39,7 @@ my_table_asset = my_datasource.get_asset(asset_name="my_table_asset")
 
 # Python
 # <snippet name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_splitter_year_and_month">
-partitioner = PartitionerYearAndMonth(column_name="pickup_datetime")
+partitioner = ColumnPartitionerMonthly(column_name="pickup_datetime")
 # </snippet>
 
 my_batch_request = my_table_asset.build_batch_request(partitioner=partitioner)

--- a/great_expectations/core/batch_definition.py
+++ b/great_expectations/core/batch_definition.py
@@ -6,7 +6,7 @@ from great_expectations.compatibility import pydantic
 
 # if we move this import into the TYPE_CHECKING block, we need to provide the
 # Partitioner class when we update forward refs, so we just import here.
-from great_expectations.core.partitioners import Partitioner, RegexPartitioner
+from great_expectations.core.partitioners import ColumnPartitioner, RegexPartitioner
 from great_expectations.core.serdes import _EncodedValidationData, _IdentifierBundle
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent.interfaces import Batch, DataAsset
 
 # Depending on the Asset
-PartitionerT = TypeVar("PartitionerT", Partitioner, RegexPartitioner, None)
+PartitionerT = TypeVar("PartitionerT", ColumnPartitioner, RegexPartitioner, None)
 
 
 class BatchDefinition(pydantic.GenericModel, Generic[PartitionerT]):

--- a/great_expectations/core/batch_definition.py
+++ b/great_expectations/core/batch_definition.py
@@ -6,7 +6,7 @@ from great_expectations.compatibility import pydantic
 
 # if we move this import into the TYPE_CHECKING block, we need to provide the
 # Partitioner class when we update forward refs, so we just import here.
-from great_expectations.core.partitioners import ColumnPartitioner, RegexPartitioner
+from great_expectations.core.partitioners import ColumnPartitioner, FileNamePartitioner
 from great_expectations.core.serdes import _EncodedValidationData, _IdentifierBundle
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent.interfaces import Batch, DataAsset
 
 # Depending on the Asset
-PartitionerT = TypeVar("PartitionerT", ColumnPartitioner, RegexPartitioner, None)
+PartitionerT = TypeVar("PartitionerT", ColumnPartitioner, FileNamePartitioner, None)
 
 
 class BatchDefinition(pydantic.GenericModel, Generic[PartitionerT]):

--- a/great_expectations/core/partitioners.py
+++ b/great_expectations/core/partitioners.py
@@ -89,28 +89,30 @@ ColumnPartitioner = Union[
 ]
 
 
-class PartitionerYearly(pydantic.BaseModel):
+class RegexPartitionerYearly(pydantic.BaseModel):
     regex: re.Pattern
     param_names = ["year"]
     sort_ascending: bool = True
 
 
-class PartitionerMonthly(pydantic.BaseModel):
+class RegexPartitionerMonthly(pydantic.BaseModel):
     regex: re.Pattern
     param_names = ["year", "month"]
     sort_ascending: bool = True
 
 
-class PartitionerDaily(pydantic.BaseModel):
+class RegexPartitionerDaily(pydantic.BaseModel):
     regex: re.Pattern
     param_names = ["year", "month", "day"]
     sort_ascending: bool = True
 
 
-class PartitionerPath(pydantic.BaseModel):
+class RegexPartitionerPath(pydantic.BaseModel):
     regex: re.Pattern
     param_names: Final[List[str]] = []
     sort_ascending: bool = True
 
 
-RegexPartitioner = Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]
+RegexPartitioner = Union[
+    RegexPartitionerYearly, RegexPartitionerMonthly, RegexPartitionerDaily, RegexPartitionerPath
+]

--- a/great_expectations/core/partitioners.py
+++ b/great_expectations/core/partitioners.py
@@ -76,7 +76,7 @@ class PartitionerConvertedDatetime(pydantic.BaseModel):
     date_format_string: str
 
 
-Partitioner = Union[
+ColumnPartitioner = Union[
     PartitionerColumnValue,
     PartitionerMultiColumnValue,
     PartitionerDividedInteger,

--- a/great_expectations/core/partitioners.py
+++ b/great_expectations/core/partitioners.py
@@ -89,30 +89,33 @@ ColumnPartitioner = Union[
 ]
 
 
-class RegexPartitionerYearly(pydantic.BaseModel):
+class FileNamePartitionerYearly(pydantic.BaseModel):
     regex: re.Pattern
     param_names = ["year"]
     sort_ascending: bool = True
 
 
-class RegexPartitionerMonthly(pydantic.BaseModel):
+class FileNamePartitionerMonthly(pydantic.BaseModel):
     regex: re.Pattern
     param_names = ["year", "month"]
     sort_ascending: bool = True
 
 
-class RegexPartitionerDaily(pydantic.BaseModel):
+class FileNamePartitionerDaily(pydantic.BaseModel):
     regex: re.Pattern
     param_names = ["year", "month", "day"]
     sort_ascending: bool = True
 
 
-class RegexPartitionerPath(pydantic.BaseModel):
+class FileNamePartitionerPath(pydantic.BaseModel):
     regex: re.Pattern
     param_names: Final[List[str]] = []
     sort_ascending: bool = True
 
 
-RegexPartitioner = Union[
-    RegexPartitionerYearly, RegexPartitionerMonthly, RegexPartitionerDaily, RegexPartitionerPath
+FileNamePartitioner = Union[
+    FileNamePartitionerYearly,
+    FileNamePartitionerMonthly,
+    FileNamePartitionerDaily,
+    FileNamePartitionerPath,
 ]

--- a/great_expectations/core/partitioners.py
+++ b/great_expectations/core/partitioners.py
@@ -8,21 +8,21 @@ from great_expectations.compatibility import pydantic
 
 
 @public_api
-class PartitionerYear(pydantic.BaseModel):
+class ColumnPartitionerYearly(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True
     method_name: Literal["partition_on_year"] = "partition_on_year"
 
 
 @public_api
-class PartitionerYearAndMonth(pydantic.BaseModel):
+class ColumnPartitionerMonthly(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True
     method_name: Literal["partition_on_year_and_month"] = "partition_on_year_and_month"
 
 
 @public_api
-class PartitionerYearAndMonthAndDay(pydantic.BaseModel):
+class ColumnPartitionerDaily(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True
     method_name: Literal["partition_on_year_and_month_and_day"] = (
@@ -81,9 +81,9 @@ ColumnPartitioner = Union[
     PartitionerMultiColumnValue,
     PartitionerDividedInteger,
     PartitionerModInteger,
-    PartitionerYear,
-    PartitionerYearAndMonth,
-    PartitionerYearAndMonthAndDay,
+    ColumnPartitionerYearly,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerDaily,
     PartitionerDatetimePart,
     PartitionerConvertedDatetime,
 ]

--- a/great_expectations/datasource/fluent/data_asset/path/directory_asset.py
+++ b/great_expectations/datasource/fluent/data_asset/path/directory_asset.py
@@ -10,8 +10,12 @@ from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import IDDict
 from great_expectations.core.batch import LegacyBatchDefinition
-from great_expectations.core.partitioners import ColumnPartitioner, ColumnPartitionerYearly, \
-    ColumnPartitionerMonthly, ColumnPartitionerDaily
+from great_expectations.core.partitioners import (
+    ColumnPartitioner,
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
+)
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME, MATCH_ALL_PATTERN
 from great_expectations.datasource.fluent.data_asset.path.dataframe_partitioners import (
@@ -33,9 +37,7 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent import BatchParameters
 
 
-class DirectoryDataAsset(
-    PathDataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT], ABC
-):
+class DirectoryDataAsset(PathDataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT], ABC):
     """Base class for PathDataAssets which batch by combining the contents of a directory."""
 
     data_directory: pathlib.Path
@@ -109,15 +111,15 @@ class DirectoryDataAsset(
     def _get_dataframe_partitioner(self, partitioner) -> Optional[DataframePartitioner]: ...
 
     @_get_dataframe_partitioner.register
-    def _(self, partitioner: PartitionerYear) -> DataframePartitionerYearly:
+    def _(self, partitioner: ColumnPartitionerYearly) -> DataframePartitionerYearly:
         return DataframePartitionerYearly(**partitioner.dict(exclude={"param_names"}))
 
     @_get_dataframe_partitioner.register
-    def _(self, partitioner: PartitionerYearAndMonth) -> DataframePartitionerMonthly:
+    def _(self, partitioner: ColumnPartitionerMonthly) -> DataframePartitionerMonthly:
         return DataframePartitionerMonthly(**partitioner.dict(exclude={"param_names"}))
 
     @_get_dataframe_partitioner.register
-    def _(self, partitioner: PartitionerYearAndMonthAndDay) -> DataframePartitionerDaily:
+    def _(self, partitioner: ColumnPartitionerDaily) -> DataframePartitionerDaily:
         return DataframePartitionerDaily(**partitioner.dict(exclude={"param_names"}))
 
     @_get_dataframe_partitioner.register

--- a/great_expectations/datasource/fluent/data_asset/path/directory_asset.py
+++ b/great_expectations/datasource/fluent/data_asset/path/directory_asset.py
@@ -9,7 +9,7 @@ from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import IDDict
 from great_expectations.core.batch import LegacyBatchDefinition
-from great_expectations.core.partitioners import RegexPartitioner
+from great_expectations.core.partitioners import FileNamePartitioner
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME, MATCH_ALL_PATTERN
 from great_expectations.datasource.fluent.data_asset.path.path_data_asset import (
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent import BatchParameters
 
 
-class DirectoryDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[DatasourceT], ABC):
+class DirectoryDataAsset(
+    PathDataAsset[DatasourceT, FileNamePartitioner], Generic[DatasourceT], ABC
+):
     """Base class for PathDataAssets which batch by combining the contents of a directory."""
 
     data_directory: pathlib.Path
@@ -80,7 +82,7 @@ class DirectoryDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[D
     @override
     def get_batch_parameters_keys(
         self,
-        partitioner: Optional[RegexPartitioner] = None,
+        partitioner: Optional[FileNamePartitioner] = None,
     ) -> tuple[str, ...]:
         option_keys: tuple[str, ...] = (FILE_PATH_BATCH_SPEC_KEY,)
         # todo: need to get dataframe partitioner here
@@ -99,7 +101,7 @@ class DirectoryDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[D
         self,
         options: Optional[BatchParameters] = None,
         batch_slice: Optional[BatchSlice] = None,
-        partitioner: Optional[RegexPartitioner] = None,
+        partitioner: Optional[FileNamePartitioner] = None,
     ) -> BatchRequest:
         if options is not None and not self._batch_parameters_are_valid(
             options=options,

--- a/great_expectations/datasource/fluent/data_asset/path/file_asset.py
+++ b/great_expectations/datasource/fluent/data_asset/path/file_asset.py
@@ -9,11 +9,11 @@ from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.partitioners import (
-    PartitionerDaily,
-    PartitionerMonthly,
-    PartitionerPath,
-    PartitionerYearly,
     RegexPartitioner,
+    RegexPartitionerDaily,
+    RegexPartitionerMonthly,
+    RegexPartitionerPath,
+    RegexPartitionerYearly,
 )
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import MATCH_ALL_PATTERN
@@ -108,7 +108,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
             raise AmbiguousPathError(path=path)
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerPath(regex=regex),
+            partitioner=RegexPartitionerPath(regex=regex),
         )
 
     @public_api
@@ -130,7 +130,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
         self._assert_group_names_in_regex(regex=regex, required_group_names=REQUIRED_GROUP_NAME)
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerYearly(regex=regex, sort_ascending=sort_ascending),
+            partitioner=RegexPartitionerYearly(regex=regex, sort_ascending=sort_ascending),
         )
 
     @public_api
@@ -152,7 +152,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
         self._assert_group_names_in_regex(regex=regex, required_group_names=REQUIRED_GROUP_NAMES)
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerMonthly(regex=regex, sort_ascending=sort_ascending),
+            partitioner=RegexPartitionerMonthly(regex=regex, sort_ascending=sort_ascending),
         )
 
     @public_api
@@ -175,7 +175,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
         self._assert_group_names_in_regex(regex=regex, required_group_names=REQUIRED_GROUP_NAMES)
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerDaily(regex=regex, sort_ascending=sort_ascending),
+            partitioner=RegexPartitionerDaily(regex=regex, sort_ascending=sort_ascending),
         )
 
     @classmethod

--- a/great_expectations/datasource/fluent/data_asset/path/file_asset.py
+++ b/great_expectations/datasource/fluent/data_asset/path/file_asset.py
@@ -9,11 +9,11 @@ from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.partitioners import (
-    RegexPartitioner,
-    RegexPartitionerDaily,
-    RegexPartitionerMonthly,
-    RegexPartitionerPath,
-    RegexPartitionerYearly,
+    FileNamePartitioner,
+    FileNamePartitionerDaily,
+    FileNamePartitionerMonthly,
+    FileNamePartitionerPath,
+    FileNamePartitionerYearly,
 )
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import MATCH_ALL_PATTERN
@@ -66,7 +66,7 @@ class AmbiguousPathError(ValueError):
         self.path = path
 
 
-class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[DatasourceT], ABC):
+class FileDataAsset(PathDataAsset[DatasourceT, FileNamePartitioner], Generic[DatasourceT], ABC):
     """Base class for PathDataAssets which batch by applying a regex to file names."""
 
     batching_regex: Pattern = (  # must use typing.Pattern for pydantic < v1.10
@@ -108,7 +108,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
             raise AmbiguousPathError(path=path)
         return self.add_batch_definition(
             name=name,
-            partitioner=RegexPartitionerPath(regex=regex),
+            partitioner=FileNamePartitionerPath(regex=regex),
         )
 
     @public_api
@@ -130,7 +130,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
         self._assert_group_names_in_regex(regex=regex, required_group_names=REQUIRED_GROUP_NAME)
         return self.add_batch_definition(
             name=name,
-            partitioner=RegexPartitionerYearly(regex=regex, sort_ascending=sort_ascending),
+            partitioner=FileNamePartitionerYearly(regex=regex, sort_ascending=sort_ascending),
         )
 
     @public_api
@@ -152,7 +152,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
         self._assert_group_names_in_regex(regex=regex, required_group_names=REQUIRED_GROUP_NAMES)
         return self.add_batch_definition(
             name=name,
-            partitioner=RegexPartitionerMonthly(regex=regex, sort_ascending=sort_ascending),
+            partitioner=FileNamePartitionerMonthly(regex=regex, sort_ascending=sort_ascending),
         )
 
     @public_api
@@ -175,7 +175,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
         self._assert_group_names_in_regex(regex=regex, required_group_names=REQUIRED_GROUP_NAMES)
         return self.add_batch_definition(
             name=name,
-            partitioner=RegexPartitionerDaily(regex=regex, sort_ascending=sort_ascending),
+            partitioner=FileNamePartitionerDaily(regex=regex, sort_ascending=sort_ascending),
         )
 
     @classmethod
@@ -205,7 +205,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
     @override
     def get_batch_parameters_keys(
         self,
-        partitioner: Optional[RegexPartitioner] = None,
+        partitioner: Optional[FileNamePartitioner] = None,
     ) -> tuple[str, ...]:
         option_keys: tuple[str, ...] = tuple(self._group_names) + (FILE_PATH_BATCH_SPEC_KEY,)
         if partitioner:
@@ -223,7 +223,7 @@ class FileDataAsset(PathDataAsset[DatasourceT, RegexPartitioner], Generic[Dataso
         self,
         options: Optional[BatchParameters] = None,
         batch_slice: Optional[BatchSlice] = None,
-        partitioner: Optional[RegexPartitioner] = None,
+        partitioner: Optional[FileNamePartitioner] = None,
     ) -> BatchRequest:
         """A batch request that can be used to obtain batches for this DataAsset.
 

--- a/great_expectations/datasource/fluent/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_connector/file_path_data_connector.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from typing import DefaultDict
 
     from great_expectations.alias_types import PathStr
-    from great_expectations.core.partitioners import RegexPartitioner
+    from great_expectations.core.partitioners import FileNamePartitioner
     from great_expectations.datasource.fluent import BatchRequest
 
 logger = logging.getLogger(__name__)
@@ -194,7 +194,7 @@ class FilePathDataConnector(DataConnector):
         return len(self.get_unmatched_data_references())
 
     def _get_unfiltered_batch_definition_list(
-        self, batch_request: BatchRequest[RegexPartitioner]
+        self, batch_request: BatchRequest[FileNamePartitioner]
     ) -> list[LegacyBatchDefinition]:
         """Get all batch definitions for all files from a data connector
          using the supplied batch request.

--- a/great_expectations/datasource/fluent/invalid_datasource.py
+++ b/great_expectations/datasource/fluent/invalid_datasource.py
@@ -25,7 +25,7 @@ from great_expectations.datasource.fluent import (
 from great_expectations.datasource.fluent.type_lookup import TypeLookup, ValidTypes
 
 if TYPE_CHECKING:
-    from great_expectations.core.partitioners import Partitioner
+    from great_expectations.core.partitioners import ColumnPartitioner
     from great_expectations.datasource.fluent.batch_request import BatchRequest
     from great_expectations.datasource.fluent.interfaces import (
         Batch,
@@ -102,7 +102,7 @@ class InvalidAsset(DataAsset):
         self._raise_type_error()
 
     @override
-    def get_batch_parameters_keys(self, partitioner: Partitioner | None = None) -> NoReturn:
+    def get_batch_parameters_keys(self, partitioner: ColumnPartitioner | None = None) -> NoReturn:
         self._raise_type_error()
 
 

--- a/great_expectations/datasource/fluent/pandas_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_datasource.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from great_expectations.core.batch_definition import BatchDefinition
-    from great_expectations.core.partitioners import Partitioner
+    from great_expectations.core.partitioners import ColumnPartitioner
 
     MappingIntStrAny: TypeAlias = Mapping[Union[int, str], Any]
     AbstractSetIntStr: TypeAlias = AbstractSet[Union[int, str]]
@@ -117,7 +117,7 @@ work-around, until "type" naming convention and method for obtaining 'reader_met
 
     @override
     def get_batch_parameters_keys(
-        self, partitioner: Optional[Partitioner] = None
+        self, partitioner: Optional[ColumnPartitioner] = None
     ) -> Tuple[str, ...]:
         return tuple()
 
@@ -176,7 +176,7 @@ work-around, until "type" naming convention and method for obtaining 'reader_met
         self,
         options: Optional[BatchParameters] = None,
         batch_slice: Optional[BatchSlice] = None,
-        partitioner: Optional[Partitioner] = None,
+        partitioner: Optional[ColumnPartitioner] = None,
     ) -> BatchRequest:
         """A batch request that can be used to obtain batches for this DataAsset.
 
@@ -395,7 +395,7 @@ class DataFrameAsset(_PandasDataAsset, Generic[_PandasDataFrameT]):
         dataframe: Optional[pd.DataFrame] = None,
         options: Optional[BatchParameters] = None,
         batch_slice: Optional[BatchSlice] = None,
-        partitioner: Optional[Partitioner] = None,
+        partitioner: Optional[ColumnPartitioner] = None,
     ) -> BatchRequest:
         """A batch request that can be used to obtain batches for this DataAsset.
 

--- a/great_expectations/datasource/fluent/pandas_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_datasource.pyi
@@ -36,7 +36,7 @@ from great_expectations.compatibility import pydantic, sqlalchemy
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch_definition import BatchDefinition
-from great_expectations.core.partitioners import Partitioner
+from great_expectations.core.partitioners import ColumnPartitioner
 from great_expectations.datasource.data_connector.batch_filter import BatchSlice
 from great_expectations.datasource.fluent.dynamic_pandas import (
     CompressionOptions,
@@ -78,7 +78,7 @@ class _PandasDataAsset(DataAsset):
         self,
         options: Optional[BatchParameters] = ...,
         batch_slice: Optional[BatchSlice] = ...,
-        partitioner: Optional[Partitioner] = ...,
+        partitioner: Optional[ColumnPartitioner] = ...,
     ) -> BatchRequest: ...
     def add_batch_definition_whole_dataframe(self, name: str) -> BatchDefinition: ...
     @override

--- a/great_expectations/datasource/fluent/schemas/BatchRequest.json
+++ b/great_expectations/datasource/fluent/schemas/BatchRequest.json
@@ -34,13 +34,13 @@
                     "$ref": "#/definitions/PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/ColumnPartitionerYearly"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/ColumnPartitionerMonthly"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/ColumnPartitionerDaily"
                 },
                 {
                     "$ref": "#/definitions/PartitionerDatetimePart"
@@ -49,16 +49,16 @@
                     "$ref": "#/definitions/PartitionerConvertedDatetime"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearly"
+                    "$ref": "#/definitions/FileNamePartitionerYearly"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMonthly"
+                    "$ref": "#/definitions/FileNamePartitionerMonthly"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDaily"
+                    "$ref": "#/definitions/FileNamePartitionerDaily"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerPath"
+                    "$ref": "#/definitions/FileNamePartitionerPath"
                 }
             ]
         },
@@ -227,8 +227,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -254,8 +254,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -281,8 +281,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -375,8 +375,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -402,8 +402,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -430,8 +430,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -459,8 +459,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
@@ -226,8 +226,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -253,8 +253,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -280,8 +280,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -374,8 +374,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -403,13 +403,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -462,7 +462,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "table_name": {
@@ -519,7 +519,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "query": {

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "table_name": {
@@ -194,8 +194,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -221,8 +221,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -248,8 +248,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -342,8 +342,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -371,13 +371,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "query": {
@@ -189,8 +189,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -216,8 +216,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -337,8 +337,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -366,13 +366,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/Datasource.json
@@ -171,8 +171,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -198,8 +198,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -225,8 +225,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -319,8 +319,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -346,8 +346,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -374,8 +374,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -451,13 +451,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -466,16 +466,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
@@ -217,8 +217,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -244,8 +244,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -271,8 +271,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -365,8 +365,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -392,8 +392,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -420,8 +420,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -449,8 +449,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -497,13 +497,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -512,16 +512,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
@@ -189,8 +189,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -216,8 +216,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -337,8 +337,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -364,8 +364,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -392,8 +392,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -421,8 +421,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -469,13 +469,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -484,16 +484,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
@@ -229,8 +229,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -256,8 +256,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -283,8 +283,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -377,8 +377,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -404,8 +404,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -432,8 +432,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -461,8 +461,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -509,13 +509,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -524,16 +524,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
@@ -213,8 +213,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -240,8 +240,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -267,8 +267,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -361,8 +361,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -388,8 +388,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -416,8 +416,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -445,8 +445,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -493,13 +493,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -508,16 +508,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
@@ -68,8 +68,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -95,8 +95,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -123,8 +123,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -152,8 +152,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -188,16 +188,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -240,7 +240,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
@@ -208,7 +208,7 @@
         },
         "FileDataAsset": {
             "title": "FileDataAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -376,8 +376,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -431,8 +431,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -460,8 +460,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -479,8 +479,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -496,16 +496,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -267,8 +267,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -294,8 +294,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -322,8 +322,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -351,8 +351,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -370,8 +370,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -387,16 +387,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FWFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -90,8 +90,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -117,8 +117,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -145,8 +145,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -193,8 +193,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -210,16 +210,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -128,8 +128,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -212,8 +212,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -248,16 +248,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -188,8 +188,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -272,8 +272,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -291,8 +291,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -308,16 +308,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -175,8 +175,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -259,8 +259,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -278,8 +278,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -295,16 +295,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -86,8 +86,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -113,8 +113,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -141,8 +141,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -170,8 +170,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -189,8 +189,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -206,16 +206,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -100,8 +100,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -127,8 +127,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -184,8 +184,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -203,8 +203,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -220,16 +220,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -99,8 +99,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -126,8 +126,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -219,16 +219,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SASAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -96,8 +96,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -123,8 +123,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -151,8 +151,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -216,16 +216,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/StataAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -144,8 +144,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -228,8 +228,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -247,8 +247,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -264,16 +264,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -152,8 +152,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -179,8 +179,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -207,8 +207,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -255,8 +255,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -272,16 +272,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
@@ -64,8 +64,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -91,8 +91,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -119,8 +119,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -148,8 +148,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -167,8 +167,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -184,16 +184,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -236,7 +236,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
@@ -204,7 +204,7 @@
         },
         "FileDataAsset": {
             "title": "FileDataAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -376,8 +376,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -431,8 +431,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -460,8 +460,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -479,8 +479,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -496,16 +496,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -267,8 +267,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -294,8 +294,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -322,8 +322,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -351,8 +351,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -370,8 +370,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -387,16 +387,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FWFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -90,8 +90,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -117,8 +117,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -145,8 +145,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -193,8 +193,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -210,16 +210,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -128,8 +128,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -212,8 +212,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -248,16 +248,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -188,8 +188,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -272,8 +272,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -291,8 +291,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -308,16 +308,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -175,8 +175,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -259,8 +259,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -278,8 +278,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -295,16 +295,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -86,8 +86,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -113,8 +113,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -141,8 +141,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -170,8 +170,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -189,8 +189,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -206,16 +206,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -100,8 +100,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -127,8 +127,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -184,8 +184,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -203,8 +203,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -220,16 +220,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -99,8 +99,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -126,8 +126,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -219,16 +219,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SASAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -96,8 +96,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -123,8 +123,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -151,8 +151,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -216,16 +216,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/StataAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -144,8 +144,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -228,8 +228,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -247,8 +247,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -264,16 +264,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -152,8 +152,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -179,8 +179,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -207,8 +207,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -255,8 +255,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -272,16 +272,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource.json
@@ -174,8 +174,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -201,8 +201,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -228,8 +228,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -322,8 +322,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -349,8 +349,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -377,8 +377,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -406,8 +406,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -454,13 +454,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -469,16 +469,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
@@ -503,8 +503,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -530,8 +530,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -557,8 +557,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -651,8 +651,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -678,8 +678,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -706,8 +706,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -735,8 +735,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -783,13 +783,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -798,16 +798,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
@@ -194,8 +194,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -221,8 +221,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -248,8 +248,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -342,8 +342,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -369,8 +369,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -397,8 +397,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -426,8 +426,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -474,13 +474,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -489,16 +489,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
@@ -187,8 +187,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -214,8 +214,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -241,8 +241,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -335,8 +335,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -362,8 +362,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -390,8 +390,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -419,8 +419,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -467,13 +467,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -482,16 +482,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
@@ -394,8 +394,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -421,8 +421,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -448,8 +448,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -542,8 +542,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -569,8 +569,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -597,8 +597,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -626,8 +626,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -674,13 +674,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -689,16 +689,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -270,8 +270,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -297,8 +297,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -391,8 +391,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -418,8 +418,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -446,8 +446,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -475,8 +475,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -523,13 +523,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -538,16 +538,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
@@ -217,8 +217,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -244,8 +244,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -271,8 +271,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -365,8 +365,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -392,8 +392,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -420,8 +420,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -449,8 +449,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -497,13 +497,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -512,16 +512,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
@@ -241,8 +241,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -268,8 +268,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -295,8 +295,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -389,8 +389,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -416,8 +416,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -444,8 +444,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -473,8 +473,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -521,13 +521,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -536,16 +536,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
@@ -255,8 +255,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -282,8 +282,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -309,8 +309,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -403,8 +403,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -430,8 +430,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -458,8 +458,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -487,8 +487,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -535,13 +535,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -550,16 +550,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
@@ -315,8 +315,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -342,8 +342,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -369,8 +369,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -463,8 +463,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -490,8 +490,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -518,8 +518,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -547,8 +547,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -595,13 +595,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -610,16 +610,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
@@ -302,8 +302,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -329,8 +329,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -356,8 +356,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -450,8 +450,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -477,8 +477,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -505,8 +505,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -534,8 +534,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -582,13 +582,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -597,16 +597,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
@@ -213,8 +213,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -240,8 +240,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -267,8 +267,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -361,8 +361,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -388,8 +388,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -416,8 +416,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -445,8 +445,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -493,13 +493,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -508,16 +508,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
@@ -227,8 +227,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -254,8 +254,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -281,8 +281,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -375,8 +375,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -402,8 +402,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -430,8 +430,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -459,8 +459,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -507,13 +507,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -522,16 +522,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
@@ -226,8 +226,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -253,8 +253,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -280,8 +280,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -374,8 +374,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -401,8 +401,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -429,8 +429,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -458,8 +458,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -506,13 +506,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -521,16 +521,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -270,8 +270,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -297,8 +297,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -391,8 +391,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -418,8 +418,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -446,8 +446,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -475,8 +475,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -523,13 +523,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -538,16 +538,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
@@ -223,8 +223,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -250,8 +250,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -277,8 +277,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -371,8 +371,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -398,8 +398,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -426,8 +426,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -455,8 +455,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -503,13 +503,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -518,16 +518,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
@@ -264,8 +264,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -291,8 +291,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -318,8 +318,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -412,8 +412,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -439,8 +439,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -467,8 +467,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -496,8 +496,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -544,13 +544,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -559,16 +559,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
@@ -256,8 +256,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -283,8 +283,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -310,8 +310,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -404,8 +404,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -431,8 +431,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -459,8 +459,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -488,8 +488,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -536,13 +536,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -551,16 +551,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
@@ -239,8 +239,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -266,8 +266,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -293,8 +293,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -387,8 +387,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -414,8 +414,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -442,8 +442,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -471,8 +471,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -519,13 +519,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -534,16 +534,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
@@ -271,8 +271,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -298,8 +298,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -325,8 +325,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -419,8 +419,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -446,8 +446,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -474,8 +474,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -503,8 +503,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -551,13 +551,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -566,16 +566,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
@@ -499,8 +499,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -526,8 +526,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -553,8 +553,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -647,8 +647,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -674,8 +674,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -702,8 +702,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -731,8 +731,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -779,13 +779,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -794,16 +794,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
@@ -279,8 +279,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -306,8 +306,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -333,8 +333,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -427,8 +427,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -454,8 +454,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -482,8 +482,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -511,8 +511,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -559,13 +559,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -574,16 +574,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -64,8 +64,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -91,8 +91,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -119,8 +119,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -148,8 +148,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -167,8 +167,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -184,16 +184,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -236,7 +236,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -204,7 +204,7 @@
         },
         "FileDataAsset": {
             "title": "FileDataAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -376,8 +376,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -431,8 +431,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -460,8 +460,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -479,8 +479,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -496,16 +496,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -267,8 +267,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -294,8 +294,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -322,8 +322,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -351,8 +351,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -370,8 +370,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -387,16 +387,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FWFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -90,8 +90,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -117,8 +117,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -145,8 +145,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -193,8 +193,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -210,16 +210,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -128,8 +128,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -212,8 +212,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -248,16 +248,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -188,8 +188,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -272,8 +272,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -291,8 +291,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -308,16 +308,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -175,8 +175,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -259,8 +259,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -278,8 +278,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -295,16 +295,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -86,8 +86,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -113,8 +113,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -141,8 +141,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -170,8 +170,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -189,8 +189,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -206,16 +206,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -100,8 +100,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -127,8 +127,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -184,8 +184,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -203,8 +203,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -220,16 +220,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -99,8 +99,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -126,8 +126,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -219,16 +219,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SASAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -96,8 +96,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -123,8 +123,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -151,8 +151,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -216,16 +216,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/StataAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -144,8 +144,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -228,8 +228,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -247,8 +247,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -264,16 +264,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -152,8 +152,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -179,8 +179,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -207,8 +207,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -255,8 +255,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -272,16 +272,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
@@ -73,8 +73,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -100,8 +100,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -128,8 +128,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -157,8 +157,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -176,8 +176,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -193,16 +193,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -245,7 +245,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
@@ -213,7 +213,7 @@
         },
         "FileDataAsset": {
             "title": "FileDataAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -376,8 +376,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -431,8 +431,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -460,8 +460,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -479,8 +479,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -496,16 +496,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -267,8 +267,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -294,8 +294,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -322,8 +322,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -351,8 +351,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -370,8 +370,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -387,16 +387,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FWFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -90,8 +90,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -117,8 +117,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -145,8 +145,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -193,8 +193,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -210,16 +210,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -128,8 +128,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -212,8 +212,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -248,16 +248,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -188,8 +188,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -272,8 +272,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -291,8 +291,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -308,16 +308,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -175,8 +175,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -259,8 +259,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -278,8 +278,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -295,16 +295,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -86,8 +86,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -113,8 +113,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -141,8 +141,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -170,8 +170,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -189,8 +189,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -206,16 +206,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -100,8 +100,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -127,8 +127,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -184,8 +184,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -203,8 +203,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -220,16 +220,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -99,8 +99,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -126,8 +126,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -219,16 +219,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SASAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -96,8 +96,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -123,8 +123,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -151,8 +151,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -216,16 +216,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/StataAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -144,8 +144,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -228,8 +228,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -247,8 +247,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -264,16 +264,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -152,8 +152,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -179,8 +179,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -207,8 +207,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -255,8 +255,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -272,16 +272,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
@@ -73,8 +73,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -100,8 +100,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -128,8 +128,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -157,8 +157,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -176,8 +176,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -193,16 +193,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -245,7 +245,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
@@ -213,7 +213,7 @@
         },
         "FileDataAsset": {
             "title": "FileDataAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -376,8 +376,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -431,8 +431,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -460,8 +460,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -479,8 +479,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -496,16 +496,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -267,8 +267,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -294,8 +294,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -322,8 +322,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -351,8 +351,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -370,8 +370,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -387,16 +387,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FWFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -90,8 +90,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -117,8 +117,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -145,8 +145,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -193,8 +193,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -210,16 +210,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -128,8 +128,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -212,8 +212,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -248,16 +248,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -188,8 +188,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -272,8 +272,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -291,8 +291,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -308,16 +308,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -175,8 +175,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -259,8 +259,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -278,8 +278,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -295,16 +295,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -86,8 +86,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -113,8 +113,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -141,8 +141,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -170,8 +170,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -189,8 +189,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -206,16 +206,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -100,8 +100,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -127,8 +127,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -155,8 +155,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -184,8 +184,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -203,8 +203,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -220,16 +220,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -99,8 +99,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -126,8 +126,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -183,8 +183,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -219,16 +219,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SASAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -116,8 +116,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -200,8 +200,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -236,16 +236,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -96,8 +96,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -123,8 +123,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -151,8 +151,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -216,16 +216,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/StataAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -144,8 +144,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -171,8 +171,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -199,8 +199,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -228,8 +228,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -247,8 +247,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -264,16 +264,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -152,8 +152,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -179,8 +179,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -207,8 +207,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -255,8 +255,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -272,16 +272,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
@@ -226,8 +226,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -253,8 +253,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -280,8 +280,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -374,8 +374,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -403,13 +403,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -462,7 +462,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "table_name": {
@@ -519,7 +519,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "query": {

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "query": {
@@ -189,8 +189,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -216,8 +216,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -337,8 +337,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -366,13 +366,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "table_name": {
@@ -194,8 +194,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -221,8 +221,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -248,8 +248,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -342,8 +342,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -371,13 +371,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource.json
@@ -223,8 +223,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -250,8 +250,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -277,8 +277,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -371,8 +371,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -400,13 +400,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -459,7 +459,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "table_name": {
@@ -516,7 +516,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "query": {

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "query": {
@@ -189,8 +189,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -216,8 +216,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -337,8 +337,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -366,13 +366,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "table_name": {
@@ -194,8 +194,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -221,8 +221,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -248,8 +248,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -342,8 +342,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -371,13 +371,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -229,8 +229,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -256,8 +256,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -283,8 +283,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -377,8 +377,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -406,13 +406,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -465,7 +465,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "table_name": {
@@ -522,7 +522,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "query": {

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "query": {
@@ -189,8 +189,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -216,8 +216,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -337,8 +337,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -366,13 +366,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "table_name": {
@@ -194,8 +194,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -221,8 +221,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -248,8 +248,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -342,8 +342,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -371,13 +371,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
@@ -135,8 +135,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -162,8 +162,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -190,8 +190,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -238,8 +238,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -255,16 +255,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -275,7 +275,7 @@
         },
         "CSVAsset": {
             "title": "CSVAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -311,7 +311,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -701,8 +701,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -728,8 +728,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -755,8 +755,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -849,8 +849,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -878,13 +878,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -901,7 +901,7 @@
         },
         "DirectoryCSVAsset": {
             "title": "DirectoryCSVAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -937,7 +937,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1214,7 +1214,7 @@
         },
         "ParquetAsset": {
             "title": "ParquetAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1250,7 +1250,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1345,7 +1345,7 @@
         },
         "DirectoryParquetAsset": {
             "title": "DirectoryParquetAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1381,7 +1381,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1482,7 +1482,7 @@
         },
         "ORCAsset": {
             "title": "ORCAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1518,7 +1518,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1596,7 +1596,7 @@
         },
         "DirectoryORCAsset": {
             "title": "DirectoryORCAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1632,7 +1632,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1716,7 +1716,7 @@
         },
         "JSONAsset": {
             "title": "JSONAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1752,7 +1752,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1994,7 +1994,7 @@
         },
         "DirectoryJSONAsset": {
             "title": "DirectoryJSONAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2030,7 +2030,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2278,7 +2278,7 @@
         },
         "TextAsset": {
             "title": "TextAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2314,7 +2314,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2389,7 +2389,7 @@
         },
         "DirectoryTextAsset": {
             "title": "DirectoryTextAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2425,7 +2425,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2506,7 +2506,7 @@
         },
         "DeltaAsset": {
             "title": "DeltaAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2542,7 +2542,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2572,7 +2572,7 @@
         },
         "DirectoryDeltaAsset": {
             "title": "DirectoryDeltaAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2608,7 +2608,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
@@ -135,8 +135,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -162,8 +162,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -190,8 +190,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -219,8 +219,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -238,8 +238,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -255,16 +255,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -311,7 +311,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -618,7 +618,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -931,7 +931,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1062,7 +1062,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1199,7 +1199,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1313,7 +1313,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1433,7 +1433,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1711,7 +1711,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1995,7 +1995,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2106,7 +2106,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2223,7 +2223,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2289,7 +2289,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -323,8 +323,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -350,8 +350,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -407,8 +407,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -426,8 +426,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -443,16 +443,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "CSVAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DeltaAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -82,8 +82,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -109,8 +109,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -137,8 +137,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -166,8 +166,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -202,16 +202,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -329,8 +329,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -356,8 +356,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -413,8 +413,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -432,8 +432,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -449,16 +449,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryCSVAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -450,8 +450,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -477,8 +477,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -504,8 +504,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -598,8 +598,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -627,13 +627,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -88,8 +88,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -115,8 +115,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -172,8 +172,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -208,16 +208,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryDeltaAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -209,8 +209,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -236,8 +236,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -263,8 +263,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -357,8 +357,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -386,13 +386,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -300,8 +300,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -327,8 +327,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -355,8 +355,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -420,16 +420,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryJSONAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -421,8 +421,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -448,8 +448,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -475,8 +475,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -569,8 +569,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -598,13 +598,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -136,8 +136,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -163,8 +163,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -220,8 +220,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -239,8 +239,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -256,16 +256,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryORCAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -257,8 +257,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -284,8 +284,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -311,8 +311,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -405,8 +405,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -434,13 +434,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -153,8 +153,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -208,8 +208,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -237,8 +237,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -256,8 +256,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -273,16 +273,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryParquetAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -274,8 +274,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -301,8 +301,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -328,8 +328,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -422,8 +422,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -451,13 +451,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryTextAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -254,8 +254,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -281,8 +281,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -308,8 +308,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -402,8 +402,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -431,13 +431,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -133,8 +133,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -160,8 +160,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -188,8 +188,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -217,8 +217,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -253,16 +253,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -294,8 +294,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -321,8 +321,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -349,8 +349,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -397,8 +397,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -414,16 +414,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "JSONAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -130,8 +130,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -157,8 +157,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -214,8 +214,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -233,8 +233,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -250,16 +250,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ORCAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -147,8 +147,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -250,8 +250,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -267,16 +267,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ParquetAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "TextAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -127,8 +127,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -182,8 +182,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -211,8 +211,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -247,16 +247,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
@@ -131,8 +131,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -158,8 +158,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -186,8 +186,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -234,8 +234,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -251,16 +251,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -271,7 +271,7 @@
         },
         "CSVAsset": {
             "title": "CSVAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -307,7 +307,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -697,8 +697,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -724,8 +724,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -751,8 +751,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -845,8 +845,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -874,13 +874,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -897,7 +897,7 @@
         },
         "DirectoryCSVAsset": {
             "title": "DirectoryCSVAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -933,7 +933,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1210,7 +1210,7 @@
         },
         "ParquetAsset": {
             "title": "ParquetAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1246,7 +1246,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1341,7 +1341,7 @@
         },
         "DirectoryParquetAsset": {
             "title": "DirectoryParquetAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1377,7 +1377,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1478,7 +1478,7 @@
         },
         "ORCAsset": {
             "title": "ORCAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1514,7 +1514,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1592,7 +1592,7 @@
         },
         "DirectoryORCAsset": {
             "title": "DirectoryORCAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1628,7 +1628,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1712,7 +1712,7 @@
         },
         "JSONAsset": {
             "title": "JSONAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1748,7 +1748,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1990,7 +1990,7 @@
         },
         "DirectoryJSONAsset": {
             "title": "DirectoryJSONAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2026,7 +2026,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2274,7 +2274,7 @@
         },
         "TextAsset": {
             "title": "TextAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2310,7 +2310,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2385,7 +2385,7 @@
         },
         "DirectoryTextAsset": {
             "title": "DirectoryTextAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2421,7 +2421,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2502,7 +2502,7 @@
         },
         "DeltaAsset": {
             "title": "DeltaAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2538,7 +2538,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2568,7 +2568,7 @@
         },
         "DirectoryDeltaAsset": {
             "title": "DirectoryDeltaAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2604,7 +2604,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
@@ -131,8 +131,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -158,8 +158,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -186,8 +186,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -234,8 +234,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -251,16 +251,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -307,7 +307,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -614,7 +614,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -927,7 +927,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1058,7 +1058,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1195,7 +1195,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1309,7 +1309,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1429,7 +1429,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1707,7 +1707,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1991,7 +1991,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2102,7 +2102,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2219,7 +2219,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2285,7 +2285,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -323,8 +323,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -350,8 +350,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -407,8 +407,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -426,8 +426,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -443,16 +443,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "CSVAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DeltaAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -82,8 +82,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -109,8 +109,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -137,8 +137,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -166,8 +166,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -202,16 +202,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -329,8 +329,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -356,8 +356,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -413,8 +413,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -432,8 +432,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -449,16 +449,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryCSVAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -450,8 +450,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -477,8 +477,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -504,8 +504,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -598,8 +598,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -627,13 +627,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -88,8 +88,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -115,8 +115,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -172,8 +172,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -208,16 +208,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryDeltaAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -209,8 +209,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -236,8 +236,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -263,8 +263,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -357,8 +357,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -386,13 +386,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -300,8 +300,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -327,8 +327,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -355,8 +355,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -420,16 +420,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryJSONAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -421,8 +421,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -448,8 +448,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -475,8 +475,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -569,8 +569,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -598,13 +598,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -136,8 +136,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -163,8 +163,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -220,8 +220,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -239,8 +239,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -256,16 +256,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryORCAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -257,8 +257,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -284,8 +284,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -311,8 +311,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -405,8 +405,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -434,13 +434,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -153,8 +153,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -208,8 +208,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -237,8 +237,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -256,8 +256,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -273,16 +273,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryParquetAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -274,8 +274,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -301,8 +301,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -328,8 +328,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -422,8 +422,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -451,13 +451,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryTextAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -254,8 +254,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -281,8 +281,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -308,8 +308,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -402,8 +402,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -431,13 +431,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -133,8 +133,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -160,8 +160,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -188,8 +188,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -217,8 +217,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -253,16 +253,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -294,8 +294,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -321,8 +321,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -349,8 +349,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -397,8 +397,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -414,16 +414,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "JSONAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -130,8 +130,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -157,8 +157,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -214,8 +214,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -233,8 +233,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -250,16 +250,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ORCAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -147,8 +147,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -250,8 +250,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -267,16 +267,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ParquetAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "TextAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -127,8 +127,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -182,8 +182,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -211,8 +211,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -247,16 +247,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource.json
@@ -204,8 +204,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -231,8 +231,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -258,8 +258,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -352,8 +352,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -379,8 +379,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -407,8 +407,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -436,8 +436,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -484,13 +484,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -499,16 +499,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
@@ -187,8 +187,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -214,8 +214,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -241,8 +241,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -335,8 +335,8 @@
                 "date_format_string"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -362,8 +362,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -390,8 +390,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -419,8 +419,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -467,13 +467,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -482,16 +482,16 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
@@ -131,8 +131,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -158,8 +158,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -186,8 +186,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -234,8 +234,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -251,16 +251,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -271,7 +271,7 @@
         },
         "CSVAsset": {
             "title": "CSVAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -307,7 +307,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -697,8 +697,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -724,8 +724,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -751,8 +751,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -845,8 +845,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -874,13 +874,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -897,7 +897,7 @@
         },
         "DirectoryCSVAsset": {
             "title": "DirectoryCSVAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -933,7 +933,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1210,7 +1210,7 @@
         },
         "ParquetAsset": {
             "title": "ParquetAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1246,7 +1246,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1341,7 +1341,7 @@
         },
         "DirectoryParquetAsset": {
             "title": "DirectoryParquetAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1377,7 +1377,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1478,7 +1478,7 @@
         },
         "ORCAsset": {
             "title": "ORCAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1514,7 +1514,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1592,7 +1592,7 @@
         },
         "DirectoryORCAsset": {
             "title": "DirectoryORCAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1628,7 +1628,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1712,7 +1712,7 @@
         },
         "JSONAsset": {
             "title": "JSONAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1748,7 +1748,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1990,7 +1990,7 @@
         },
         "DirectoryJSONAsset": {
             "title": "DirectoryJSONAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2026,7 +2026,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2274,7 +2274,7 @@
         },
         "TextAsset": {
             "title": "TextAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2310,7 +2310,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2385,7 +2385,7 @@
         },
         "DirectoryTextAsset": {
             "title": "DirectoryTextAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2421,7 +2421,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2502,7 +2502,7 @@
         },
         "DeltaAsset": {
             "title": "DeltaAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2538,7 +2538,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2568,7 +2568,7 @@
         },
         "DirectoryDeltaAsset": {
             "title": "DirectoryDeltaAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2604,7 +2604,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
@@ -131,8 +131,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -158,8 +158,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -186,8 +186,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -215,8 +215,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -234,8 +234,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -251,16 +251,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -307,7 +307,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -614,7 +614,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -927,7 +927,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1058,7 +1058,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1195,7 +1195,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1309,7 +1309,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1429,7 +1429,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1707,7 +1707,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1991,7 +1991,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2102,7 +2102,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2219,7 +2219,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2285,7 +2285,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -323,8 +323,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -350,8 +350,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -407,8 +407,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -426,8 +426,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -443,16 +443,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "CSVAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DeltaAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -82,8 +82,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -109,8 +109,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -137,8 +137,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -166,8 +166,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -202,16 +202,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -329,8 +329,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -356,8 +356,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -413,8 +413,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -432,8 +432,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -449,16 +449,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryCSVAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -450,8 +450,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -477,8 +477,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -504,8 +504,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -598,8 +598,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -627,13 +627,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -88,8 +88,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -115,8 +115,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -172,8 +172,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -208,16 +208,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryDeltaAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -209,8 +209,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -236,8 +236,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -263,8 +263,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -357,8 +357,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -386,13 +386,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -300,8 +300,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -327,8 +327,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -355,8 +355,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -420,16 +420,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryJSONAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -421,8 +421,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -448,8 +448,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -475,8 +475,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -569,8 +569,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -598,13 +598,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -136,8 +136,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -163,8 +163,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -220,8 +220,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -239,8 +239,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -256,16 +256,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryORCAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -257,8 +257,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -284,8 +284,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -311,8 +311,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -405,8 +405,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -434,13 +434,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -153,8 +153,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -208,8 +208,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -237,8 +237,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -256,8 +256,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -273,16 +273,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryParquetAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -274,8 +274,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -301,8 +301,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -328,8 +328,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -422,8 +422,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -451,13 +451,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryTextAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -254,8 +254,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -281,8 +281,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -308,8 +308,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -402,8 +402,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -431,13 +431,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -133,8 +133,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -160,8 +160,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -188,8 +188,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -217,8 +217,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -253,16 +253,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -294,8 +294,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -321,8 +321,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -349,8 +349,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -397,8 +397,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -414,16 +414,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "JSONAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -130,8 +130,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -157,8 +157,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -214,8 +214,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -233,8 +233,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -250,16 +250,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ORCAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -147,8 +147,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -250,8 +250,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -267,16 +267,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ParquetAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "TextAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -127,8 +127,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -182,8 +182,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -211,8 +211,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -247,16 +247,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
@@ -140,8 +140,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -167,8 +167,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -195,8 +195,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -224,8 +224,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -260,16 +260,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -280,7 +280,7 @@
         },
         "CSVAsset": {
             "title": "CSVAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -316,7 +316,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -706,8 +706,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -733,8 +733,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -760,8 +760,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -854,8 +854,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -883,13 +883,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -906,7 +906,7 @@
         },
         "DirectoryCSVAsset": {
             "title": "DirectoryCSVAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -942,7 +942,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1219,7 +1219,7 @@
         },
         "ParquetAsset": {
             "title": "ParquetAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1255,7 +1255,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1350,7 +1350,7 @@
         },
         "DirectoryParquetAsset": {
             "title": "DirectoryParquetAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1386,7 +1386,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1487,7 +1487,7 @@
         },
         "ORCAsset": {
             "title": "ORCAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1523,7 +1523,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1601,7 +1601,7 @@
         },
         "DirectoryORCAsset": {
             "title": "DirectoryORCAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1637,7 +1637,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1721,7 +1721,7 @@
         },
         "JSONAsset": {
             "title": "JSONAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1757,7 +1757,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1999,7 +1999,7 @@
         },
         "DirectoryJSONAsset": {
             "title": "DirectoryJSONAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2035,7 +2035,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2283,7 +2283,7 @@
         },
         "TextAsset": {
             "title": "TextAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2319,7 +2319,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2394,7 +2394,7 @@
         },
         "DirectoryTextAsset": {
             "title": "DirectoryTextAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2430,7 +2430,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2511,7 +2511,7 @@
         },
         "DeltaAsset": {
             "title": "DeltaAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2547,7 +2547,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2577,7 +2577,7 @@
         },
         "DirectoryDeltaAsset": {
             "title": "DirectoryDeltaAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2613,7 +2613,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
@@ -140,8 +140,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -167,8 +167,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -195,8 +195,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -224,8 +224,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -260,16 +260,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -316,7 +316,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -623,7 +623,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -936,7 +936,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1067,7 +1067,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1204,7 +1204,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1318,7 +1318,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1438,7 +1438,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1716,7 +1716,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2000,7 +2000,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2111,7 +2111,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2228,7 +2228,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2294,7 +2294,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -323,8 +323,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -350,8 +350,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -407,8 +407,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -426,8 +426,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -443,16 +443,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "CSVAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DeltaAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -82,8 +82,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -109,8 +109,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -137,8 +137,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -166,8 +166,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -202,16 +202,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -329,8 +329,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -356,8 +356,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -413,8 +413,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -432,8 +432,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -449,16 +449,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryCSVAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -450,8 +450,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -477,8 +477,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -504,8 +504,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -598,8 +598,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -627,13 +627,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -88,8 +88,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -115,8 +115,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -172,8 +172,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -208,16 +208,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryDeltaAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -209,8 +209,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -236,8 +236,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -263,8 +263,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -357,8 +357,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -386,13 +386,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -300,8 +300,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -327,8 +327,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -355,8 +355,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -420,16 +420,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryJSONAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -421,8 +421,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -448,8 +448,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -475,8 +475,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -569,8 +569,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -598,13 +598,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -136,8 +136,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -163,8 +163,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -220,8 +220,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -239,8 +239,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -256,16 +256,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryORCAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -257,8 +257,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -284,8 +284,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -311,8 +311,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -405,8 +405,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -434,13 +434,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -153,8 +153,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -208,8 +208,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -237,8 +237,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -256,8 +256,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -273,16 +273,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryParquetAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -274,8 +274,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -301,8 +301,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -328,8 +328,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -422,8 +422,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -451,13 +451,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryTextAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -254,8 +254,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -281,8 +281,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -308,8 +308,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -402,8 +402,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -431,13 +431,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -133,8 +133,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -160,8 +160,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -188,8 +188,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -217,8 +217,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -253,16 +253,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -294,8 +294,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -321,8 +321,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -349,8 +349,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -397,8 +397,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -414,16 +414,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "JSONAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -130,8 +130,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -157,8 +157,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -214,8 +214,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -233,8 +233,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -250,16 +250,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ORCAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -147,8 +147,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -250,8 +250,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -267,16 +267,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ParquetAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "TextAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -127,8 +127,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -182,8 +182,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -211,8 +211,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -247,16 +247,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
@@ -140,8 +140,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -167,8 +167,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -195,8 +195,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -224,8 +224,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -260,16 +260,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -280,7 +280,7 @@
         },
         "CSVAsset": {
             "title": "CSVAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -316,7 +316,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -706,8 +706,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -733,8 +733,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -760,8 +760,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -854,8 +854,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -883,13 +883,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -906,7 +906,7 @@
         },
         "DirectoryCSVAsset": {
             "title": "DirectoryCSVAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -942,7 +942,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1219,7 +1219,7 @@
         },
         "ParquetAsset": {
             "title": "ParquetAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1255,7 +1255,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1350,7 +1350,7 @@
         },
         "DirectoryParquetAsset": {
             "title": "DirectoryParquetAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1386,7 +1386,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1487,7 +1487,7 @@
         },
         "ORCAsset": {
             "title": "ORCAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1523,7 +1523,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1601,7 +1601,7 @@
         },
         "DirectoryORCAsset": {
             "title": "DirectoryORCAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1637,7 +1637,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -1721,7 +1721,7 @@
         },
         "JSONAsset": {
             "title": "JSONAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -1757,7 +1757,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1999,7 +1999,7 @@
         },
         "DirectoryJSONAsset": {
             "title": "DirectoryJSONAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2035,7 +2035,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2283,7 +2283,7 @@
         },
         "TextAsset": {
             "title": "TextAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2319,7 +2319,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2394,7 +2394,7 @@
         },
         "DirectoryTextAsset": {
             "title": "DirectoryTextAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2430,7 +2430,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {
@@ -2511,7 +2511,7 @@
         },
         "DeltaAsset": {
             "title": "DeltaAsset",
-            "description": "Base class for PathDataAssets which batch by file.",
+            "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2547,7 +2547,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2577,7 +2577,7 @@
         },
         "DirectoryDeltaAsset": {
             "title": "DirectoryDeltaAsset",
-            "description": "Base class for PathDataAssets which batch by directory.",
+            "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
             "type": "object",
             "properties": {
                 "name": {
@@ -2613,7 +2613,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
@@ -140,8 +140,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -167,8 +167,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -195,8 +195,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -224,8 +224,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -243,8 +243,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -260,16 +260,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }
@@ -316,7 +316,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -623,7 +623,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -936,7 +936,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1067,7 +1067,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1204,7 +1204,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1318,7 +1318,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1438,7 +1438,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -1716,7 +1716,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2000,7 +2000,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2111,7 +2111,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2228,7 +2228,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {
@@ -2294,7 +2294,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                        "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
                     }
                 },
                 "connect_options": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -323,8 +323,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -350,8 +350,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -407,8 +407,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -426,8 +426,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -443,16 +443,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "CSVAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DeltaAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -82,8 +82,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -109,8 +109,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -137,8 +137,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -166,8 +166,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -202,16 +202,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -329,8 +329,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -356,8 +356,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -413,8 +413,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -432,8 +432,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -449,16 +449,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryCSVAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -450,8 +450,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -477,8 +477,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -504,8 +504,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -598,8 +598,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -627,13 +627,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -88,8 +88,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -115,8 +115,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -143,8 +143,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -172,8 +172,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -208,16 +208,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryDeltaAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -209,8 +209,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -236,8 +236,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -263,8 +263,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -357,8 +357,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -386,13 +386,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -300,8 +300,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -327,8 +327,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -355,8 +355,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -384,8 +384,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -403,8 +403,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -420,16 +420,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryJSONAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -421,8 +421,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -448,8 +448,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -475,8 +475,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -569,8 +569,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -598,13 +598,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -136,8 +136,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -163,8 +163,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -191,8 +191,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -220,8 +220,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -239,8 +239,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -256,16 +256,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryORCAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -257,8 +257,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -284,8 +284,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -311,8 +311,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -405,8 +405,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -434,13 +434,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -153,8 +153,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -180,8 +180,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -208,8 +208,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -237,8 +237,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -256,8 +256,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -273,16 +273,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryParquetAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -274,8 +274,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -301,8 +301,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -328,8 +328,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -422,8 +422,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -451,13 +451,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "DirectoryTextAsset",
-    "description": "Base class for PathDataAssets which batch by directory.",
+    "description": "Base class for PathDataAssets which batch by combining the contents of a directory.",
     "type": "object",
     "properties": {
         "name": {
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "connect_options": {
@@ -254,8 +254,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -281,8 +281,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -308,8 +308,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -402,8 +402,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -431,13 +431,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -133,8 +133,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -160,8 +160,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -188,8 +188,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -217,8 +217,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -236,8 +236,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -253,16 +253,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -294,8 +294,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -321,8 +321,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -349,8 +349,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -378,8 +378,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -397,8 +397,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -414,16 +414,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "JSONAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -130,8 +130,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -157,8 +157,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -185,8 +185,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -214,8 +214,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -233,8 +233,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -250,16 +250,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ORCAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -147,8 +147,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -174,8 +174,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -202,8 +202,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -231,8 +231,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -250,8 +250,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -267,16 +267,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "ParquetAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
@@ -1,6 +1,6 @@
 {
     "title": "TextAsset",
-    "description": "Base class for PathDataAssets which batch by file.",
+    "description": "Base class for PathDataAssets which batch by applying a regex to file names.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__"
+                "$ref": "#/definitions/BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__"
             }
         },
         "connect_options": {
@@ -127,8 +127,8 @@
                 "key"
             ]
         },
-        "PartitionerYearly": {
-            "title": "PartitionerYearly",
+        "FileNamePartitionerYearly": {
+            "title": "FileNamePartitionerYearly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -154,8 +154,8 @@
                 "regex"
             ]
         },
-        "PartitionerMonthly": {
-            "title": "PartitionerMonthly",
+        "FileNamePartitionerMonthly": {
+            "title": "FileNamePartitionerMonthly",
             "type": "object",
             "properties": {
                 "regex": {
@@ -182,8 +182,8 @@
                 "regex"
             ]
         },
-        "PartitionerDaily": {
-            "title": "PartitionerDaily",
+        "FileNamePartitionerDaily": {
+            "title": "FileNamePartitionerDaily",
             "type": "object",
             "properties": {
                 "regex": {
@@ -211,8 +211,8 @@
                 "regex"
             ]
         },
-        "PartitionerPath": {
-            "title": "PartitionerPath",
+        "FileNamePartitionerPath": {
+            "title": "FileNamePartitionerPath",
             "type": "object",
             "properties": {
                 "regex": {
@@ -230,8 +230,8 @@
                 "regex"
             ]
         },
-        "BatchDefinition_Union_PartitionerYearly__PartitionerMonthly__PartitionerDaily__PartitionerPath__": {
-            "title": "BatchDefinition[Union[PartitionerYearly, PartitionerMonthly, PartitionerDaily, PartitionerPath]]",
+        "BatchDefinition_Union_FileNamePartitionerYearly__FileNamePartitionerMonthly__FileNamePartitionerDaily__FileNamePartitionerPath__": {
+            "title": "BatchDefinition[Union[FileNamePartitionerYearly, FileNamePartitionerMonthly, FileNamePartitionerDaily, FileNamePartitionerPath]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -247,16 +247,16 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerYearly"
+                            "$ref": "#/definitions/FileNamePartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMonthly"
+                            "$ref": "#/definitions/FileNamePartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDaily"
+                            "$ref": "#/definitions/FileNamePartitionerDaily"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerPath"
+                            "$ref": "#/definitions/FileNamePartitionerPath"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
@@ -226,8 +226,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -253,8 +253,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -280,8 +280,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -374,8 +374,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -403,13 +403,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"
@@ -462,7 +462,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "table_name": {
@@ -519,7 +519,7 @@
                     "title": "Batch Definitions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
                     }
                 },
                 "query": {

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "query": {
@@ -189,8 +189,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -216,8 +216,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -243,8 +243,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -337,8 +337,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -366,13 +366,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -36,7 +36,7 @@
             "title": "Batch Definitions",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
             }
         },
         "table_name": {
@@ -194,8 +194,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYear": {
-            "title": "PartitionerYear",
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -221,8 +221,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonth": {
-            "title": "PartitionerYearAndMonth",
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -248,8 +248,8 @@
                 "column_name"
             ]
         },
-        "PartitionerYearAndMonthAndDay": {
-            "title": "PartitionerYearAndMonthAndDay",
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
             "description": "--Public API--",
             "type": "object",
             "properties": {
@@ -342,8 +342,8 @@
                 "date_format_string"
             ]
         },
-        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__PartitionerYear__PartitionerYearAndMonth__PartitionerYearAndMonthAndDay__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
-            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, PartitionerYear, PartitionerYearAndMonth, PartitionerYearAndMonthAndDay, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
             "type": "object",
             "properties": {
@@ -371,13 +371,13 @@
                             "$ref": "#/definitions/PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
                         },
                         {
                             "$ref": "#/definitions/PartitionerDatetimePart"

--- a/great_expectations/datasource/fluent/spark_datasource.py
+++ b/great_expectations/datasource/fluent/spark_datasource.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from great_expectations.compatibility.pyspark import SparkSession
-    from great_expectations.core.partitioners import Partitioner
+    from great_expectations.core.partitioners import ColumnPartitioner
     from great_expectations.datasource.data_connector.batch_filter import BatchSlice
     from great_expectations.datasource.fluent.interfaces import BatchMetadata
     from great_expectations.execution_engine import SparkDFExecutionEngine
@@ -186,7 +186,7 @@ class DataFrameAsset(DataAsset, Generic[_SparkDataFrameT]):
 
     @override
     def get_batch_parameters_keys(
-        self, partitioner: Optional[Partitioner] = None
+        self, partitioner: Optional[ColumnPartitioner] = None
     ) -> tuple[str, ...]:
         return tuple()
 
@@ -211,7 +211,7 @@ class DataFrameAsset(DataAsset, Generic[_SparkDataFrameT]):
         dataframe: Optional[_SparkDataFrameT] = None,
         options: Optional[BatchParameters] = None,
         batch_slice: Optional[BatchSlice] = None,
-        partitioner: Optional[Partitioner] = None,
+        partitioner: Optional[ColumnPartitioner] = None,
     ) -> BatchRequest:
         """A batch request that can be used to obtain batches for this DataAsset.
 

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -36,7 +36,7 @@ from great_expectations.core.batch_spec import (
     SqlAlchemyDatasourceBatchSpec,
 )
 from great_expectations.core.partitioners import (
-    Partitioner,
+    ColumnPartitioner,
     PartitionerColumnValue,
     PartitionerConvertedDatetime,
     PartitionerDatetimePart,
@@ -423,7 +423,7 @@ SqlPartitioner = Union[
 ]
 
 
-class _SQLAsset(DataAsset[DatasourceT, Partitioner], Generic[DatasourceT]):
+class _SQLAsset(DataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT]):
     """A _SQLAsset Mixin
 
     This is used as a mixin for _SQLAsset subclasses to give them the TableAsset functionality
@@ -436,23 +436,25 @@ class _SQLAsset(DataAsset[DatasourceT, Partitioner], Generic[DatasourceT]):
     # Instance fields
     type: str = pydantic.Field("_sql_asset")
     name: str
-    _partitioner_implementation_map: Dict[Type[Partitioner], Optional[Type[SqlPartitioner]]] = (
-        pydantic.PrivateAttr(
-            default={
-                PartitionerYear: SqlPartitionerYear,
-                PartitionerYearAndMonth: SqlPartitionerYearAndMonth,
-                PartitionerYearAndMonthAndDay: SqlPartitionerYearAndMonthAndDay,
-                PartitionerColumnValue: SqlPartitionerColumnValue,
-                PartitionerDatetimePart: SqlPartitionerDatetimePart,
-                PartitionerDividedInteger: SqlPartitionerDividedInteger,
-                PartitionerModInteger: SqlPartitionerModInteger,
-                PartitionerMultiColumnValue: SqlPartitionerMultiColumnValue,
-                PartitionerConvertedDatetime: None,  # only implemented for sqlite backend
-            }
-        )
+    _partitioner_implementation_map: Dict[
+        Type[ColumnPartitioner], Optional[Type[SqlPartitioner]]
+    ] = pydantic.PrivateAttr(
+        default={
+            PartitionerYear: SqlPartitionerYear,
+            PartitionerYearAndMonth: SqlPartitionerYearAndMonth,
+            PartitionerYearAndMonthAndDay: SqlPartitionerYearAndMonthAndDay,
+            PartitionerColumnValue: SqlPartitionerColumnValue,
+            PartitionerDatetimePart: SqlPartitionerDatetimePart,
+            PartitionerDividedInteger: SqlPartitionerDividedInteger,
+            PartitionerModInteger: SqlPartitionerModInteger,
+            PartitionerMultiColumnValue: SqlPartitionerMultiColumnValue,
+            PartitionerConvertedDatetime: None,  # only implemented for sqlite backend
+        }
     )
 
-    def get_partitioner_implementation(self, abstract_partitioner: Partitioner) -> SqlPartitioner:
+    def get_partitioner_implementation(
+        self, abstract_partitioner: ColumnPartitioner
+    ) -> SqlPartitioner:
         PartitionerClass = self._partitioner_implementation_map.get(type(abstract_partitioner))
         if not PartitionerClass:
             raise ValueError(  # noqa: TRY003
@@ -464,7 +466,7 @@ class _SQLAsset(DataAsset[DatasourceT, Partitioner], Generic[DatasourceT]):
     @override
     def get_batch_parameters_keys(
         self,
-        partitioner: Optional[Partitioner] = None,
+        partitioner: Optional[ColumnPartitioner] = None,
     ) -> tuple[str, ...]:
         option_keys: Tuple[str, ...] = tuple()
         if partitioner:
@@ -596,7 +598,7 @@ class _SQLAsset(DataAsset[DatasourceT, Partitioner], Generic[DatasourceT]):
         self,
         options: Optional[BatchParameters] = None,
         batch_slice: Optional[BatchSlice] = None,
-        partitioner: Optional[Partitioner] = None,
+        partitioner: Optional[ColumnPartitioner] = None,
     ) -> BatchRequest:
         """A batch request that can be used to obtain batches for this DataAsset.
 
@@ -686,7 +688,7 @@ class _SQLAsset(DataAsset[DatasourceT, Partitioner], Generic[DatasourceT]):
                 option: None
                 for option in self.get_batch_parameters_keys(partitioner=batch_request.partitioner)
             }
-            expect_batch_request_form = BatchRequest[Partitioner](
+            expect_batch_request_form = BatchRequest[ColumnPartitioner](
                 datasource_name=self.datasource.name,
                 data_asset_name=self.name,
                 options=options,

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -37,15 +37,15 @@ from great_expectations.core.batch_spec import (
 )
 from great_expectations.core.partitioners import (
     ColumnPartitioner,
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
     PartitionerColumnValue,
     PartitionerConvertedDatetime,
     PartitionerDatetimePart,
     PartitionerDividedInteger,
     PartitionerModInteger,
     PartitionerMultiColumnValue,
-    PartitionerYear,
-    PartitionerYearAndMonth,
-    PartitionerYearAndMonthAndDay,
 )
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,
@@ -440,9 +440,9 @@ class _SQLAsset(DataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT])
         Type[ColumnPartitioner], Optional[Type[SqlPartitioner]]
     ] = pydantic.PrivateAttr(
         default={
-            PartitionerYear: SqlPartitionerYear,
-            PartitionerYearAndMonth: SqlPartitionerYearAndMonth,
-            PartitionerYearAndMonthAndDay: SqlPartitionerYearAndMonthAndDay,
+            ColumnPartitionerYearly: SqlPartitionerYear,
+            ColumnPartitionerMonthly: SqlPartitionerYearAndMonth,
+            ColumnPartitionerDaily: SqlPartitionerYearAndMonthAndDay,
             PartitionerColumnValue: SqlPartitionerColumnValue,
             PartitionerDatetimePart: SqlPartitionerDatetimePart,
             PartitionerDividedInteger: SqlPartitionerDividedInteger,
@@ -646,7 +646,7 @@ class _SQLAsset(DataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT])
     ) -> BatchDefinition:
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerYear(column_name=column, sort_ascending=sort_ascending),
+            partitioner=ColumnPartitionerYearly(column_name=column, sort_ascending=sort_ascending),
         )
 
     @public_api
@@ -655,7 +655,7 @@ class _SQLAsset(DataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT])
     ) -> BatchDefinition:
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerYearAndMonth(column_name=column, sort_ascending=sort_ascending),
+            partitioner=ColumnPartitionerMonthly(column_name=column, sort_ascending=sort_ascending),
         )
 
     @public_api
@@ -664,9 +664,7 @@ class _SQLAsset(DataAsset[DatasourceT, ColumnPartitioner], Generic[DatasourceT])
     ) -> BatchDefinition:
         return self.add_batch_definition(
             name=name,
-            partitioner=PartitionerYearAndMonthAndDay(
-                column_name=column, sort_ascending=sort_ascending
-            ),
+            partitioner=ColumnPartitionerDaily(column_name=column, sort_ascending=sort_ascending),
         )
 
     @override

--- a/tests/core/test_batch_definition.py
+++ b/tests/core/test_batch_definition.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock  # noqa: TID251
 import pytest
 
 from great_expectations.core.batch_definition import BatchDefinition
-from great_expectations.core.partitioners import PartitionerYearly
+from great_expectations.core.partitioners import RegexPartitionerYearly
 from great_expectations.core.serdes import _EncodedValidationData, _IdentifierBundle
 from great_expectations.datasource.fluent.batch_request import BatchParameters
 from great_expectations.datasource.fluent.interfaces import Batch, DataAsset
@@ -49,7 +49,7 @@ def test_build_batch_request(
     mock_data_asset: DataAsset,
 ):
     batching_regex = re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2}).csv")
-    partitioner = PartitionerYearly(regex=batching_regex)
+    partitioner = RegexPartitionerYearly(regex=batching_regex)
     batch_definition = BatchDefinition(
         name="test_batch_definition",
         partitioner=partitioner,

--- a/tests/core/test_batch_definition.py
+++ b/tests/core/test_batch_definition.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock  # noqa: TID251
 import pytest
 
 from great_expectations.core.batch_definition import BatchDefinition
-from great_expectations.core.partitioners import RegexPartitionerYearly
+from great_expectations.core.partitioners import FileNamePartitionerYearly
 from great_expectations.core.serdes import _EncodedValidationData, _IdentifierBundle
 from great_expectations.datasource.fluent.batch_request import BatchParameters
 from great_expectations.datasource.fluent.interfaces import Batch, DataAsset
@@ -49,7 +49,7 @@ def test_build_batch_request(
     mock_data_asset: DataAsset,
 ):
     batching_regex = re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2}).csv")
-    partitioner = RegexPartitionerYearly(regex=batching_regex)
+    partitioner = FileNamePartitionerYearly(regex=batching_regex)
     batch_definition = BatchDefinition(
         name="test_batch_definition",
         partitioner=partitioner,

--- a/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
@@ -7,7 +7,7 @@ import pytest
 from great_expectations.compatibility import pydantic
 from great_expectations.core import IDDict
 from great_expectations.core.batch import LegacyBatchDefinition
-from great_expectations.core.partitioners import PartitionerYearly
+from great_expectations.core.partitioners import RegexPartitionerYearly
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import MATCH_ALL_PATTERN
 from great_expectations.datasource.fluent.data_connector import (
@@ -705,7 +705,7 @@ def test_filesystem_data_connector_uses_batching_regex_from_batch_request(
             datasource_name="my_file_path_datasource",
             data_asset_name="my_filesystem_data_asset",
             options={},
-            partitioner=PartitionerYearly(regex=re.compile(batching_regex)),
+            partitioner=RegexPartitionerYearly(regex=re.compile(batching_regex)),
         )
     )
 

--- a/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
@@ -7,7 +7,7 @@ import pytest
 from great_expectations.compatibility import pydantic
 from great_expectations.core import IDDict
 from great_expectations.core.batch import LegacyBatchDefinition
-from great_expectations.core.partitioners import RegexPartitionerYearly
+from great_expectations.core.partitioners import FileNamePartitionerYearly
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import MATCH_ALL_PATTERN
 from great_expectations.datasource.fluent.data_connector import (
@@ -705,7 +705,7 @@ def test_filesystem_data_connector_uses_batching_regex_from_batch_request(
             datasource_name="my_file_path_datasource",
             data_asset_name="my_filesystem_data_asset",
             options={},
-            partitioner=RegexPartitionerYearly(regex=re.compile(batching_regex)),
+            partitioner=FileNamePartitionerYearly(regex=re.compile(batching_regex)),
         )
     )
 

--- a/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
@@ -9,7 +9,7 @@ from moto import mock_s3
 
 from great_expectations.core import IDDict
 from great_expectations.core.batch import LegacyBatchDefinition
-from great_expectations.core.partitioners import RegexPartitionerYearly
+from great_expectations.core.partitioners import FileNamePartitionerYearly
 from great_expectations.core.util import S3Url
 from great_expectations.datasource.data_connector.util import (
     sanitize_prefix,
@@ -165,7 +165,7 @@ def test_return_all_batch_definitions_unsorted():
         # noinspection PyArgumentList
         my_data_connector.get_batch_definition_list()
 
-    partitioner = RegexPartitionerYearly(regex=batching_regex)
+    partitioner = FileNamePartitionerYearly(regex=batching_regex)
 
     # with empty options
     unsorted_batch_definition_list: List[LegacyBatchDefinition] = (

--- a/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
@@ -9,7 +9,7 @@ from moto import mock_s3
 
 from great_expectations.core import IDDict
 from great_expectations.core.batch import LegacyBatchDefinition
-from great_expectations.core.partitioners import PartitionerYearly
+from great_expectations.core.partitioners import RegexPartitionerYearly
 from great_expectations.core.util import S3Url
 from great_expectations.datasource.data_connector.util import (
     sanitize_prefix,
@@ -165,7 +165,7 @@ def test_return_all_batch_definitions_unsorted():
         # noinspection PyArgumentList
         my_data_connector.get_batch_definition_list()
 
-    partitioner = PartitionerYearly(regex=batching_regex)
+    partitioner = RegexPartitionerYearly(regex=batching_regex)
 
     # with empty options
     unsorted_batch_definition_list: List[LegacyBatchDefinition] = (

--- a/tests/datasource/fluent/data_asset/test_data_asset.py
+++ b/tests/datasource/fluent/data_asset/test_data_asset.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 from great_expectations.core.batch_definition import BatchDefinition
-from great_expectations.core.partitioners import PartitionerYear
+from great_expectations.core.partitioners import ColumnPartitionerYearly
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
@@ -93,7 +93,7 @@ def test_add_batch_definition__success(empty_data_asset: DataAsset):
 @pytest.mark.unit
 def test_add_batch_definition_with_partitioner__success(empty_data_asset: DataAsset):
     name = "my batch config"
-    partitioner = PartitionerYear(column_name="test-column")
+    partitioner = ColumnPartitionerYearly(column_name="test-column")
     batch_definition = empty_data_asset.add_batch_definition(name, partitioner=partitioner)
 
     assert batch_definition.partitioner == partitioner
@@ -104,7 +104,7 @@ def test_add_batch_definition__persists(
     file_context: AbstractDataContext, empty_data_asset: DataAsset
 ):
     name = "my batch config"
-    partitioner = PartitionerYear(column_name="test-column")
+    partitioner = ColumnPartitionerYearly(column_name="test-column")
     batch_definition = empty_data_asset.add_batch_definition(name, partitioner=partitioner)
 
     loaded_datasource = file_context.get_datasource(DATASOURCE_NAME)
@@ -119,7 +119,7 @@ def test_add_batch_definition_with_partitioner__persists(
     file_context: AbstractDataContext, empty_data_asset: DataAsset
 ):
     name = "my batch config"
-    partitioner = PartitionerYear(column_name="test-column")
+    partitioner = ColumnPartitionerYearly(column_name="test-column")
     empty_data_asset.add_batch_definition(name, partitioner=partitioner)
 
     loaded_datasource = file_context.get_datasource(DATASOURCE_NAME)

--- a/tests/datasource/fluent/data_asset/test_file_path_asset.py
+++ b/tests/datasource/fluent/data_asset/test_file_path_asset.py
@@ -7,10 +7,10 @@ import pytest
 from great_expectations.alias_types import PathStr
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.partitioners import (
-    RegexPartitionerDaily,
-    RegexPartitionerMonthly,
-    RegexPartitionerPath,
-    RegexPartitionerYearly,
+    FileNamePartitionerDaily,
+    FileNamePartitionerMonthly,
+    FileNamePartitionerPath,
+    FileNamePartitionerYearly,
 )
 from great_expectations.datasource.fluent import Datasource
 from great_expectations.datasource.fluent.data_asset.path.file_asset import (
@@ -111,7 +111,9 @@ def test_get_batch_list_from_batch_request__sort_ascending(
     )
     batch_definition = asset.add_batch_definition(
         "foo",
-        partitioner=RegexPartitionerMonthly(sort_ascending=True, regex=re.compile(batching_regex)),
+        partitioner=FileNamePartitionerMonthly(
+            sort_ascending=True, regex=re.compile(batching_regex)
+        ),
     )
     batch_request = batch_definition.build_batch_request()
 
@@ -141,7 +143,9 @@ def test_get_batch_list_from_batch_request__sort_descending(
     )
     batch_definition = asset.add_batch_definition(
         "foo",
-        partitioner=RegexPartitionerMonthly(regex=re.compile(batching_regex), sort_ascending=False),
+        partitioner=FileNamePartitionerMonthly(
+            regex=re.compile(batching_regex), sort_ascending=False
+        ),
     )
     batch_request = batch_definition.build_batch_request()
 
@@ -219,7 +223,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_path_succes
     name = "batch_def_name"
     expected_regex = re.compile(str(path))
     expected_batch_definition = BatchDefinition(
-        name=name, partitioner=RegexPartitionerPath(regex=expected_regex)
+        name=name, partitioner=FileNamePartitionerPath(regex=expected_regex)
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
     file_path_data_connector.get_matched_data_references.return_value = [PATH_NAME]
@@ -312,7 +316,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_yearly_succ
     batching_regex = re.compile(r"data_(?P<year>\d{4}).csv")
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=RegexPartitionerYearly(regex=batching_regex, sort_ascending=sort),
+        partitioner=FileNamePartitionerYearly(regex=batching_regex, sort_ascending=sort),
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 
@@ -377,7 +381,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_monthly_suc
     batching_regex = re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2}).csv")
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=RegexPartitionerMonthly(regex=batching_regex, sort_ascending=sort),
+        partitioner=FileNamePartitionerMonthly(regex=batching_regex, sort_ascending=sort),
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 
@@ -442,7 +446,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_daily_succe
     batching_regex = re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2}).csv")
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=RegexPartitionerDaily(regex=batching_regex, sort_ascending=sort),
+        partitioner=FileNamePartitionerDaily(regex=batching_regex, sort_ascending=sort),
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 

--- a/tests/datasource/fluent/data_asset/test_file_path_asset.py
+++ b/tests/datasource/fluent/data_asset/test_file_path_asset.py
@@ -7,10 +7,10 @@ import pytest
 from great_expectations.alias_types import PathStr
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.partitioners import (
-    PartitionerDaily,
-    PartitionerMonthly,
-    PartitionerPath,
-    PartitionerYearly,
+    RegexPartitionerDaily,
+    RegexPartitionerMonthly,
+    RegexPartitionerPath,
+    RegexPartitionerYearly,
 )
 from great_expectations.datasource.fluent import Datasource
 from great_expectations.datasource.fluent.data_asset.path.file_asset import (
@@ -110,7 +110,8 @@ def test_get_batch_list_from_batch_request__sort_ascending(
         batching_regex=batching_regex,
     )
     batch_definition = asset.add_batch_definition(
-        "foo", partitioner=PartitionerMonthly(sort_ascending=True, regex=re.compile(batching_regex))
+        "foo",
+        partitioner=RegexPartitionerMonthly(sort_ascending=True, regex=re.compile(batching_regex)),
     )
     batch_request = batch_definition.build_batch_request()
 
@@ -140,7 +141,7 @@ def test_get_batch_list_from_batch_request__sort_descending(
     )
     batch_definition = asset.add_batch_definition(
         "foo",
-        partitioner=PartitionerMonthly(regex=re.compile(batching_regex), sort_ascending=False),
+        partitioner=RegexPartitionerMonthly(regex=re.compile(batching_regex), sort_ascending=False),
     )
     batch_request = batch_definition.build_batch_request()
 
@@ -218,7 +219,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_path_succes
     name = "batch_def_name"
     expected_regex = re.compile(str(path))
     expected_batch_definition = BatchDefinition(
-        name=name, partitioner=PartitionerPath(regex=expected_regex)
+        name=name, partitioner=RegexPartitionerPath(regex=expected_regex)
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
     file_path_data_connector.get_matched_data_references.return_value = [PATH_NAME]
@@ -311,7 +312,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_yearly_succ
     batching_regex = re.compile(r"data_(?P<year>\d{4}).csv")
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=PartitionerYearly(regex=batching_regex, sort_ascending=sort),
+        partitioner=RegexPartitionerYearly(regex=batching_regex, sort_ascending=sort),
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 
@@ -376,7 +377,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_monthly_suc
     batching_regex = re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2}).csv")
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=PartitionerMonthly(regex=batching_regex, sort_ascending=sort),
+        partitioner=RegexPartitionerMonthly(regex=batching_regex, sort_ascending=sort),
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 
@@ -441,7 +442,7 @@ def test_add_batch_definition_fluent_file_path__add_batch_definition_daily_succe
     batching_regex = re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2}).csv")
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=PartitionerDaily(regex=batching_regex, sort_ascending=sort),
+        partitioner=RegexPartitionerDaily(regex=batching_regex, sort_ascending=sort),
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 

--- a/tests/datasource/fluent/data_asset/test_path_asset.py
+++ b/tests/datasource/fluent/data_asset/test_path_asset.py
@@ -7,13 +7,13 @@ import pytest
 from great_expectations.alias_types import PathStr
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.partitioners import (
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
     FileNamePartitionerDaily,
     FileNamePartitionerMonthly,
     FileNamePartitionerPath,
     FileNamePartitionerYearly,
-    ColumnPartitionerYearly,
-ColumnPartitionerMonthly,
-ColumnPartitionerDaily,
 )
 from great_expectations.datasource.fluent import Datasource
 from great_expectations.datasource.fluent.data_asset.path.file_asset import (
@@ -581,7 +581,7 @@ def test_add_batch_definition_monthly_success(
     name = "batch_def_name"
     column = "foo"
     expected_batch_definition = BatchDefinition(
-        name=name, partitioner=PartitionerYearAndMonth(column_name=column)
+        name=name, partitioner=ColumnPartitionerMonthly(column_name=column)
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 
@@ -603,7 +603,7 @@ def test_add_batch_definition_yearly_success(
     name = "batch_def_name"
     column = "foo"
     expected_batch_definition = BatchDefinition(
-        name=name, partitioner=PartitionerYear(column_name=column)
+        name=name, partitioner=ColumnPartitionerYearly(column_name=column)
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
 

--- a/tests/datasource/fluent/data_asset/test_sql_asset.py
+++ b/tests/datasource/fluent/data_asset/test_sql_asset.py
@@ -2,9 +2,9 @@ import pytest
 
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.partitioners import (
-    PartitionerYear,
-    PartitionerYearAndMonth,
-    PartitionerYearAndMonthAndDay,
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
 )
 from great_expectations.datasource.fluent import SQLDatasource
 from great_expectations.datasource.fluent.sql_datasource import TableAsset, _SQLAsset
@@ -46,7 +46,7 @@ def test_get_batch_list_from_batch_request__sort_ascending(postgres_asset):
     years = [2021, 2022]
     batches = postgres_asset.get_batch_list_from_batch_request(
         postgres_asset.build_batch_request(
-            partitioner=PartitionerYear(column_name="year", sort_ascending=True)
+            partitioner=ColumnPartitionerYearly(column_name="year", sort_ascending=True)
         )
     )
 
@@ -60,7 +60,7 @@ def test_get_batch_list_from_batch_request__sort_descending(postgres_asset):
     years = [2021, 2022]
     batches = postgres_asset.get_batch_list_from_batch_request(
         postgres_asset.build_batch_request(
-            partitioner=PartitionerYear(column_name="year", sort_ascending=False)
+            partitioner=ColumnPartitionerYearly(column_name="year", sort_ascending=False)
         )
     )
 
@@ -106,7 +106,7 @@ def test_add_batch_definition_fluent_sql__add_batch_definition_yearly(
     column = "test_column"
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=PartitionerYear(column_name=column, sort_ascending=sort_ascending),
+        partitioner=ColumnPartitionerYearly(column_name=column, sort_ascending=sort_ascending),
         batching_regex=None,
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
@@ -131,7 +131,7 @@ def test_add_batch_definition_fluent_sql__add_batch_definition_monthly(
     column = "test_column"
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=PartitionerYearAndMonth(column_name=column, sort_ascending=sort_ascending),
+        partitioner=ColumnPartitionerMonthly(column_name=column, sort_ascending=sort_ascending),
         batching_regex=None,
     )
     datasource.add_batch_definition.return_value = expected_batch_definition
@@ -156,9 +156,7 @@ def test_add_batch_definition_fluent_sql__add_batch_definition_daily(
     column = "test_column"
     expected_batch_definition = BatchDefinition(
         name=name,
-        partitioner=PartitionerYearAndMonthAndDay(
-            column_name=column, sort_ascending=sort_ascending
-        ),
+        partitioner=ColumnPartitionerDaily(column_name=column, sort_ascending=sort_ascending),
         batching_regex=None,
     )
     datasource.add_batch_definition.return_value = expected_batch_definition

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -12,7 +12,7 @@ from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
-from great_expectations.core.partitioners import PartitionerYearAndMonth
+from great_expectations.core.partitioners import ColumnPartitionerMonthly
 from great_expectations.data_context import AbstractDataContext, EphemeralDataContext
 from great_expectations.datasource.fluent import (
     BatchRequest,
@@ -129,7 +129,7 @@ def sql_data(
     )
     batch_request = asset.build_batch_request(
         options={"year": 2019, "month": 1},
-        partitioner=PartitionerYearAndMonth(column_name="pickup_datetime"),
+        partitioner=ColumnPartitionerMonthly(column_name="pickup_datetime"),
     )
     return context, datasource, asset, batch_request
 
@@ -199,7 +199,7 @@ def multibatch_sql_data(
     )
     batch_request = asset.build_batch_request(
         options={"year": 2020},
-        partitioner=PartitionerYearAndMonth(column_name="pickup_datetime"),
+        partitioner=ColumnPartitionerMonthly(column_name="pickup_datetime"),
     )
     return context, datasource, asset, batch_request
 

--- a/tests/datasource/fluent/integration/test_integration_datasource.py
+++ b/tests/datasource/fluent/integration/test_integration_datasource.py
@@ -12,15 +12,15 @@ import great_expectations as gx
 import great_expectations.expectations as gxe
 from great_expectations.compatibility import pydantic
 from great_expectations.core.partitioners import (
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
     PartitionerColumnValue,
     PartitionerConvertedDatetime,
     PartitionerDatetimePart,
     PartitionerDividedInteger,
     PartitionerModInteger,
     PartitionerMultiColumnValue,
-    PartitionerYear,
-    PartitionerYearAndMonth,
-    PartitionerYearAndMonthAndDay,
 )
 from great_expectations.data_context import (
     AbstractDataContext,
@@ -116,7 +116,7 @@ class TestQueryAssets:
         validator = context.get_validator(
             batch_request=asset.build_batch_request(
                 options={"year": 2019},
-                partitioner=PartitionerYearAndMonth(column_name="pickup_datetime"),
+                partitioner=ColumnPartitionerMonthly(column_name="pickup_datetime"),
             )
         )
         result = validator.expect_column_distinct_values_to_equal_set(
@@ -219,7 +219,7 @@ def test_filesystem_data_asset_batching_regex(
         pytest.param(
             "yellow_tripdata_sample_2020_all_months_combined.db",
             "yellow_tripdata_sample_2020",
-            PartitionerYear,
+            ColumnPartitionerYearly,
             {"column_name": "pickup_datetime"},
             1,
             {"year": 2020},
@@ -230,7 +230,7 @@ def test_filesystem_data_asset_batching_regex(
         pytest.param(
             "yellow_tripdata_sample_2020_all_months_combined.db",
             "yellow_tripdata_sample_2020",
-            PartitionerYearAndMonth,
+            ColumnPartitionerMonthly,
             {"column_name": "pickup_datetime"},
             12,
             {"year": 2020, "month": 6},
@@ -241,7 +241,7 @@ def test_filesystem_data_asset_batching_regex(
         pytest.param(
             "yellow_tripdata.db",
             "yellow_tripdata_sample_2019_02",
-            PartitionerYearAndMonthAndDay,
+            ColumnPartitionerDaily,
             {"column_name": "pickup_datetime"},
             28,
             {"year": 2019, "month": 2, "day": 10},
@@ -435,7 +435,7 @@ def test_success_with_partitioners_from_batch_definitions(
     )
     batch_definition = asset.add_batch_definition(
         name="whatevs",
-        partitioner=PartitionerYearAndMonth(column_name="pickup_datetime"),
+        partitioner=ColumnPartitionerMonthly(column_name="pickup_datetime"),
     )
     validator = Validator(
         batch_definition=batch_definition,
@@ -470,7 +470,7 @@ def test_asset_specified_metadata(empty_data_context, add_asset_method, add_asse
         batch_metadata=asset_specified_metadata,
         **add_asset_kwarg,
     )
-    partitioner = PartitionerYearAndMonth(column_name="pickup_datetime")
+    partitioner = ColumnPartitionerMonthly(column_name="pickup_datetime")
     # Test getting all batches
     batches = asset.get_batch_list_from_batch_request(
         asset.build_batch_request(partitioner=partitioner)

--- a/tests/datasource/fluent/test_batch_request.py
+++ b/tests/datasource/fluent/test_batch_request.py
@@ -8,7 +8,7 @@ import pytest
 
 from great_expectations.core.batch_definition import PartitionerT
 from great_expectations.core.partitioners import (
-    Partitioner,
+    ColumnPartitioner,
     PartitionerColumnValue,
     PartitionerDaily,
     PartitionerMonthly,
@@ -81,7 +81,7 @@ def test_batch_request_config_serialization_round_trips(
         "partitioner": PartitionerColumnValue(column_name="my_column"),
     }
     batch_request_config.update(optional_batch_request_config)
-    batch_request = BatchRequest[Partitioner](**batch_request_config)
+    batch_request = BatchRequest[ColumnPartitioner](**batch_request_config)
     assert batch_request.datasource_name == datasource_name
     assert batch_request.data_asset_name == data_asset_name
     # options is optional and an empty dict by default

--- a/tests/datasource/fluent/test_batch_request.py
+++ b/tests/datasource/fluent/test_batch_request.py
@@ -9,10 +9,10 @@ import pytest
 from great_expectations.core.batch_definition import PartitionerT
 from great_expectations.core.partitioners import (
     ColumnPartitioner,
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
     PartitionerColumnValue,
-    PartitionerYear,
-    PartitionerYearAndMonth,
-    PartitionerYearAndMonthAndDay,
     RegexPartitionerDaily,
     RegexPartitionerMonthly,
     RegexPartitionerYearly,
@@ -131,21 +131,21 @@ def test_batch_request_config_serialization_round_trips(
 def _partitioner_test_cases():
     return [
         pytest.param(
-            PartitionerYearAndMonthAndDay(
+            ColumnPartitionerDaily(
                 column_name="foo",
                 sort_ascending=False,
             ),
             id="Sql Daily",
         ),
         pytest.param(
-            PartitionerYearAndMonth(
+            ColumnPartitionerMonthly(
                 column_name="foo",
                 sort_ascending=False,
             ),
             id="Sql Monthly",
         ),
         pytest.param(
-            PartitionerYear(
+            ColumnPartitionerYearly(
                 column_name="foo",
                 sort_ascending=False,
             ),

--- a/tests/datasource/fluent/test_batch_request.py
+++ b/tests/datasource/fluent/test_batch_request.py
@@ -12,10 +12,10 @@ from great_expectations.core.partitioners import (
     ColumnPartitionerDaily,
     ColumnPartitionerMonthly,
     ColumnPartitionerYearly,
+    FileNamePartitionerDaily,
+    FileNamePartitionerMonthly,
+    FileNamePartitionerYearly,
     PartitionerColumnValue,
-    RegexPartitionerDaily,
-    RegexPartitionerMonthly,
-    RegexPartitionerYearly,
 )
 from great_expectations.datasource.fluent import BatchRequest
 
@@ -152,21 +152,21 @@ def _partitioner_test_cases():
             id="Sql Yearly",
         ),
         pytest.param(
-            RegexPartitionerDaily(
+            FileNamePartitionerDaily(
                 regex=re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2}).csv"),
                 sort_ascending=False,
             ),
             id="Regex Daily",
         ),
         pytest.param(
-            RegexPartitionerMonthly(
+            FileNamePartitionerMonthly(
                 regex=re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2}).csv"),
                 sort_ascending=False,
             ),
             id="Regex Monthly",
         ),
         pytest.param(
-            RegexPartitionerYearly(
+            FileNamePartitionerYearly(
                 regex=re.compile(r"data_(?P<year>\d{4}).csv"),
                 sort_ascending=False,
             ),

--- a/tests/datasource/fluent/test_batch_request.py
+++ b/tests/datasource/fluent/test_batch_request.py
@@ -10,12 +10,12 @@ from great_expectations.core.batch_definition import PartitionerT
 from great_expectations.core.partitioners import (
     ColumnPartitioner,
     PartitionerColumnValue,
-    PartitionerDaily,
-    PartitionerMonthly,
     PartitionerYear,
     PartitionerYearAndMonth,
     PartitionerYearAndMonthAndDay,
-    PartitionerYearly,
+    RegexPartitionerDaily,
+    RegexPartitionerMonthly,
+    RegexPartitionerYearly,
 )
 from great_expectations.datasource.fluent import BatchRequest
 
@@ -152,21 +152,21 @@ def _partitioner_test_cases():
             id="Sql Yearly",
         ),
         pytest.param(
-            PartitionerDaily(
+            RegexPartitionerDaily(
                 regex=re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2}).csv"),
                 sort_ascending=False,
             ),
             id="Regex Daily",
         ),
         pytest.param(
-            PartitionerMonthly(
+            RegexPartitionerMonthly(
                 regex=re.compile(r"data_(?P<year>\d{4})-(?P<month>\d{2}).csv"),
                 sort_ascending=False,
             ),
             id="Regex Monthly",
         ),
         pytest.param(
-            PartitionerYearly(
+            RegexPartitionerYearly(
                 regex=re.compile(r"data_(?P<year>\d{4}).csv"),
                 sort_ascending=False,
             ),

--- a/tests/datasource/fluent/test_batch_request.py
+++ b/tests/datasource/fluent/test_batch_request.py
@@ -15,7 +15,6 @@ from great_expectations.core.partitioners import (
     FileNamePartitionerDaily,
     FileNamePartitionerMonthly,
     FileNamePartitionerYearly,
-    PartitionerColumnValue,
 )
 from great_expectations.datasource.fluent import BatchRequest
 

--- a/tests/datasource/fluent/test_config.py
+++ b/tests/datasource/fluent/test_config.py
@@ -23,7 +23,7 @@ import pytest
 import great_expectations as gx
 from great_expectations.compatibility import pydantic
 from great_expectations.core.batch_definition import BatchDefinition
-from great_expectations.core.partitioners import PartitionerYearAndMonth
+from great_expectations.core.partitioners import ColumnPartitionerMonthly
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import FileDataContext
 from great_expectations.datasource.fluent.config import (
@@ -754,7 +754,7 @@ def test_partitioners_deserialization(inject_engine_lookup_double, from_all_conf
         asset_name="with_partitioner"
     )
     partitioner = table_asset.batch_definitions[0].partitioner
-    assert isinstance(partitioner, PartitionerYearAndMonth)
+    assert isinstance(partitioner, ColumnPartitionerMonthly)
     assert partitioner.method_name == "partition_on_year_and_month"
 
 

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -14,7 +14,7 @@ import pytest
 import requests
 
 from great_expectations import get_context
-from great_expectations.core.partitioners import PartitionerYear
+from great_expectations.core.partitioners import ColumnPartitionerYearly
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import CloudDataContext, FileDataContext
 from great_expectations.datasource.fluent import (
@@ -111,7 +111,7 @@ def test_partitioners_are_persisted_on_creation(
     )
     my_asset = datasource.add_table_asset("table_partitioned_by_date_column__A")
     my_asset.test_connection()
-    partitioner = PartitionerYear(column_name="date")
+    partitioner = ColumnPartitionerYearly(column_name="date")
     my_asset.add_batch_definition(name="cloud partitioner test", partitioner=partitioner)
 
     datasource_config = cloud_api_fake_db["datasources"][str(datasource.id)]["data"]["attributes"][

--- a/tests/datasource/fluent/test_metadatasource.py
+++ b/tests/datasource/fluent/test_metadatasource.py
@@ -11,7 +11,7 @@ import pytest
 
 from great_expectations.compatibility.pydantic import DirectoryPath, validate_arguments
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core.partitioners import Partitioner
+from great_expectations.core.partitioners import ColumnPartitioner
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import AbstractDataContext, FileDataContext
 from great_expectations.data_context import get_context as get_gx_context
@@ -124,7 +124,7 @@ class DummyDataAsset(DataAsset):
         self,
         options: Optional[BatchParameters] = None,
         batch_slice: Optional[BatchSlice] = None,
-        partitioner: Optional[Partitioner] = None,
+        partitioner: Optional[ColumnPartitioner] = None,
     ) -> BatchRequest:
         return BatchRequest("datasource_name", "data_asset_name", options or {})
 

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -19,14 +19,14 @@ from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.partitioners import (
     ColumnPartitioner,
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
     PartitionerColumnValue,
     PartitionerDatetimePart,
     PartitionerDividedInteger,
     PartitionerModInteger,
     PartitionerMultiColumnValue,
-    PartitionerYear,
-    PartitionerYearAndMonth,
-    PartitionerYearAndMonthAndDay,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.data_context.file_data_context import (
@@ -125,7 +125,7 @@ def test_add_table_asset_with_partitioner(mocker, create_source: CreateSourceFix
         has_table.return_value = True
 
         asset = source.add_table_asset(name="my_asset", table_name="my_table")
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         assert len(source.assets) == 1
         assert asset == source.assets[0]
         assert_table_asset(
@@ -218,7 +218,7 @@ def test_construct_table_asset_directly_with_partitioner(create_source):
             name="my_asset",
             table_name="my_table",
         )
-        partitioner = PartitionerYearAndMonth(column_name="col")
+        partitioner = ColumnPartitionerMonthly(column_name="col")
         assert_table_asset(
             asset,
             "my_asset",
@@ -310,7 +310,7 @@ def test_datasource_gets_batch_list_partitioner_with_unspecified_batch_parameter
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         empty_batch_request = asset.build_batch_request(partitioner=partitioner)
         assert empty_batch_request.options == {}
         batches = source.get_batch_list_from_batch_request(empty_batch_request)
@@ -339,7 +339,7 @@ def test_datasource_gets_batch_list_partitioner_with_batch_parameters_set_to_non
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         assert asset.get_batch_parameters_keys(partitioner=partitioner) == (
             "year",
             "month",
@@ -377,7 +377,7 @@ def test_datasource_gets_batch_list_partitioner_with_partially_specified_batch_p
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(options={"year": year}, partitioner=partitioner)
         )
@@ -432,7 +432,7 @@ def test_datasource_gets_batch_list_with_fully_specified_batch_parameters(
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(
                 options={"month": month, "year": year}, partitioner=partitioner
@@ -458,22 +458,22 @@ def test_datasource_gets_nonexistent_asset(create_source: CreateSourceFixture):
     ],
     [
         # These bad parameters do not occur in the batch request params
-        (PartitionerYear, {"column_name": "my_col"}, ("bad", None, None)),
-        (PartitionerYear, {"column_name": "my_col"}, (None, "bad", None)),
-        (PartitionerYear, {"column_name": "my_col"}, ("bad", "bad", None)),
+        (ColumnPartitionerYearly, {"column_name": "my_col"}, ("bad", None, None)),
+        (ColumnPartitionerYearly, {"column_name": "my_col"}, (None, "bad", None)),
+        (ColumnPartitionerYearly, {"column_name": "my_col"}, ("bad", "bad", None)),
         # These bad parameters are request option parameters which depend on the partitioner.
         (
-            PartitionerYear,
+            ColumnPartitionerYearly,
             {"column_name": "my_col"},
             (None, None, {"bad": None}),
         ),
         (
-            PartitionerYearAndMonth,
+            ColumnPartitionerMonthly,
             {"column_name": "my_col"},
             (None, None, {"bad": None}),
         ),
         (
-            PartitionerYearAndMonthAndDay,
+            ColumnPartitionerDaily,
             {"column_name": "my_col"},
             (None, None, {"bad": None}),
         ),
@@ -544,7 +544,7 @@ def test_get_batch_list_from_batch_request_with_good_batch_request(
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         batch_request = BatchRequest(
             datasource_name=source.name,
             data_asset_name=asset.name,
@@ -575,7 +575,7 @@ def test_get_batch_list_from_batch_request_with_malformed_batch_request(
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         src, ast, op = batch_request_args
         batch_request = BatchRequest(
             datasource_name=src or source.name,
@@ -596,7 +596,7 @@ def test_get_bad_batch_request(create_source: CreateSourceFixture):
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         with pytest.raises(ge_exceptions.InvalidBatchRequestError):
             asset.build_batch_request(options={"invalid_key": None}, partitioner=partitioner)
 
@@ -637,7 +637,7 @@ def test_postgres_slice_batch_count(
         ) = create_and_add_table_asset_without_testing_connection(
             source=source, name="my_asset", table_name="my_table"
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         batch_request = asset.build_batch_request(
             options={"year": 2021}, batch_slice=batch_slice, partitioner=partitioner
         )
@@ -922,7 +922,7 @@ def test_adding_partitioner_persists_results(
     ).add_query_asset(
         name="my_asset", query="select * from table", order_by=["year"]
     ).add_batch_definition(
-        name="my_batch_definition", partitioner=PartitionerYear(column_name="my_col")
+        name="my_batch_definition", partitioner=ColumnPartitionerYearly(column_name="my_col")
     )
 
     final_yaml: dict = YAMLHandler().load(  # type: ignore[assignment]
@@ -956,7 +956,7 @@ def test_partitioner_year(
         asset = source.add_query_asset(
             name="my_asset", query="select * from table", order_by=["year"]
         )
-        partitioner = PartitionerYear(column_name="my_col")
+        partitioner = ColumnPartitionerYearly(column_name="my_col")
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(partitioner=partitioner)
         )
@@ -996,7 +996,7 @@ def test_partitioner_year_and_month(
         asset = source.add_query_asset(
             name="my_asset", query="select * from table", order_by=["year", "month"]
         )
-        partitioner = PartitionerYearAndMonth(column_name="my_col")
+        partitioner = ColumnPartitionerMonthly(column_name="my_col")
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(partitioner=partitioner)
         )
@@ -1046,7 +1046,7 @@ def test_partitioner_year_and_month_and_day(
             query="select * from table",
             order_by=["year", "month", "day"],
         )
-        partitioner = PartitionerYearAndMonthAndDay(column_name="my_col")
+        partitioner = ColumnPartitionerDaily(column_name="my_col")
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(partitioner=partitioner)
         )
@@ -1081,7 +1081,7 @@ def test_partitioner_year_and_month_and_day(
     ],
     [
         pytest.param(
-            PartitionerYear,
+            ColumnPartitionerYearly,
             {"column_name": "pickup_datetime"},
             [{"year": 2020}],
             1,
@@ -1091,7 +1091,7 @@ def test_partitioner_year_and_month_and_day(
             id="year",
         ),
         pytest.param(
-            PartitionerYearAndMonth,
+            ColumnPartitionerMonthly,
             {"column_name": "pickup_datetime"},
             [{"year": 2020, "month": 1}, {"year": 2020, "month": 2}],
             2,
@@ -1101,7 +1101,7 @@ def test_partitioner_year_and_month_and_day(
             id="year_and_month",
         ),
         pytest.param(
-            PartitionerYearAndMonthAndDay,
+            ColumnPartitionerDaily,
             {"column_name": "pickup_datetime"},
             [
                 {"year": 2020, "month": 2, "day": 10},
@@ -1221,7 +1221,7 @@ def test_sorting_none_in_metadata(
         # We use a query asset because then we don't have to mock out db connection tests
         # in this unit test.
         asset = source.add_query_asset(name="my_asset", query="select * from table")
-        partitioner = PartitionerYear(column_name="my_col", sort_ascending=False)
+        partitioner = ColumnPartitionerYearly(column_name="my_col", sort_ascending=False)
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(partitioner=partitioner)
         )
@@ -1271,7 +1271,7 @@ def test_add_postgres_query_asset_with_batch_metadata(
             order_by=["year"],
         )
         assert asset.batch_metadata == asset_specified_metadata
-        partitioner = PartitionerYear(column_name="col")
+        partitioner = ColumnPartitionerYearly(column_name="col")
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(partitioner=partitioner)
         )
@@ -1316,7 +1316,7 @@ def test_add_postgres_table_asset_with_batch_metadata(
             order_by=["year"],
         )
         assert asset.batch_metadata == asset_specified_metadata
-        partitioner = PartitionerYear(column_name="my_col")
+        partitioner = ColumnPartitionerYearly(column_name="my_col")
         batches = source.get_batch_list_from_batch_request(
             asset.build_batch_request(partitioner=partitioner)
         )

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -18,7 +18,7 @@ import great_expectations.exceptions as ge_exceptions
 from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.partitioners import (
-    Partitioner,
+    ColumnPartitioner,
     PartitionerColumnValue,
     PartitionerDatetimePart,
     PartitionerDividedInteger,
@@ -96,7 +96,7 @@ def assert_table_asset(
     table_name: str,
     source: PostgresDatasource,
     batch_parameters: tuple[str, ...],
-    partitioner: Optional[Partitioner] = None,
+    partitioner: Optional[ColumnPartitioner] = None,
 ):
     assert asset.name == name
     assert asset.table_name == table_name
@@ -508,7 +508,7 @@ def test_bad_batch_request_passed_into_get_batch_list_from_batch_request(
         partitioner = PartitionerClass(**add_partitioner_kwargs)
 
         src, ast, op = batch_request_args
-        batch_request = BatchRequest[Partitioner](
+        batch_request = BatchRequest[ColumnPartitioner](
             datasource_name=src or source.name,
             data_asset_name=ast or asset.name,
             options=op or {},

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -16,8 +16,8 @@ from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.pyspark import types as pyspark_types
 from great_expectations.core.partitioners import (
     PartitionerColumnValue,
-    PartitionerMonthly,
-    PartitionerYearly,
+    RegexPartitionerMonthly,
+    RegexPartitionerYearly,
 )
 from great_expectations.datasource.fluent.data_asset.path.path_data_asset import (
     PathDataAsset,
@@ -1315,7 +1315,7 @@ class TestPartitionerFileAsset:
             r"first_ten_trips_in_each_file/yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
         )
         asset_with_conflicting_partitioner = file_asset_with_no_partitioner
-        partitioner = PartitionerYearly(regex=regex)
+        partitioner = RegexPartitionerYearly(regex=regex)
         assert asset_with_conflicting_partitioner.get_batch_parameters_keys(
             partitioner=partitioner
         ) == (
@@ -1333,7 +1333,7 @@ class TestPartitionerFileAsset:
         )
 
         asset = file_asset_with_no_partitioner
-        partitioner = PartitionerMonthly(regex=regex)
+        partitioner = RegexPartitionerMonthly(regex=regex)
 
         post_partitioner_batch_request = asset.build_batch_request(
             options={"year": "2020", "month": "11"}, partitioner=partitioner
@@ -1354,7 +1354,7 @@ class TestPartitionerFileAsset:
             r"first_ten_trips_in_each_file/yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
         )
         asset = file_asset_with_no_partitioner
-        partitioner = PartitionerMonthly(regex=regex)
+        partitioner = RegexPartitionerMonthly(regex=regex)
 
         post_partitioner_batch_request = asset.build_batch_request(
             options={"year": "2020", "month": "11"}, partitioner=partitioner

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -15,9 +15,9 @@ from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.pyspark import types as pyspark_types
 from great_expectations.core.partitioners import (
+    FileNamePartitionerMonthly,
+    FileNamePartitionerYearly,
     PartitionerColumnValue,
-    RegexPartitionerMonthly,
-    RegexPartitionerYearly,
 )
 from great_expectations.datasource.fluent.data_asset.path.path_data_asset import (
     PathDataAsset,
@@ -1315,7 +1315,7 @@ class TestPartitionerFileAsset:
             r"first_ten_trips_in_each_file/yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
         )
         asset_with_conflicting_partitioner = file_asset_with_no_partitioner
-        partitioner = RegexPartitionerYearly(regex=regex)
+        partitioner = FileNamePartitionerYearly(regex=regex)
         assert asset_with_conflicting_partitioner.get_batch_parameters_keys(
             partitioner=partitioner
         ) == (
@@ -1333,7 +1333,7 @@ class TestPartitionerFileAsset:
         )
 
         asset = file_asset_with_no_partitioner
-        partitioner = RegexPartitionerMonthly(regex=regex)
+        partitioner = FileNamePartitionerMonthly(regex=regex)
 
         post_partitioner_batch_request = asset.build_batch_request(
             options={"year": "2020", "month": "11"}, partitioner=partitioner
@@ -1354,7 +1354,7 @@ class TestPartitionerFileAsset:
             r"first_ten_trips_in_each_file/yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
         )
         asset = file_asset_with_no_partitioner
-        partitioner = RegexPartitionerMonthly(regex=regex)
+        partitioner = FileNamePartitionerMonthly(regex=regex)
 
         post_partitioner_batch_request = asset.build_batch_request(
             options={"year": "2020", "month": "11"}, partitioner=partitioner

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -16,12 +16,12 @@ from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.pyspark import types as pyspark_types
 from great_expectations.core.partitioners import (
+    ColumnPartitioner,
+    ColumnPartitionerDaily,
+    ColumnPartitionerMonthly,
+    ColumnPartitionerYearly,
     FileNamePartitionerMonthly,
     FileNamePartitionerYearly,
-    PartitionerColumnValue,
-    ColumnPartitionerDaily,
-    ColumnPartitionerYearly,
-    ColumnPartitionerMonthly, ColumnPartitioner
 )
 from great_expectations.datasource.fluent.data_asset.path.path_data_asset import (
     PathDataAsset,

--- a/tests/datasource/fluent/test_viral_snippets.py
+++ b/tests/datasource/fluent/test_viral_snippets.py
@@ -11,7 +11,7 @@ import pytest
 
 import great_expectations.expectations as gxe
 from great_expectations import get_context
-from great_expectations.core.partitioners import PartitionerYearAndMonth
+from great_expectations.core.partitioners import ColumnPartitionerMonthly
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import CloudDataContext, FileDataContext
 from great_expectations.datasource.fluent.config import GxConfig
@@ -63,7 +63,7 @@ def test_serialize_fluent_config(
 def test_fluent_simple_validate_workflow(seeded_file_context: FileDataContext):
     datasource = seeded_file_context.get_datasource("sqlite_taxi")
     assert isinstance(datasource, Datasource)
-    partitioner = PartitionerYearAndMonth(column_name="pickup_datetime")
+    partitioner = ColumnPartitionerMonthly(column_name="pickup_datetime")
     batch_request = datasource.get_asset("my_asset").build_batch_request(
         options={"year": 2019, "month": 1}, partitioner=partitioner
     )


### PR DESCRIPTION
This PR updates the naming of partitioners in `great_expectations.core.partitioners` to follow a consistent convention. Partitioners which split on columns are renamed to `ColumnPartitionerYearly/Monthly/Daily`, and `RegexPartitioners` are renamed to `FilePartitioner`.