### PR TITLE
[DOCS] reorganizes content under the 1.0 Set up a GX environment topic

### DIFF
--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_databricks_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_databricks_installation.md
@@ -15,29 +15,23 @@ DBFS is a distributed file system mounted in a Databricks workspace and availabl
 
 1. Run the following command in your notebook to install GX as a notebook-scoped library:
 
-    ```bash title="Terminal input"
-    %pip install great-expectations
-    ```
+   ```bash title="Terminal input"
+   %pip install great-expectations
+   ```
 
-  A notebook-scoped library is a custom Python environment that is specific to a notebook. You can also install a library at the cluster or workspace level. See [Databricks Libraries](https://docs.databricks.com/data/databricks-file-system.html).
+   A notebook-scoped library is a custom Python environment that is specific to a notebook. You can also install a library at the cluster or workspace level. See [Databricks Libraries](https://docs.databricks.com/data/databricks-file-system.html).
 
 2. Run the following command to import the Python configurations you'll use in the following steps:
 
-  ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports"
-  ```
+   ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports"
+   ```
 
 3. Run the following code to specify a `/dbfs/` path for your Data Context:
 
-  ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir"
-  ```
+   ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir"
+   ```
+
 4. Run the following code to instantiate your Data Context:
 
-  ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context"
-  ```
-
-## Next steps
-
-<InProgress />
-
-- Connect to data in files stored in the DBFS
-- Connect to data in an in-memory Spark Dataframe
+   ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context"
+   ```

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_databricks_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_databricks_installation.md
@@ -1,6 +1,6 @@
 import InProgress from '../../_core_components/_in_progress.md';
 
-Databricks is a web-based platform automating Spark cluster management and working with them through Python notebooks.
+Databricks is a web-based platform that automates Spark cluster management.
 
 To avoid configuring external resources, you'll use the [Databricks File System (DBFS)](https://docs.databricks.com/data/databricks-file-system.html) for your Metadata Stores and Data Docs store.
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_databricks_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_databricks_installation.md
@@ -1,0 +1,43 @@
+import InProgress from '../../_core_components/_in_progress.md';
+
+Databricks is a web-based platform automating Spark cluster management and working with them through Python notebooks.
+
+To avoid configuring external resources, you'll use the [Databricks File System (DBFS)](https://docs.databricks.com/data/databricks-file-system.html) for your Metadata Stores and Data Docs store.
+
+DBFS is a distributed file system mounted in a Databricks workspace and available on Databricks clusters. Files on DBFS can be written and read as if they were on a local filesystem by <a href="https://docs.databricks.com/data/databricks-file-system.html#local-file-apis">adding the /dbfs/ prefix to the path</a>. It also persists in object storage, so you won’t lose data after terminating a cluster. See the Databricks documentation for best practices, including mounting object stores.
+
+## Additional prerequisites
+
+- A complete Databricks setup, including a running Databricks cluster with an attached notebook
+- Access to [DBFS](https://docs.databricks.com/dbfs/index.html)
+
+## Installation and setup
+
+1. Run the following command in your notebook to install GX as a notebook-scoped library:
+
+    ```bash title="Terminal input"
+    %pip install great-expectations
+    ```
+
+  A notebook-scoped library is a custom Python environment that is specific to a notebook. You can also install a library at the cluster or workspace level. See [Databricks Libraries](https://docs.databricks.com/data/databricks-file-system.html).
+
+2. Run the following command to import the Python configurations you'll use in the following steps:
+
+  ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports"
+  ```
+
+3. Run the following code to specify a `/dbfs/` path for your Data Context:
+
+  ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir"
+  ```
+4. Run the following code to instantiate your Data Context:
+
+  ```python title="Python" name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context"
+  ```
+
+## Next steps
+
+<InProgress />
+
+- Connect to data in files stored in the DBFS
+- Connect to data in an in-memory Spark Dataframe

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_emr_spark_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_emr_spark_installation.md
@@ -1,0 +1,25 @@
+Use the information provided here to install GX on an EMR Spark cluster and instantiate a Data Context without a full configuration directory.
+
+## Additional prerequisites
+
+- An EMR Spark cluster.
+- Access to the EMR Spark notebook.
+
+## Installation and setup
+
+1. To install Great Expectations on your EMR Spark cluster copy this code snippet into a cell in your EMR Spark notebook and then run it:
+
+  ```python title="Python"
+  sc.install_pypi_package("great_expectations")
+  ```
+2. Create an in-code Data Context. See [Instantiate an Ephemeral Data Context](/core/installation_and_setup/manage_data_contexts.md?context-type=ephemeral#initialize-a-new-data-context).
+
+3. Copy the Python code at the end of **How to instantiate an Ephemeral Data Context** into a cell in your EMR Spark notebook, or use the other examples to customize your configuration. The code instantiates and configures a Data Context for an EMR Spark cluster.
+
+4. Execute the cell with your Data Context initialization and configuration.
+
+5. Run the following command to verify that GX was installed and your in-memory Data Context was instantiated successfully:
+
+  ```python title="Python"
+      context.list_datasources()
+   ```

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_emr_spark_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_emr_spark_installation.md
@@ -9,9 +9,10 @@ Use the information provided here to install GX on an EMR Spark cluster and inst
 
 1. To install Great Expectations on your EMR Spark cluster copy this code snippet into a cell in your EMR Spark notebook and then run it:
 
-  ```python title="Python"
-  sc.install_pypi_package("great_expectations")
-  ```
+   ```python title="Python"
+   sc.install_pypi_package("great_expectations")
+   ```
+
 2. Create an in-code Data Context. See [Instantiate an Ephemeral Data Context](/core/installation_and_setup/manage_data_contexts.md?context-type=ephemeral#initialize-a-new-data-context).
 
 3. Copy the Python code at the end of **How to instantiate an Ephemeral Data Context** into a cell in your EMR Spark notebook, or use the other examples to customize your configuration. The code instantiates and configures a Data Context for an EMR Spark cluster.
@@ -20,6 +21,6 @@ Use the information provided here to install GX on an EMR Spark cluster and inst
 
 5. Run the following command to verify that GX was installed and your in-memory Data Context was instantiated successfully:
 
-  ```python title="Python"
+   ```python title="Python"
       context.list_datasources()
    ```

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_emr_spark_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_emr_spark_installation.md
@@ -7,7 +7,7 @@ Use the information provided here to install GX on an EMR Spark cluster and inst
 
 ## Installation and setup
 
-1. To install Great Expectations on your EMR Spark cluster copy this code snippet into a cell in your EMR Spark notebook and then run it:
+1. To install GX on your EMR Spark cluster copy this code snippet into a cell in your EMR Spark notebook and then run it:
 
    ```python title="Python"
    sc.install_pypi_package("great_expectations")

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_gx_cloud_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_gx_cloud_installation.md
@@ -1,7 +1,7 @@
-GX Cloud provides a web interface for using GX to validate your data without creating and running complex Python code.  However, GX 1.0 is also capable of connecting to a GX Cloud account should you wish to engage in further customization or automation of your workflows through Python scripts.
+GX Cloud provides a web interface for using GX to validate your data without creating and running complex Python code. However, GX 1.0 can connect to a GX Cloud account if you want to customize or automate your workflows through Python scripts.
 
 ## Installation and setup
 
-To deploy a GX Agent, which serves as an intermediary between GX Cloud's interface and your organization's data stores, see [Connect GX Cloud](/cloud/connect/connect_lp.md).  The GX Agent serves all GX Cloud users within your organization.  If a GX Agent has already been deployed for your organization, you can use the GX Cloud online application without further installation or setup.
+To deploy a GX Agent, which serves as an intermediary between GX Cloud's interface and your organization's data stores, see [Connect GX Cloud](/cloud/connect/connect_lp.md). The GX Agent serves all GX Cloud users within your organization.  If a GX Agent has already been deployed for your organization, you can use the GX Cloud online application without further installation or setup.
 
 To connect to GX Cloud from a Python script utilizing a [local installation of GX 1.0](/core/installation_and_setup/install_gx.md?install-location=local) instead of the GX Agent, see [Connect to an existing Data Context](/core/installation_and_setup/manage_data_contexts.md?context-type=gx_cloud#connect-to-an-existing-data-context).

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_gx_cloud_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_gx_cloud_installation.md
@@ -1,7 +1,10 @@
-GX Cloud provides a web interface for using GX to validate your data without creating and running complex Python code. However, GX 1.0 can connect to a GX Cloud account if you want to customize or automate your workflows through Python scripts.
+import GxData from '../../_core_components/_data.jsx'
+
+GX Cloud provides a web interface for using GX to validate your data without creating and running complex Python code. However,
+{GxData.product_name} can connect to a GX Cloud account if you want to customize or automate your workflows through Python scripts.
 
 ## Installation and setup
 
 To deploy a GX Agent, which serves as an intermediary between GX Cloud's interface and your organization's data stores, see [Connect GX Cloud](/cloud/connect/connect_lp.md). The GX Agent serves all GX Cloud users within your organization.  If a GX Agent has already been deployed for your organization, you can use the GX Cloud online application without further installation or setup.
 
-To connect to GX Cloud from a Python script utilizing a [local installation of GX 1.0](/core/installation_and_setup/install_gx.md?install-location=local) instead of the GX Agent, see [Connect to an existing Data Context](/core/installation_and_setup/manage_data_contexts.md?context-type=gx_cloud#connect-to-an-existing-data-context).
+To connect to GX Cloud from a Python script utilizing a [local installation of GX](/core/installation_and_setup/install_gx.md?install-location=local) instead of the GX Agent, see [Connect to an existing Data Context](/core/installation_and_setup/manage_data_contexts.md?context-type=gx_cloud#connect-to-an-existing-data-context).

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_gx_cloud_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_gx_cloud_installation.md
@@ -1,0 +1,7 @@
+GX Cloud provides a web interface for using GX to validate your data without creating and running complex Python code.  However, GX 1.0 is also capable of connecting to a GX Cloud account should you wish to engage in further customization or automation of your workflows through Python scripts.
+
+## Installation and setup
+
+To deploy a GX Agent, which serves as an intermediary between GX Cloud's interface and your organization's data stores, see [Connect GX Cloud](/cloud/connect/connect_lp.md).  The GX Agent serves all GX Cloud users within your organization.  If a GX Agent has already been deployed for your organization, you can use the GX Cloud online application without further installation or setup.
+
+To connect to GX Cloud from a Python script utilizing a [local installation of GX 1.0](/core/installation_and_setup/install_gx.md?install-location=local) instead of the GX Agent, see [Connect to an existing Data Context](/core/installation_and_setup/manage_data_contexts.md?context-type=gx_cloud#connect-to-an-existing-data-context).

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
@@ -1,6 +1,7 @@
 import ReleaseVersionBox from '../../../components/versions/_gx_version_code_box.mdx'
+import GxData from '../../_core_components/_data.jsx'
 
-GX 1.0 is a Python library and as such can be used with a local Python installation to access the functionality of GX through Python scripts.
+{GxData.product_name} is a Python library and as such can be used with a local Python installation to access the functionality of GX through Python scripts.
 
 ## Installation and setup
 
@@ -18,13 +19,13 @@ GX 1.0 is a Python library and as such can be used with a local Python installat
    python -m ensurepip --upgrade
    ```
 
-3. Install the GX 1.0 library:
+3. Install the {GxData.product_name} library:
 
    ```bash title="Terminal input"
    pip install great_expectations
    ```
 
-4. Verify that GX installed successfully with the CLI command:
+4. Verify that GX installed successfully with the terminal command:
 
    ```bash title="Terminal input"
    great_expectations --version

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
@@ -1,0 +1,35 @@
+import ReleaseVersionBox from '../../../components/versions/_gx_version_code_box.mdx'
+
+GX 1.0 is a Python library and as such can be used with a local Python installation to access the functionality of GX through Python scripts.
+
+## Installation and setup
+
+1. (Optional) Activate your virtual environment.
+
+  If you created a virtual environment for your GX Python installation, navigate to the folder that contains your virtual environment and activate it by running the following command:
+
+  ```bash title="Terminal input"
+  source my_venv/bin/activate
+  ```
+
+2. Ensure you have the latest version of `pip`:
+
+  ```bash title="Terminal input"
+  python -m ensurepip --upgrade
+  ```
+
+3. Install the GX 1.0 library:
+
+  ```bash title="Terminal input"
+  pip install great_expectations
+  ```
+
+4. Verify that GX installed successfully with the CLI command:
+
+  ```bash title="Terminal input"
+  great_expectations --version
+  ```
+
+  The output you receive if GX was successfully installed will be:
+
+  <ReleaseVersionBox/>

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
@@ -6,30 +6,30 @@ GX 1.0 is a Python library and as such can be used with a local Python installat
 
 1. (Optional) Activate your virtual environment.
 
-  If you created a virtual environment for your GX Python installation, navigate to the folder that contains your virtual environment and activate it by running the following command:
+   If you created a virtual environment for your GX Python installation, navigate to the folder that contains your virtual environment and activate it by running the following command:
 
-  ```bash title="Terminal input"
-  source my_venv/bin/activate
-  ```
+   ```bash title="Terminal input"
+   source my_venv/bin/activate
+   ```
 
 2. Ensure you have the latest version of `pip`:
 
-  ```bash title="Terminal input"
-  python -m ensurepip --upgrade
-  ```
+   ```bash title="Terminal input"
+   python -m ensurepip --upgrade
+   ```
 
 3. Install the GX 1.0 library:
 
-  ```bash title="Terminal input"
-  pip install great_expectations
-  ```
+   ```bash title="Terminal input"
+   pip install great_expectations
+   ```
 
 4. Verify that GX installed successfully with the CLI command:
 
-  ```bash title="Terminal input"
-  great_expectations --version
-  ```
+   ```bash title="Terminal input"
+   great_expectations --version
+   ```
 
-  The output you receive if GX was successfully installed will be:
+   The output you receive if GX was successfully installed will be:
 
-  <ReleaseVersionBox/>
+   <ReleaseVersionBox/>

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_gx/_local_installation.md
@@ -4,9 +4,9 @@ GX 1.0 is a Python library and as such can be used with a local Python installat
 
 ## Installation and setup
 
-1. (Optional) Activate your virtual environment.
+1. Optional. Activate your virtual environment.
 
-   If you created a virtual environment for your GX Python installation, navigate to the folder that contains your virtual environment and activate it by running the following command:
+   If you created a virtual environment for your GX Python installation, browse to the folder that contains your virtual environment and run the following command to activate it:
 
    ```bash title="Terminal input"
    source my_venv/bin/activate
@@ -30,6 +30,6 @@ GX 1.0 is a Python library and as such can be used with a local Python installat
    great_expectations --version
    ```
 
-   The output you receive if GX was successfully installed will be:
+   If GX was successfully installed, the following output appears:
 
    <ReleaseVersionBox/>

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_gx.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_gx.md
@@ -4,6 +4,7 @@ title: Install GX
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
+import GxData from '../_core_components/_data.jsx'
 import PrereqPythonInstalled from '../_core_components/prerequisites/_python_installation.md';
 import InstallLocal from './_install_gx/_local_installation.md';
 import InstallEmrSpark from './_install_gx/_emr_spark_installation.md';
@@ -12,7 +13,7 @@ import InstallGxCloud from './_install_gx/_gx_cloud_installation.md';
 
 import PythonVersion from '../_core_components/_python_version.md';
 
-Great Expectations (GX) is a Python library that provides a framework for describing data with expressive tests and then validating that the data meets those criteria.
+{GxData.product_name} is a Python library.  Follow the instructions in this guide to install GX in your local Python environment, or as a notebook-scoped library in hosted environments such as Databricks or EMR Spark clusters.
 
 ## Prerequisites
 
@@ -28,7 +29,6 @@ Great Expectations (GX) is a Python library that provides a framework for descri
   <TabItem value="local" label="Local">
 <InstallLocal/>
   </TabItem>
-
 
   <TabItem value="hosted" label="Hosted">
 
@@ -53,7 +53,6 @@ Hosted environments such as EMR Spark or Databricks clusters do not provide a fi
   </TabItem>
 
 </Tabs>
-
 
 ## Next steps
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_gx.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_gx.md
@@ -17,7 +17,7 @@ Great Expectations (GX) is a Python library that provides a framework for descri
 ## Prerequisites
 
 - <PrereqPythonInstalled/>
-- (Recommended) [A Python virtual environment](/core/installation_and_setup/set_up_a_python_environment.mdx#optional-create-a-virtual-environment)
+- Recommended. [A Python virtual environment](/core/installation_and_setup/set_up_a_python_environment.mdx#optional-create-a-virtual-environment)
 - Internet access
 - Permissions to download and install packages in your environment
 
@@ -32,7 +32,7 @@ Great Expectations (GX) is a Python library that provides a framework for descri
 
   <TabItem value="hosted" label="Hosted">
 
-Hosted environments such as EMR Spark clusters or Databricks clusters do not provide for a filesystem where you can install your GX instance.  Instead, you must install GX in-memory using the Python-style notebooks available on those platforms.
+Hosted environments such as EMR Spark or Databricks clusters do not provide a filesystem to install your GX instance.  Instead, you must install GX in memory using the Python-style notebooks available on those platforms.
 
 <Tabs queryString="hosted-type" groupId="hosted-type" defaultValue='spark-notebook' values={[{label: 'EMR Spark notebook', value:'spark-notebook'}, {label: 'Databricks notebook', value:'databricks-notebook'}]}>
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_gx.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_gx.md
@@ -1,0 +1,61 @@
+---
+title: Install GX
+---
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+import PrereqPythonInstalled from '../_core_components/prerequisites/_python_installation.md';
+import InstallLocal from './_install_gx/_local_installation.md';
+import InstallEmrSpark from './_install_gx/_emr_spark_installation.md';
+import InstallDatabricks from './_install_gx/_databricks_installation.md';
+import InstallGxCloud from './_install_gx/_gx_cloud_installation.md';
+
+import PythonVersion from '../_core_components/_python_version.md';
+
+Great Expectations (GX) is a Python library that provides a framework for describing data with expressive tests and then validating that the data meets those criteria.
+
+## Prerequisites
+
+- <PrereqPythonInstalled/>
+- (Recommended) [A Python virtual environment](/core/installation_and_setup/set_up_a_python_environment.mdx#optional-create-a-virtual-environment)
+- Internet access
+- Permissions to download and install packages in your environment
+
+## Install the GX Python library
+
+<Tabs queryString="install-location" groupId="install-location" defaultValue='local' values={[{label: 'Local', value:'local'}, {label: 'Hosted environment', value:'hosted'}, {label: 'GX Cloud', value:'gx-cloud'}]}>
+
+  <TabItem value="local" label="Local">
+<InstallLocal/>
+  </TabItem>
+
+
+  <TabItem value="hosted" label="Hosted">
+
+Hosted environments such as EMR Spark clusters or Databricks clusters do not provide for a filesystem where you can install your GX instance.  Instead, you must install GX in-memory using the Python-style notebooks available on those platforms.
+
+<Tabs queryString="hosted-type" groupId="hosted-type" defaultValue='spark-notebook' values={[{label: 'EMR Spark notebook', value:'spark-notebook'}, {label: 'Databricks notebook', value:'databricks-notebook'}]}>
+
+  <TabItem value="spark-notebook">
+<InstallEmrSpark/>
+  </TabItem>
+
+  <TabItem value="databricks-notebook">
+<InstallDatabricks/>
+  </TabItem>
+
+</Tabs>
+
+  </TabItem>
+
+  <TabItem value="gx-cloud" label="GX Cloud">
+<InstallGxCloud/>
+  </TabItem>
+
+</Tabs>
+
+
+## Next steps
+
+- [Install additional dependencies](/core/installation_and_setup/additional_dependencies/additional_dependencies.md)
+- [Manage Data Contexts](/core/installation_and_setup/manage_data_contexts.md)

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_python.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_python.md
@@ -1,0 +1,65 @@
+---
+title: Install Python
+---
+
+import GxData from '../_core_components/_data.jsx';
+import PythonVersion from '../_core_components/_python_version.md';
+import PrereqPythonInstalled from '../_core_components/prerequisites/_python_installation.md';
+
+To use Great Expectations (GX) you need to install Python and the {GxData.product_name} Python library. GX also recommends you set up a virtual environment for your GX Python projects.
+
+## Prerequisites
+
+- Internet access
+- Permissions to download and install packages in your environment
+
+## Install Python
+
+1. Reference the [official Python documentation](https://www.python.org/) to install an appropriate version of Python.
+
+   GX Requires <PythonVersion/>, which can be found on the [official Python downloads page](https://www.python.org/downloads/).
+
+
+2. Verify your Python installation.
+
+   Run the following command to display your Python version:
+
+   ```shell title="Terminal input"
+   python --version
+   ```
+
+   You should receive a response similar to:
+
+   ```shell title="Terminal output"
+   Python 3.8.6
+   ```
+
+## (Optional) Create a virtual environment
+
+   Although it is an optional step, the best practice when working with a Python project is to do so in a virtual environment.  A virtual environment ensures that any libraries and dependencies that you install as part of your project do not encounter or cause conflicts with libraries and dependencies installed for other Python projects.
+
+   There are various tools such as virtualenv and pyenv which can be used to create a virtual environment.  This example uses `venv` because it is included with Python 3.
+
+1. Create the virtual environment with `venv`.
+
+   To create your virtual environment, run the following code from the folder the environment should reside in:
+
+   ```shell title="Terminal input"
+   python -m venv my_venv
+   ```
+
+   This command creates a new directory named `my_venv` which will contain your virtual environment.
+
+   :::tip Virtual environment names
+
+   If you wish to use a different name for your virtual environment, replace `my_venv` in the example with the name you would prefer.  You will also have to replace `my_venv` with your virtual environment's actual name in any other example code that includes `my_venv`.
+
+   :::
+
+2. (Optional) Test your virtual environment by activating it.
+
+   Activate your virtual environment by running the following command from the folder it was installed in:
+
+   ```shell title="Terminal input"
+   source my_venv/bin/activate
+   ```

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_python.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_python.md
@@ -34,7 +34,7 @@ To use Great Expectations (GX) you need to install Python and the {GxData.produc
    Python 3.8.6
    ```
 
-## (Optional) Create a virtual environment
+## Optional. Create a virtual environment
 
    Although it is optional, the best practice when working with a Python project is to do so in a virtual environment.  A virtual environment ensures that any libraries and dependencies you install as part of your project do not encounter or cause conflicts with libraries and dependencies installed for other Python projects.
 
@@ -42,7 +42,7 @@ To use Great Expectations (GX) you need to install Python and the {GxData.produc
 
 1. Create the virtual environment with `venv`.
 
-   To create your virtual environment, run the following code from the folder the environment should reside in:
+   To create your virtual environment, run the following code from the folder that the environment will be created in:
 
    ```shell title="Terminal input"
    python -m venv my_venv
@@ -52,13 +52,13 @@ To use Great Expectations (GX) you need to install Python and the {GxData.produc
 
    :::tip Virtual environment names
 
-   If you wish to use a different name for your virtual environment, replace `my_venv` in the example with the name you would prefer.  You will also have to replace `my_venv` with your virtual environment's actual name in any other example code that includes `my_venv`.
+   To use a different name for your virtual environment, replace `my_venv` in the example with the name you would prefer.  You will also have to replace `my_venv` with your virtual environment's actual name in any other example code that includes `my_venv`.
 
    :::
 
 2. Optional. Test your virtual environment by activating it.
 
-   Activate your virtual environment by running the following command from the folder it was installed in:
+   Activate your virtual environment by running the following command from the same folder it was installed from:
 
    ```shell title="Terminal input"
    source my_venv/bin/activate

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_python.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_python.md
@@ -28,7 +28,7 @@ To use Great Expectations (GX) you need to install Python and the {GxData.produc
    python --version
    ```
 
-   You should receive a response similar to:
+   You should receive a response similar to the following:
 
    ```shell title="Terminal output"
    Python 3.8.6
@@ -36,7 +36,7 @@ To use Great Expectations (GX) you need to install Python and the {GxData.produc
 
 ## (Optional) Create a virtual environment
 
-   Although it is an optional step, the best practice when working with a Python project is to do so in a virtual environment.  A virtual environment ensures that any libraries and dependencies that you install as part of your project do not encounter or cause conflicts with libraries and dependencies installed for other Python projects.
+   Although it is optional, the best practice when working with a Python project is to do so in a virtual environment.  A virtual environment ensures that any libraries and dependencies you install as part of your project do not encounter or cause conflicts with libraries and dependencies installed for other Python projects.
 
    There are various tools such as virtualenv and pyenv which can be used to create a virtual environment.  This example uses `venv` because it is included with Python 3.
 
@@ -48,7 +48,7 @@ To use Great Expectations (GX) you need to install Python and the {GxData.produc
    python -m venv my_venv
    ```
 
-   This command creates a new directory named `my_venv` which will contain your virtual environment.
+   This command creates a new directory named `my_venv` for your virtual environment.
 
    :::tip Virtual environment names
 
@@ -56,7 +56,7 @@ To use Great Expectations (GX) you need to install Python and the {GxData.produc
 
    :::
 
-2. (Optional) Test your virtual environment by activating it.
+2. Optional. Test your virtual environment by activating it.
 
    Activate your virtual environment by running the following command from the folder it was installed in:
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
@@ -20,15 +20,15 @@ import OverviewCard from '@site/src/components/OverviewCard';
     topIcon 
     label="Install Python"
     description="Install the Python language and set up a virtual environment"
-    to="/core/set_up_a_gx_environment/install_python.md" 
+    to="/core/set_up_a_gx_environment/install_python" 
     icon="/img/expectation_icon.svg" 
   />
   
   <LinkCard 
     topIcon 
     label="Install GX"
-    description="Install the {GxData.product_name} Python library."
-    to="/core/set_up_a_gx_environment/install_gx.md" 
+    description="Install the GX Python library."
+    to="/core/set_up_a_gx_environment/install_gx" 
     icon="/img/expectation_icon.svg" 
   />
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
@@ -4,10 +4,10 @@ description: Learn how to set up a Python environment for GX, install the GX lib
 hide_feedback_survey: true
 hide_title: true
 ---
+
 import LinkCardGrid from '@site/src/components/LinkCardGrid';
 import LinkCard from '@site/src/components/LinkCard';
 import OverviewCard from '@site/src/components/OverviewCard';
-
 
 <OverviewCard title={frontMatter.title}>
   Learn how to set up a Python environment for GX, install the GX library, and get a Data Context for project management from a Python script, IDE, or interpreter.

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
@@ -1,0 +1,35 @@
+---
+title: "Set up a GX environment"
+description: Learn how to set up a Python environment for GX, install the GX library, and get a Data Context for project management from a Python script, IDE, or interpreter.
+hide_feedback_survey: true
+hide_title: true
+---
+import LinkCardGrid from '@site/src/components/LinkCardGrid';
+import LinkCard from '@site/src/components/LinkCard';
+import OverviewCard from '@site/src/components/OverviewCard';
+
+
+<OverviewCard title={frontMatter.title}>
+  Learn how to set up a Python environment for GX, install the GX library, and get a Data Context for project management from a Python script, IDE, or interpreter.
+</OverviewCard>
+
+
+<LinkCardGrid>
+
+  <LinkCard 
+    topIcon 
+    label="Install Python"
+    description="Install the Python language and set up a virtual environment"
+    to="/core/set_up_a_gx_environment/install_python.md" 
+    icon="/img/expectation_icon.svg" 
+  />
+  
+  <LinkCard 
+    topIcon 
+    label="Install GX"
+    description="Install the {GxData.product_name} Python library."
+    to="/core/set_up_a_gx_environment/install_gx.md" 
+    icon="/img/expectation_icon.svg" 
+  />
+
+</LinkCardGrid>

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -29,13 +29,18 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'Install and manage GX 1.0',
-      link: {type: 'doc', id: 'core/installation_and_setup/installation_and_setup'},
+      label: 'Set up a GX environment',
+      link: {type: 'doc', id: 'core/set_up_a_gx_environment/set_up_a_gx_environment'},
       items: [
         {
           type: 'doc',
-          id: 'core/installation_and_setup/install_gx',
-          label: 'Install GX 1.0'
+          id: 'core/set_up_a_gx_environment/install_python',
+          label: 'Install Python'
+        },
+        {
+          type: 'doc',
+          id: 'core/set_up_a_gx_environment/install_gx',
+          label: 'Install GX'
         },
         {
           type: 'doc',
@@ -44,7 +49,7 @@ module.exports = {
         },
         {
           type: 'category',
-          label: 'Manage Data Contexts',
+          label: 'Create a Data Context',
           link: {type: 'doc', id: 'core/installation_and_setup/manage_data_contexts'},
           items: [
             {


### PR DESCRIPTION
## Description
- Creates the "Set up a GX environment" category and landing page.
- Splits "Install Python" and "Install GX" into individual topics

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated
