### PR TITLE
[MAINTENANCE] Improve error message around instantiating and saving s…

### DIFF
--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -17,6 +17,7 @@ from great_expectations._docs_decorators import public_api
 from great_expectations.exceptions import (
     GXCloudConfigurationError,
 )
+from great_expectations.exceptions.exceptions import DataContextRequiredError
 
 logger = logging.getLogger(__name__)
 
@@ -82,16 +83,13 @@ class ProjectManager:
         )
         return self.__project
 
-    def set_project(self, project: AbstractDataContext) -> None:
+    def set_project(self, project: AbstractDataContext | None) -> None:
         self.__project = project
 
     @property
     def _project(self) -> AbstractDataContext:
         if not self.__project:
-            raise RuntimeError(
-                "This action requires an active DataContext. "
-                + "Please call `great_expectations.get_context()` first, then try your action again."  # noqa: E501
-            )
+            raise DataContextRequiredError()
         return self.__project
 
     def get_expectations_store(self) -> ExpectationsStore:

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -260,11 +260,10 @@ class ExpectationsStore(Store):
                     local_suite=value,
                     cloud_suite=cloud_suite,
                 )
-        except gx_exceptions.StoreBackendError as exc:
+        except gx_exceptions.StoreBackendError as e:
             # todo: this generic error clobbers more informative errors coming from the store
-            raise gx_exceptions.ExpectationSuiteError(  # noqa: TRY003
-                f"Could not find an existing ExpectationSuite named {value.name}."
-            ) from exc
+
+            raise gx_exceptions.ExpectationSuiteNotAddedToStoreError() from e
 
     def _add_ids_on_create(self, suite: ExpectationSuite) -> ExpectationSuite:
         """This method handles adding IDs to suites and expectations for non-cloud backends.

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -48,6 +48,15 @@ class ExpectationSuiteError(DataContextError):
     pass
 
 
+class ExpectationSuiteNotAddedToStoreError(DataContextError):
+    def __init__(self) -> None:
+        super().__init__(
+            "ExpectationSuite must be added to the DataContext store before it can be saved. "
+            "Please call my_data_context.suites.add(my_expectation_suite), "
+            "then try your action again."
+        )
+
+
 class CheckpointError(DataContextError):
     pass
 
@@ -146,6 +155,14 @@ class UnsupportedConfigVersionError(DataContextError):
 class MissingDataContextError(DataContextError):
     def __init__(self) -> None:
         super().__init__("Missing DataContext")
+
+
+class DataContextRequiredError(DataContextError):
+    def __init__(self) -> None:
+        super().__init__(
+            "This action requires an active data context. "
+            "Please call `great_expectations.get_context()` first, then try your action again."
+        )
 
 
 class SuiteParameterError(GreatExpectationsError):

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -83,7 +83,19 @@ class TestInit:
     """Tests related to ExpectationSuite.__init__()"""
 
     @pytest.mark.unit
-    def test_expectation_suite_init_defaults(self, fake_expectation_suite_name: str):
+    def test_instantiate_with_no_context_raises(self):
+        set_context(None)
+        with pytest.raises(gx_exceptions.DataContextRequiredError):
+            ExpectationSuite(
+                name="i've made a huge mistake",
+            )
+
+    @pytest.mark.unit
+    def test_expectation_suite_init_defaults(
+        self,
+        empty_data_context: AbstractDataContext,
+        fake_expectation_suite_name: str,
+    ):
         suite = ExpectationSuite(name=fake_expectation_suite_name)
 
         default_meta = {"great_expectations_version": ge_version}
@@ -97,6 +109,7 @@ class TestInit:
     @pytest.mark.unit
     def test_expectation_suite_init_overrides(
         self,
+        empty_data_context: AbstractDataContext,
         fake_expectation_suite_name: str,
         expect_column_values_to_be_in_set_col_a_with_meta: ExpectationConfiguration,
     ):
@@ -127,6 +140,7 @@ class TestInit:
     @pytest.mark.unit
     def test_expectation_suite_init_overrides_expectations_dict_and_obj(
         self,
+        empty_data_context: AbstractDataContext,
         fake_expectation_suite_name: str,
         expect_column_values_to_be_in_set_col_a_with_meta_dict: dict,
         expect_column_values_to_be_in_set_col_a_with_meta: ExpectationConfiguration,
@@ -361,6 +375,16 @@ class TestCRUDMethods:
 
         # expect that the data context is kept in sync
         context.expectations_store.update.assert_called_once_with(key=store_key, value=suite)
+
+    @pytest.mark.unit
+    def test_save_before_add_raises(self):
+        gx.get_context(mode="ephemeral")
+        suite = ExpectationSuite(
+            name=self.expectation_suite_name,
+        )
+
+        with pytest.raises(gx_exceptions.ExpectationSuiteNotAddedToStoreError):
+            suite.save()
 
     @pytest.mark.filesystem
     def test_filesystem_context_update_suite_adds_ids(self, empty_data_context, expectation):

--- a/tests/data_context/test_project_manager.py
+++ b/tests/data_context/test_project_manager.py
@@ -4,11 +4,10 @@ import pytest
 
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.data_context.data_context.context_factory import ProjectManager
+from great_expectations.exceptions.exceptions import DataContextRequiredError
 
 
 class TestProjectManagerStores:
-    missing_project_error_str = "This action requires an active DataContext."
-
     @pytest.mark.unit
     def test_get_expectations_store_success(self):
         context = Mock(spec=AbstractDataContext)
@@ -23,7 +22,7 @@ class TestProjectManagerStores:
     def test_get_expectations_store_fails_without_context(self):
         project_manager = ProjectManager()
 
-        with pytest.raises(RuntimeError, match=self.missing_project_error_str):
+        with pytest.raises(DataContextRequiredError):
             project_manager.get_expectations_store()
 
     @pytest.mark.unit
@@ -40,7 +39,7 @@ class TestProjectManagerStores:
     def test_get_checkpoints_store_fails_without_context(self):
         project_manager = ProjectManager()
 
-        with pytest.raises(RuntimeError, match=self.missing_project_error_str):
+        with pytest.raises(DataContextRequiredError):
             project_manager.get_checkpoints_store()
 
     @pytest.mark.unit
@@ -57,7 +56,7 @@ class TestProjectManagerStores:
     def test_get_validation_results_store_fails_without_context(self):
         project_manager = ProjectManager()
 
-        with pytest.raises(RuntimeError, match=self.missing_project_error_str):
+        with pytest.raises(DataContextRequiredError):
             project_manager.get_validation_results_store()
 
     @pytest.mark.unit
@@ -74,5 +73,5 @@ class TestProjectManagerStores:
     def test_get_suite_parameters_store_fails_without_context(self):
         project_manager = ProjectManager()
 
-        with pytest.raises(RuntimeError, match=self.missing_project_error_str):
+        with pytest.raises(DataContextRequiredError):
             project_manager.get_suite_parameters_store()


### PR DESCRIPTION
…uites

## Main stuff
* Updates the error around saving a non-added suite to resolve https://greatexpectations.atlassian.net/browse/V1-240.
* Scope creep alert: also adds a test around, and cleans up, the exception that is raised when instantiating a suite with no context.

## Other stuff
* Updates `set_context` to allow `None` values. I think this is desirable to test specific cases like this, and it's not part of the public api, so it should only be used internally.
* There's a comment above the updated Exception about how we are clobbering errors from the store. I considered changing the logic so that we check in the suite if it has been persisted and raise there, but that introduces a race condition, and I think we mostly need to solve for the normal use case.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
