### PR TITLE
[MAINTENANCE] performance, avoid HTTP round trips 

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4762,11 +4762,11 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
 
         if self.expectations_store.cloud_mode:
             # use get_all to prevent round trips to GX Cloud.
-            for expectation_suite_dict in self.expectations_store.get_all():
-                if not expectation_suite_dict:
+            for exp_suite_dict in self.expectations_store.get_all():
+                if not exp_suite_dict:
                     continue
                 expectation_suite = ExpectationSuite(
-                    **expectation_suite_dict, data_context=self
+                    **exp_suite_dict, data_context=self
                 )
 
                 dependencies: dict = (

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4796,9 +4796,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
                     **expectation_suite_dict, data_context=self
                 )
 
-                dependencies: dict = (
-                    expectation_suite.get_evaluation_parameter_dependencies()
-                )
+                dependencies = expectation_suite.get_evaluation_parameter_dependencies()
                 if len(dependencies) > 0:
                     nested_update(self._evaluation_parameter_dependencies, dependencies)
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4759,18 +4759,48 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         self._evaluation_parameter_dependencies = {}
         # we have to iterate through all expectation suites because evaluation parameters
         # can reference metric values from other suites
-        for expectation_suite_dict in self.expectations_store.get_all():
-            if not expectation_suite_dict:
-                continue
-            expectation_suite = ExpectationSuite(
-                **expectation_suite_dict, data_context=self
-            )
 
-            dependencies: dict = (
-                expectation_suite.get_evaluation_parameter_dependencies()
-            )
-            if len(dependencies) > 0:
-                nested_update(self._evaluation_parameter_dependencies, dependencies)
+        if self.expectations_store.cloud_mode:
+            # use get_all to prevent round trips to GX Cloud.
+            for expectation_suite_dict in self.expectations_store.get_all():
+                if not expectation_suite_dict:
+                    continue
+                expectation_suite = ExpectationSuite(
+                    **expectation_suite_dict, data_context=self
+                )
+
+                dependencies: dict = (
+                    expectation_suite.get_evaluation_parameter_dependencies()
+                )
+                if len(dependencies) > 0:
+                    nested_update(self._evaluation_parameter_dependencies, dependencies)
+
+        else:
+            for key in self.expectations_store.list_keys():
+                try:
+                    expectation_suite_dict: dict = cast(
+                        dict, self.expectations_store.get(key)
+                    )
+                except ValidationError as e:
+                    # if a suite that isn't associated with the checkpoint compiling eval params is misconfigured
+                    # we should ignore that instead of breaking all checkpoints in the entire context
+                    logger.info(
+                        f"Suite with identifier {key} was not considered when compiling evaluation parameter dependencies "
+                        f"because it failed to load with message: {e}"
+                    )
+                    continue
+
+                if not expectation_suite_dict:
+                    continue
+                expectation_suite = ExpectationSuite(
+                    **expectation_suite_dict, data_context=self
+                )
+
+                dependencies: dict = (
+                    expectation_suite.get_evaluation_parameter_dependencies()
+                )
+                if len(dependencies) > 0:
+                    nested_update(self._evaluation_parameter_dependencies, dependencies)
 
         self._evaluation_parameter_dependencies_compiled = True
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4759,19 +4759,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         self._evaluation_parameter_dependencies = {}
         # we have to iterate through all expectation suites because evaluation parameters
         # can reference metric values from other suites
-        for key in self.expectations_store.list_keys():
-            try:
-                expectation_suite_dict: dict = cast(
-                    dict, self.expectations_store.get(key)
-                )
-            except ValidationError as e:
-                # if a suite that isn't associated with the checkpoint compiling eval params is misconfigured
-                # we should ignore that instead of breaking all checkpoints in the entire context
-                logger.info(
-                    f"Suite with identifier {key} was not considered when compiling evaluation parameter dependencies "
-                    f"because it failed to load with message: {e}"
-                )
-                continue
+        for expectation_suite_dict in self.expectations_store.get_all():
             if not expectation_suite_dict:
                 continue
             expectation_suite = ExpectationSuite(

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -43,6 +43,7 @@ class DataContextVariableSchema(str, enum.Enum):
     )
     CONFIG_VERSION = "config_version"
     DATASOURCES = "datasources"
+    FLUENT_DATASOURCES = "fluent_datasources"
     EXPECTATIONS_STORE_NAME = "expectations_store_name"
     VALIDATIONS_STORE_NAME = "validations_store_name"
     EVALUATION_PARAMETER_STORE_NAME = "evaluation_parameter_store_name"

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 import uuid
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility.typing_extensions import override
@@ -23,6 +23,19 @@ from great_expectations.util import (
     filter_properties_dict,
     verify_dynamic_loading_support,
 )
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    from typing_extensions import TypedDict
+
+    class DataPayload(TypedDict):
+        id: str
+        attributes: dict
+        type: Literal["expectation_suite"]
+
+    class CloudResponsePayloadTD(TypedDict):
+        data: DataPayload | list[DataPayload]
 
 
 class ExpectationsStore(Store):
@@ -300,3 +313,25 @@ class ExpectationsStore(Store):
             print()
 
         return return_obj
+
+    @override
+    @staticmethod
+    def gx_cloud_response_json_to_object_collection(
+        response_json: CloudResponsePayloadTD,  # type: ignore[override]
+    ) -> list[dict]:
+        """
+        This method takes full json response from GX cloud and outputs a list of dicts appropriate for
+        deserialization into a collection of GX objects
+        """
+        data = response_json["data"]
+        if not isinstance(data, list):
+            raise TypeError(
+                "GX Cloud did not return a collection of Datasources when expected"
+            )
+
+        return [ExpectationsStore._convert_raw_json_to_object_dict(d) for d in data]
+
+    @staticmethod
+    def _convert_raw_json_to_object_dict(data: DataPayload) -> dict:
+        data["attributes"]["suite"]["ge_cloud_id"] = data["id"]
+        return data["attributes"]["suite"]

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -326,7 +326,7 @@ class ExpectationsStore(Store):
         data = response_json["data"]
         if not isinstance(data, list):
             raise TypeError(
-                "GX Cloud did not return a collection of Datasources when expected"
+                "GX Cloud did not return a list of Expectation Suites when expected"
             )
 
         return [ExpectationsStore._convert_raw_json_to_object_dict(d) for d in data]

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -12,7 +12,10 @@ from great_expectations.data_context.data_context_variables import (
 )
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.base import DataContextConfig
-from great_expectations.exceptions.exceptions import StoreBackendError
+from great_expectations.exceptions.exceptions import (
+    StoreBackendError,
+    StoreBackendUnsupportedResourceTypeError,
+)
 from great_expectations.util import filter_properties_dict
 
 if TYPE_CHECKING:
@@ -98,7 +101,12 @@ class InlineStoreBackend(StoreBackend):
 
     @override
     def _get_all(self) -> list[Any]:
-        raise NotImplementedError
+        project_config = self._data_context.config
+        variable_config = project_config.get(self._resource_type)
+        if isinstance(variable_config, dict):
+            return list(variable_config.values())
+        else:
+            raise StoreBackendUnsupportedResourceTypeError(self._resource_type.value)
 
     @override
     def _set(self, key: tuple[str, ...], value: Any, **kwargs: dict) -> None:

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -326,6 +326,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
 
         return contents
 
+    @override
     def _get_all(self) -> list[Any]:
         keys = [
             key for key in self.list_keys() if key != StoreBackend.STORE_BACKEND_ID_KEY

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -561,13 +561,29 @@ class TupleS3StoreBackend(TupleStoreBackend):
         return s3_object_key
 
     def _get(self, key):
+        client = self._create_client()
         s3_object_key = self._build_s3_object_key(key)
+        return self._get_by_s3_object_key(client, s3_object_key)
 
-        s3 = self._create_client()
+    @override
+    def _get_all(self) -> list[Any]:
+        """Get all objects from the store.
+        NOTE: This is non-performant because we download each object separately.
+        See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/bucket/objects.html#objects
+        for the docs.
+        """
+        client = self._create_client()
+        keys = self.list_keys()
+        keys = [k for k in keys if k != StoreBackend.STORE_BACKEND_ID_KEY]
+        s3_object_keys = [self._build_s3_object_key(key) for key in keys]
+        return [self._get_by_s3_object_key(client, key) for key in s3_object_keys]
 
+    def _get_by_s3_object_key(self, s3_client, s3_object_key):
         try:
-            s3_response_object = s3.get_object(Bucket=self.bucket, Key=s3_object_key)
-        except (s3.exceptions.NoSuchKey, s3.exceptions.NoSuchBucket):
+            s3_response_object = s3_client.get_object(
+                Bucket=self.bucket, Key=s3_object_key
+            )
+        except (s3_client.exceptions.NoSuchKey, s3_client.exceptions.NoSuchBucket):
             raise InvalidKeyError(
                 f"Unable to retrieve object from TupleS3StoreBackend with the following Key: {s3_object_key!s}"
             )
@@ -577,10 +593,6 @@ class TupleS3StoreBackend(TupleStoreBackend):
             .read()
             .decode(s3_response_object.get("ContentEncoding", "utf-8"))
         )
-
-    @override
-    def _get_all(self) -> list[Any]:
-        raise NotImplementedError
 
     def _set(
         self,

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -64,6 +64,11 @@ class GitIgnoreScaffoldingError(GreatExpectationsError):
     pass
 
 
+class StoreBackendUnsupportedResourceTypeError(StoreBackendError):
+    def __init__(self, resource_type: str) -> None:
+        super().__init__(f"Unsupported resource type: {resource_type}")
+
+
 class StoreBackendTransientError(StoreBackendError):
     """The result of a timeout or other networking issues"""
 

--- a/tests/checkpoint/cloud_config.py
+++ b/tests/checkpoint/cloud_config.py
@@ -31,6 +31,24 @@ def make_store_get(data_file_name, data_dir, with_slack):
     return store_get
 
 
+def make_store_get_all(data_file_name, data_dir, with_slack):
+    def store_get_all(self):
+        # key is a 3-tuple with the form
+        # (GXCloudRESTResource, cloud_id as a string uuid, name as string)
+        # For example:
+        # (<GXCloudRESTResource.CHECKPOINT: 'checkpoint'>, '731dc2a5-45d8-4827-9118-39b77c5cd413', 'my_checkpoint')
+        type_ = self.ge_cloud_resource_type
+        if type_ == GXCloudRESTResource.CHECKPOINT:
+            return {"data": _checkpoint_config(data_file_name, with_slack)}
+        elif type_ == GXCloudRESTResource.EXPECTATION_SUITE:
+            return {"data": _expectation_suite()}
+        elif type_ == GXCloudRESTResource.DATASOURCE:
+            return {"data": _datasource(data_dir)}
+        return None
+
+    return store_get_all
+
+
 def store_set(self, key, value, **kwargs):
     base_url = os.environ["GX_CLOUD_BASE_URL"]
     org_id = os.environ["GX_CLOUD_ORGANIZATION_ID"]

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -4699,6 +4699,13 @@ def fake_cloud_context_basic(_fake_cloud_context_setup, monkeypatch):
             data_file_name=data_file, data_dir=data_dir, with_slack=False
         ),
     )
+    monkeypatch.setattr(
+        gx.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend,
+        "_get_all",
+        cloud_config.make_store_get_all(
+            data_file_name=data_file, data_dir=data_dir, with_slack=False
+        ),
+    )
     context = gx.data_context.CloudDataContext()
     yield context
 
@@ -4710,6 +4717,13 @@ def fake_cloud_context_with_slack(_fake_cloud_context_setup, monkeypatch):
         gx.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend,
         "_get",
         cloud_config.make_store_get(
+            data_file_name=data_file, data_dir=data_dir, with_slack=True
+        ),
+    )
+    monkeypatch.setattr(
+        gx.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend,
+        "_get_all",
+        cloud_config.make_store_get_all(
             data_file_name=data_file, data_dir=data_dir, with_slack=True
         ),
     )

--- a/tests/data_context/store/test_database_store_backend.py
+++ b/tests/data_context/store/test_database_store_backend.py
@@ -44,6 +44,47 @@ def test_database_store_backend_schema_spec(caplog, sa, test_backends):
         connection.execute(sa.text(f"DROP TABLE {store_backend._table};"))
 
 
+def test_database_store_backend_get_all(caplog, sa, test_backends):
+    if "postgresql" not in test_backends:
+        pytest.skip("test_database_store_backend_get_url_for_key requires postgresql")
+
+    store_backend = DatabaseStoreBackend(
+        credentials={
+            "drivername": "postgresql",
+            "username": "postgres",
+            "password": "",
+            "host": os.getenv("GE_TEST_LOCAL_DB_HOSTNAME", "localhost"),
+            "port": "5432",
+            "schema": "special",
+            "database": "test_ci",
+        },
+        table_name="test_database_store_backend_url_key",
+        key_columns=["k1", "k2"],
+    )
+
+    FOO = "foo"
+    BAR = "bar"
+    store_backend.set(
+        (
+            "1",
+            "2",
+        ),
+        FOO,
+    )
+    store_backend.set(
+        (
+            "aaa",
+            "bbb",
+        ),
+        BAR,
+    )
+    assert store_backend.get_all() == [FOO, BAR]
+
+    # clean up values
+    with store_backend.engine.begin() as connection:
+        connection.execute(sa.text(f"DROP TABLE {store_backend._table};"))
+
+
 def test_database_store_backend_get_url_for_key(caplog, sa, test_backends):
     if "postgresql" not in test_backends:
         pytest.skip("test_database_store_backend_get_url_for_key requires postgresql")
@@ -166,8 +207,8 @@ def test_database_store_backend_id_initialization(caplog, sa, test_backends):
     See also test_store_backends::test_StoreBackend_id_initialization
     """
 
-    if "postgresql" not in test_backends:
-        pytest.skip("test_database_store_backend_id_initialization requires postgresql")
+    # if "postgresql" not in test_backends:
+    #     pytest.skip("test_database_store_backend_id_initialization requires postgresql")
 
     store_backend = DatabaseStoreBackend(
         credentials={

--- a/tests/data_context/store/test_database_store_backend.py
+++ b/tests/data_context/store/test_database_store_backend.py
@@ -207,8 +207,8 @@ def test_database_store_backend_id_initialization(caplog, sa, test_backends):
     See also test_store_backends::test_StoreBackend_id_initialization
     """
 
-    # if "postgresql" not in test_backends:
-    #     pytest.skip("test_database_store_backend_id_initialization requires postgresql")
+    if "postgresql" not in test_backends:
+        pytest.skip("test_database_store_backend_id_initialization requires postgresql")
 
     store_backend = DatabaseStoreBackend(
         credentials={

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1749,8 +1749,8 @@ def test_InlineStoreBackend_get_all_success(empty_data_context) -> None:
         resource_type=DataContextVariableSchema.FLUENT_DATASOURCES,
     )
 
-    datasource_config_a = empty_data_context.data_sources.add_pandas(name="a")
-    datasource_config_b = empty_data_context.data_sources.add_pandas(name="b")
+    datasource_config_a = empty_data_context.sources.add_pandas(name="a")
+    datasource_config_b = empty_data_context.sources.add_pandas(name="b")
 
     inline_store_backend.set(
         DataContextVariableKey("a").to_tuple(), datasource_config_a

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -8,6 +8,7 @@ import boto3
 import pyparsing as pp
 import pytest
 from moto import mock_s3
+from pytest_mock import MockerFixture
 
 from great_expectations.core.data_context_key import DataContextVariableKey
 from great_expectations.core.expectation_suite import ExpectationSuite
@@ -511,6 +512,29 @@ def test_TupleFilesystemStoreBackend(tmp_path_factory):
 
 
 @pytest.mark.filesystem
+def test_TupleFilesystemStoreBackend_get_all(tmp_path_factory):
+    path = "dummy_str"
+    full_test_dir = tmp_path_factory.mktemp("test_TupleFilesystemStoreBackend__dir")
+    project_path = str(full_test_dir)
+
+    my_store = TupleFilesystemStoreBackend(
+        root_directory=project_path,
+        base_directory=os.path.join(project_path, path),  # noqa: PTH118
+        filepath_template="my_file_{0}",
+    )
+
+    value_a = "aaa"
+    value_b = "bbb"
+
+    my_store.set(("AAA",), value_a)
+    my_store.set(("BBB",), value_b)
+
+    all_values = my_store.get_all()
+
+    assert sorted(all_values) == [value_a, value_b]
+
+
+@pytest.mark.filesystem
 def test_TupleFilesystemStoreBackend_ignores_jupyter_notebook_checkpoints(
     tmp_path_factory,
 ):
@@ -747,6 +771,28 @@ def test_TupleS3StoreBackend_with_prefix(aws_credentials):
 #     assert (
 #         res["success"] is True
 #     ), "No exception thrown, validation operators ran successfully"
+
+
+@mock_s3
+@pytest.mark.aws_deps
+def test_TupleS3StoreBackend_get_all(aws_credentials):
+    bucket = "leakybucket"
+
+    # create a bucket in Moto's mock AWS environment
+    conn = boto3.resource("s3", region_name="us-east-1")
+    conn.create_bucket(Bucket=bucket)
+
+    my_store = TupleS3StoreBackend(filepath_template="my_file_{0}", bucket=bucket)
+
+    val_a = "aaa"
+    val_b = "bbb"
+
+    my_store.set(("AAA",), val_a, content_type="text/html; charset=utf-8")
+    my_store.set(("BBB",), val_b, content_type="text/html; charset=utf-8")
+
+    result = my_store.get_all()
+
+    assert sorted(result) == [val_a, val_b]
 
 
 @mock_s3
@@ -1204,6 +1250,69 @@ def test_TupleGCSStoreBackend():  # noqa: PLR0915
     )
 
 
+@pytest.mark.skipif(
+    not is_library_loadable(library_name="google.cloud"),
+    reason="google is not installed",
+)
+@pytest.mark.skipif(
+    not is_library_loadable(library_name="google"),
+    reason="google is not installed",
+)
+@pytest.mark.big
+def test_TupleGCSStoreBackend_get_all(mocker: MockerFixture):
+    # Note: it would be nice to inject the gcs client so we could pass in the mock.
+    bucket = "leakybucket"
+    prefix = "this_is_a_test_prefix"
+    project = "dummy-project"
+    base_public_path = "http://www.test.com/"
+    val_a = "aaa"
+    val_b = "bbb"
+
+    # setup mocks
+    from great_expectations.compatibility import google
+
+    def _create_mock_blob(name: str):
+        output = mocker.Mock()
+        output.name = name
+        return output
+
+    def mock_get_blob(gcs_object_key):
+        """Test double for bucket::get_blob."""
+        key_to_return_val = {
+            f"{prefix}/blob_a": val_a,
+            f"{prefix}/blob_b": val_b,
+        }
+        return mocker.Mock(
+            download_as_bytes=mocker.Mock(
+                return_value=key_to_return_val[gcs_object_key].encode("utf-8")
+            )
+        )
+
+    mock_gcs_client = mocker.MagicMock(spec=google.storage.Client)
+    mock_gcs_client.list_blobs.return_value = [
+        _create_mock_blob(name=f"{prefix}/{StoreBackend.STORE_BACKEND_ID_KEY[0]}"),
+        _create_mock_blob(name=f"{prefix}/blob_a"),
+        _create_mock_blob(name=f"{prefix}/blob_b"),
+    ]
+
+    mock_gcs_client.bucket.return_value = mocker.Mock(
+        get_blob=mocker.Mock(side_effect=mock_get_blob)
+    )
+
+    with mocker.patch("google.cloud.storage.Client", return_value=mock_gcs_client):
+        my_store = TupleGCSStoreBackend(
+            filepath_template=None,
+            bucket=bucket,
+            prefix=prefix,
+            project=project,
+            base_public_path=base_public_path,
+        )
+
+        result = my_store.get_all()
+
+        assert sorted(result) == [val_a, val_b]
+
+
 @pytest.mark.unit
 def test_TupleAzureBlobStoreBackend_credential():
     pytest.importorskip("azure.storage.blob")
@@ -1321,6 +1430,65 @@ def test_TupleAzureBlobStoreBackend_account_url():
                 "this_is_a_test_prefix/BBB"
             )
             mock_azure_credential.assert_called_once()
+
+
+@pytest.mark.unit
+def test_TupleAzureBlobStoreBackend_get_all(mocker: MockerFixture):
+    pytest.importorskip("azure.storage.blob")
+    pytest.importorskip("azure.identity")
+    """
+    What does this test test and why?
+    Since no package like moto exists for Azure-Blob services, we mock the Azure-blob client
+    and assert that the store backend makes the right calls for set, get, and list.
+    """
+    credential = "this_is_a_test_credential_string"
+    account_url = "this_is_a_test_account_url"
+    prefix = "this_is_a_test_prefix"
+    suffix = ".json"
+    container = "dummy-container"
+    val_a = "aaa"
+    val_b = "bbb"
+    key_a = f"{prefix}/foo.json"
+    key_b = f"{prefix}/bar.json"
+
+    def _create_mock_blob(name: str):
+        output = mocker.Mock()
+        output.name = name
+        return output
+
+    def mock_get_blob(object_key):
+        """Test double for BlobServiceClient::download_blob."""
+        key_to_return_val = {
+            key_a: val_a,
+            key_b: val_b,
+        }
+        return mocker.Mock(
+            readall=mocker.Mock(
+                return_value=key_to_return_val[object_key].encode("utf-8")
+            )
+        )
+
+    my_store = TupleAzureBlobStoreBackend(
+        credential=credential,
+        account_url=account_url,
+        prefix=prefix,
+        filepath_suffix=suffix,
+        container=container,
+    )
+
+    with mock.patch(
+        "great_expectations.compatibility.azure.BlobServiceClient", autospec=True
+    ):
+        mock_container_client = my_store._container_client
+        mock_container_client.list_blobs.return_value = [
+            _create_mock_blob(key_a),
+            _create_mock_blob(key_b),
+        ]
+        mock_container_client.download_blob.side_effect = mock_get_blob
+
+        result = my_store.get_all()
+
+        assert sorted(result) == [val_a, val_b]
 
 
 @mock_s3
@@ -1572,6 +1740,40 @@ def test_InlineStoreBackend_with_mocked_fs(empty_data_context: DataContext) -> N
     datasources: dict = config_commented_map_from_yaml["datasources"]
     assert len(datasources) == 1
     assert datasources["my_datasource"] == datasource_config
+
+
+@pytest.mark.filesystem
+def test_InlineStoreBackend_get_all_success(empty_data_context) -> None:
+    inline_store_backend = InlineStoreBackend(
+        data_context=empty_data_context,
+        resource_type=DataContextVariableSchema.FLUENT_DATASOURCES,
+    )
+
+    datasource_config_a = empty_data_context.data_sources.add_pandas(name="a")
+    datasource_config_b = empty_data_context.data_sources.add_pandas(name="b")
+
+    inline_store_backend.set(
+        DataContextVariableKey("a").to_tuple(), datasource_config_a
+    )
+    inline_store_backend.set(
+        DataContextVariableKey("b").to_tuple(), datasource_config_b
+    )
+
+    all_of_em = inline_store_backend.get_all()
+
+    assert all_of_em == [datasource_config_a, datasource_config_b]
+
+
+@pytest.mark.filesystem
+def test_InlineStoreBackend_get_all_invalid_resource_type(empty_data_context) -> None:
+    inline_store_backend = InlineStoreBackend(
+        data_context=empty_data_context,
+        resource_type=DataContextVariableSchema.ALL_VARIABLES,
+    )
+
+    expected_error = "Unsupported resource type: data_context_variables"
+    with pytest.raises(StoreBackendError, match=expected_error):
+        inline_store_backend.get_all()
 
 
 @pytest.mark.unit

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -8,7 +8,6 @@ import uuid
 from collections import defaultdict
 from pprint import pformat as pf
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -536,9 +535,8 @@ def test_run_checkpoint_minimizes_suite_request_count(
         validator=validator,
     )
 
-    with patch("tests.datasource.fluent.get_expectation_suites_cb") as mocked_function:
-        checkpoint.run()
-        assert mocked_function.assert_called_once()
+    checkpoint.run()
+    # TODO assert GET expectation-suites called
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Currently, when building the evaluation parameters, N round trips are made to the GX Cloud store for N Expectation Suites.
- This PR avoids this by implementing the `get_all` method on the ExpectationsStore's interface.
- I suggest using the "hide whitespace changes" option when reviewing the code diff