### PR TITLE
Rename non-metrics distribution expectation stuff to use 'distributio…

### DIFF
--- a/great_expectations/expectations/core/expect_column_chisquare_test_p_value_to_be_greater_than.py
+++ b/great_expectations/expectations/core/expect_column_chisquare_test_p_value_to_be_greater_than.py
@@ -26,7 +26,7 @@ class ExpectColumnChiSquareTestPValueToBeGreaterThan(BatchExpectation):
     success_keys = ()
     args_keys = (
         "column",
-        "partition_object",
+        "distribution_object",
         "p",
         "tail_weight_holdout",
     )

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_bootstrapped_ks_test_p_value.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_bootstrapped_ks_test_p_value.py
@@ -9,7 +9,7 @@ from great_expectations.expectations.metrics.column_aggregate_metric_provider im
     column_aggregate_value,
 )
 from great_expectations.expectations.metrics.util import (
-    is_valid_continuous_partition_object,
+    is_valid_continuous_distribution_object,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,43 +25,48 @@ class ColumnBootstrappedKSTestPValue(ColumnAggregateMetricProvider):
     """MetricProvider Class for Aggregate Standard Deviation metric"""
 
     metric_name = "column.bootstrapped_ks_test_p_value"
-    value_keys = ("partition_object", "p", "bootstrap_sample", "bootstrap_sample_size")
+    value_keys = ("distribution_object", "p", "bootstrap_sample", "bootstrap_sample_size")
 
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(  # noqa: C901, PLR0913
         cls,
         column,
-        partition_object=None,
+        distribution_object=None,
         p=0.05,
         bootstrap_samples=None,
         bootstrap_sample_size=None,
         **kwargs,
     ):
-        if not is_valid_continuous_partition_object(partition_object):
-            raise ValueError("Invalid continuous partition object.")  # noqa: TRY003
+        if not is_valid_continuous_distribution_object(distribution_object):
+            raise ValueError("Invalid continuous distribution object.")  # noqa: TRY003
 
-        # TODO: consider changing this into a check that tail_weights does not exist exclusively, by moving this check into is_valid_continuous_partition_object  # noqa: E501
-        if (partition_object["bins"][0] == -np.inf) or (partition_object["bins"][-1] == np.inf):
+        # TODO: consider changing this into a check that tail_weights does not exist exclusively, by moving this check into is_valid_continuous_distribution_object  # noqa: E501
+        if (distribution_object["bins"][0] == -np.inf) or (
+            distribution_object["bins"][-1] == np.inf
+        ):
             raise ValueError("Partition endpoints must be finite.")  # noqa: TRY003
 
-        if "tail_weights" in partition_object and np.sum(partition_object["tail_weights"]) > 0:
+        if (
+            "tail_weights" in distribution_object
+            and np.sum(distribution_object["tail_weights"]) > 0
+        ):
             raise ValueError("Partition cannot have tail weights -- endpoints must be finite.")  # noqa: TRY003
 
-        test_cdf = np.append(np.array([0]), np.cumsum(partition_object["weights"]))
+        test_cdf = np.append(np.array([0]), np.cumsum(distribution_object["weights"]))
 
         def estimated_cdf(x):
-            return np.interp(x, partition_object["bins"], test_cdf)
+            return np.interp(x, distribution_object["bins"], test_cdf)
 
         if bootstrap_samples is None:
             bootstrap_samples = 1000
 
         if bootstrap_sample_size is None:
             # Sampling too many elements (or not bootstrapping) will make the test too sensitive to the fact that we've  # noqa: E501
-            # compressed via a partition.
+            # compressed via a distribution.
 
             # Sampling too few elements will make the test insensitive to significant differences, especially  # noqa: E501
             # for nonoverlapping ranges.
-            bootstrap_sample_size = len(partition_object["weights"]) * 2
+            bootstrap_sample_size = len(distribution_object["weights"]) * 2
 
         results = [
             stats.kstest(
@@ -73,24 +78,24 @@ class ColumnBootstrappedKSTestPValue(ColumnAggregateMetricProvider):
 
         test_result = (1 + sum(x >= p for x in results)) / (bootstrap_samples + 1)
 
-        hist, _bin_edges = np.histogram(column, partition_object["bins"])
-        below_partition = len(np.where(column < partition_object["bins"][0])[0])
-        above_partition = len(np.where(column > partition_object["bins"][-1])[0])
+        hist, _bin_edges = np.histogram(column, distribution_object["bins"])
+        below_distribution = len(np.where(column < distribution_object["bins"][0])[0])
+        above_distribution = len(np.where(column > distribution_object["bins"][-1])[0])
 
-        # Expand observed partition to report, if necessary
-        if below_partition > 0 and above_partition > 0:
-            observed_bins = [np.min(column)] + partition_object["bins"] + [np.max(column)]
-            observed_weights = np.concatenate(([below_partition], hist, [above_partition])) / len(
-                column
-            )
-        elif below_partition > 0:
-            observed_bins = [np.min(column)] + partition_object["bins"]
-            observed_weights = np.concatenate(([below_partition], hist)) / len(column)
-        elif above_partition > 0:
-            observed_bins = partition_object["bins"] + [np.max(column)]
-            observed_weights = np.concatenate((hist, [above_partition])) / len(column)
+        # Expand observed distribution to report, if necessary
+        if below_distribution > 0 and above_distribution > 0:
+            observed_bins = [np.min(column)] + distribution_object["bins"] + [np.max(column)]
+            observed_weights = np.concatenate(
+                ([below_distribution], hist, [above_distribution])
+            ) / len(column)
+        elif below_distribution > 0:
+            observed_bins = [np.min(column)] + distribution_object["bins"]
+            observed_weights = np.concatenate(([below_distribution], hist)) / len(column)
+        elif above_distribution > 0:
+            observed_bins = distribution_object["bins"] + [np.max(column)]
+            observed_weights = np.concatenate((hist, [above_distribution])) / len(column)
         else:
-            observed_bins = partition_object["bins"]
+            observed_bins = distribution_object["bins"]
             observed_weights = hist / len(column)
 
         observed_cdf_values = np.cumsum(observed_weights)
@@ -101,20 +106,20 @@ class ColumnBootstrappedKSTestPValue(ColumnAggregateMetricProvider):
             "details": {
                 "bootstrap_samples": bootstrap_samples,
                 "bootstrap_sample_size": bootstrap_sample_size,
-                "observed_partition": {
+                "observed_distribution": {
                     "bins": observed_bins,
                     "weights": observed_weights.tolist(),
                 },
-                "expected_partition": {
-                    "bins": partition_object["bins"],
-                    "weights": partition_object["weights"],
+                "expected_distribution": {
+                    "bins": distribution_object["bins"],
+                    "weights": distribution_object["weights"],
                 },
                 "observed_cdf": {
                     "x": observed_bins,
                     "cdf_values": [0] + observed_cdf_values.tolist(),
                 },
                 "expected_cdf": {
-                    "x": partition_object["bins"],
+                    "x": distribution_object["bins"],
                     "cdf_values": test_cdf.tolist(),
                 },
             },

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
@@ -324,7 +324,7 @@ def _get_column_quantiles_sqlite(
 ) -> list:
     """
     The present implementation is somewhat inefficient, because it requires as many calls to
-    "execution_engine.execute_query()" as the number of partitions in the "quantiles" parameter (albeit, typically,
+    "execution_engine.execute_query()" as the number of distributions in the "quantiles" parameter (albeit, typically,
     only a few).  However, this is the only mechanism available for SQLite at the present time (11/17/2021), because
     the analytical processing is not a very strongly represented capability of the SQLite database management system.
     """  # noqa: E501

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -1100,34 +1100,34 @@ def _scipy_distribution_positional_args_from_dict(distribution, params):
         return params["loc"], params["scale"]
 
 
-def is_valid_continuous_partition_object(partition_object):
-    """Tests whether a given object is a valid continuous partition object. See :ref:`partition_object`.
+def is_valid_continuous_distribution_object(distribution_object):
+    """Tests whether a given object is a valid continuous distribution object. See :ref:`distribution_object`.
 
-    :param partition_object: The partition_object to evaluate
+    :param distribution_object: The distribution_object to evaluate
     :return: Boolean
     """  # noqa: E501
     if (
-        (partition_object is None)
-        or ("weights" not in partition_object)
-        or ("bins" not in partition_object)
+        (distribution_object is None)
+        or ("weights" not in distribution_object)
+        or ("bins" not in distribution_object)
     ):
         return False
 
-    if "tail_weights" in partition_object:
-        if len(partition_object["tail_weights"]) != 2:  # noqa: PLR2004
+    if "tail_weights" in distribution_object:
+        if len(distribution_object["tail_weights"]) != 2:  # noqa: PLR2004
             return False
-        comb_weights = partition_object["tail_weights"] + partition_object["weights"]
+        comb_weights = distribution_object["tail_weights"] + distribution_object["weights"]
     else:
-        comb_weights = partition_object["weights"]
+        comb_weights = distribution_object["weights"]
 
-    ## TODO: Consider adding this check to migrate to the tail_weights structure of partition objects  # noqa: E501
-    # if (partition_object['bins'][0] == -np.inf) or (partition_object['bins'][-1] == np.inf):
+    ## TODO: Consider adding this check to migrate to the tail_weights structure of distribution objects  # noqa: E501
+    # if (distribution_object['bins'][0] == -np.inf) or (distribution_object['bins'][-1] == np.inf):
     #     return False
 
     # Expect one more bin edge than weight; all bin edges should be monotonically increasing; weights should sum to one  # noqa: E501
     return (
-        (len(partition_object["bins"]) == (len(partition_object["weights"]) + 1))
-        and np.all(np.diff(partition_object["bins"]) > 0)
+        (len(distribution_object["bins"]) == (len(distribution_object["weights"]) + 1))
+        and np.all(np.diff(distribution_object["bins"]) > 0)
         and np.allclose(np.sum(comb_weights), 1.0)
     )
 


### PR DESCRIPTION
…n' instead of 'partition'




- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
