### PR TITLE
[MAINTENANCE] Ban future use of `convert_to_json_serializable`

### DIFF
--- a/assets/scripts/build_package_gallery.py
+++ b/assets/scripts/build_package_gallery.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, List
 import pip
 from great_expectations_contrib.commands import read_package_from_file, sync_package
 
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations_contrib.package import (

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -52,7 +52,7 @@ from great_expectations.render.renderer import (
     SlackRenderer,
 )
 from great_expectations.render.renderer.renderer import Renderer
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.checkpoint.checkpoint import CheckpointResult

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -24,7 +24,7 @@ from great_expectations.core.id_dict import BatchKwargs, BatchSpec, IDDict
 from great_expectations.exceptions import InvalidBatchIdError
 from great_expectations.types import DictDot, SerializableDictDot, safe_deep_copy
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     deep_filter_properties_iterable,
     load_class,
 )

--- a/great_expectations/core/domain.py
+++ b/great_expectations/core/domain.py
@@ -10,7 +10,7 @@ from great_expectations.core.id_dict import IDDict
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.types import SerializableDictDot, SerializableDotDict
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     deep_filter_properties_iterable,
     is_candidate_subset_of_target,
 )

--- a/great_expectations/core/expectation_diagnostics/expectation_diagnostics.py
+++ b/great_expectations/core/expectation_diagnostics/expectation_diagnostics.py
@@ -28,7 +28,7 @@ from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 
 @dataclass(frozen=True)

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -37,7 +37,7 @@ from great_expectations.render import (
 from great_expectations.types import SerializableDictDot
 from great_expectations.util import (
     convert_to_json_serializable,  # noqa: TID251
-    ensure_json_serializable,
+    ensure_json_serializable,  # noqa: TID251
 )
 
 if TYPE_CHECKING:

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -36,7 +36,7 @@ from great_expectations.render import (
 )
 from great_expectations.types import SerializableDictDot
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     ensure_json_serializable,
 )
 

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -33,7 +33,7 @@ from great_expectations.render import (
 from great_expectations.types import SerializableDictDot
 from great_expectations.util import (
     convert_to_json_serializable,  # noqa: TID251
-    ensure_json_serializable,
+    ensure_json_serializable,  # noqa: TID251
 )
 
 if TYPE_CHECKING:

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -32,7 +32,7 @@ from great_expectations.render import (
 )
 from great_expectations.types import SerializableDictDot
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     ensure_json_serializable,
 )
 

--- a/great_expectations/core/id_dict.py
+++ b/great_expectations/core/id_dict.py
@@ -5,7 +5,7 @@ import json
 from typing import Any, Set, TypeVar, Union
 
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 T = TypeVar("T")
 

--- a/great_expectations/core/serializer.py
+++ b/great_expectations/core/serializer.py
@@ -18,7 +18,7 @@ serialized_value = serializer.serialize(config)
 import abc
 from typing import TYPE_CHECKING
 
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from marshmallow import Schema

--- a/great_expectations/core/suite_parameters.py
+++ b/great_expectations/core/suite_parameters.py
@@ -27,7 +27,7 @@ from pyparsing import (
 )
 
 from great_expectations.exceptions import SuiteParameterError
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias, TypeGuard

--- a/great_expectations/data_context/migrator/configuration_bundle.py
+++ b/great_expectations/data_context/migrator/configuration_bundle.py
@@ -19,7 +19,7 @@ from great_expectations.data_context.data_context_variables import (
     DataContextVariables,  # noqa: TCH001
 )
 from great_expectations.data_context.types.base import DataContextConfigSchema
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.data_context.data_context.abstract_data_context import (

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -44,7 +44,7 @@ from great_expectations.compatibility import pyspark
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.configuration import AbstractConfig, AbstractConfigSchema
 from great_expectations.types import DictDot, SerializableDictDot
-from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable
+from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable  # noqa: TID251
 
 if TYPE_CHECKING:
     from io import TextIOWrapper

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # noqa: I001
+from __future__ import annotations
 
 import copy
 import enum
@@ -44,7 +44,10 @@ from great_expectations.compatibility import pyspark
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.configuration import AbstractConfig, AbstractConfigSchema
 from great_expectations.types import DictDot, SerializableDictDot
-from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable  # noqa: TID251
+from great_expectations.util import (
+    convert_to_json_serializable,  # noqa: TID251
+    deep_filter_properties_iterable,
+)
 
 if TYPE_CHECKING:
     from io import TextIOWrapper

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: I001
 
 import copy
 import enum

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -28,7 +28,7 @@ from great_expectations.expectations.row_conditions import (
     RowConditionParserType,
 )
 from great_expectations.types import DictDot
-from great_expectations.util import convert_to_json_serializable, filter_properties_dict
+from great_expectations.util import convert_to_json_serializable, filter_properties_dict  # noqa: TID251
 from great_expectations.validator.computed_metric import MetricValue  # noqa: TCH001
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,  # noqa: TCH001

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: I001
 
 import copy
 import logging

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # noqa: I001
+from __future__ import annotations
 
 import copy
 import logging
@@ -28,7 +28,10 @@ from great_expectations.expectations.row_conditions import (
     RowConditionParserType,
 )
 from great_expectations.types import DictDot
-from great_expectations.util import convert_to_json_serializable, filter_properties_dict  # noqa: TID251
+from great_expectations.util import (
+    convert_to_json_serializable,  # noqa: TID251
+    filter_properties_dict,
+)
 from great_expectations.validator.computed_metric import MetricValue  # noqa: TCH001
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,  # noqa: TCH001

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -65,7 +65,7 @@ from great_expectations.expectations.row_conditions import (
     RowConditionParserType,
     parse_condition_to_spark,
 )
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 from great_expectations.validator.computed_metric import MetricValue  # noqa: TCH001
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,  # noqa: TCH001

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -53,7 +53,7 @@ from great_expectations.execution_engine.partition_and_sample.sqlalchemy_data_pa
 from great_expectations.execution_engine.partition_and_sample.sqlalchemy_data_sampler import (
     SqlAlchemyDataSampler,
 )
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 from great_expectations.validator.computed_metric import MetricValue  # noqa: TCH001
 
 del get_versions  # isort:skip

--- a/great_expectations/expectations/expectation_configuration.py
+++ b/great_expectations/expectations/expectation_configuration.py
@@ -33,7 +33,7 @@ from great_expectations.expectations.registry import get_expectation_impl
 from great_expectations.render import RenderedAtomicContent, RenderedAtomicContentSchema
 from great_expectations.types import SerializableDictDot
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     ensure_json_serializable,
 )
 

--- a/great_expectations/expectations/expectation_configuration.py
+++ b/great_expectations/expectations/expectation_configuration.py
@@ -34,7 +34,7 @@ from great_expectations.render import RenderedAtomicContent, RenderedAtomicConte
 from great_expectations.types import SerializableDictDot
 from great_expectations.util import (
     convert_to_json_serializable,  # noqa: TID251
-    ensure_json_serializable,
+    ensure_json_serializable,  # noqa: TID251
 )
 
 if TYPE_CHECKING:

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
@@ -22,7 +22,7 @@ from great_expectations.expectations.metrics.column_aggregate_metric_provider im
     ColumnAggregateMetricProvider,
 )
 from great_expectations.expectations.metrics.metric_provider import metric_value
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
@@ -14,7 +14,7 @@ from great_expectations.expectations.metrics.map_metric_provider import (
     ColumnMapMetricProvider,
     column_condition_partial,
 )
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 
 class ColumnValuesMatchJsonSchema(ColumnMapMetricProvider):

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -33,7 +33,7 @@ from great_expectations.expectations.metrics.util import (
     sql_statement_with_post_compile_to_string,
 )
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     generate_temporary_table_name,
     get_sqlalchemy_selectable,
 )

--- a/great_expectations/expectations/row_conditions.py
+++ b/great_expectations/expectations/row_conditions.py
@@ -23,7 +23,7 @@ from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.compatibility import pyspark, sqlalchemy

--- a/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
+++ b/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: I001
 
 import logging
 from dataclasses import asdict, dataclass

--- a/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
+++ b/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # noqa: I001
+from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
@@ -10,7 +10,10 @@ import pandas as pd
 from great_expectations.compatibility import pyspark, sqlalchemy
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable  # noqa: TID251
+from great_expectations.util import (
+    convert_to_json_serializable,  # noqa: TID251
+    deep_filter_properties_iterable,
+)
 
 if TYPE_CHECKING:
     from great_expectations.experimental.rule_based_profiler.metric_computation_result import (

--- a/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
+++ b/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
@@ -10,7 +10,7 @@ import pandas as pd
 from great_expectations.compatibility import pyspark, sqlalchemy
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable
+from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.experimental.rule_based_profiler.metric_computation_result import (

--- a/great_expectations/experimental/rule_based_profiler/builder.py
+++ b/great_expectations/experimental/rule_based_profiler/builder.py
@@ -12,7 +12,7 @@ from great_expectations.core.batch import (
     get_batch_request_as_dict,
 )
 from great_expectations.types import SerializableDictDot, safe_deep_copy
-from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable
+from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.data_context.data_context.abstract_data_context import (

--- a/great_expectations/experimental/rule_based_profiler/builder.py
+++ b/great_expectations/experimental/rule_based_profiler/builder.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # noqa: I001
+from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, Set, Union
@@ -12,7 +12,10 @@ from great_expectations.core.batch import (
     get_batch_request_as_dict,
 )
 from great_expectations.types import SerializableDictDot, safe_deep_copy
-from great_expectations.util import convert_to_json_serializable, deep_filter_properties_iterable  # noqa: TID251
+from great_expectations.util import (
+    convert_to_json_serializable,  # noqa: TID251
+    deep_filter_properties_iterable,
+)
 
 if TYPE_CHECKING:
     from great_expectations.data_context.data_context.abstract_data_context import (

--- a/great_expectations/experimental/rule_based_profiler/builder.py
+++ b/great_expectations/experimental/rule_based_profiler/builder.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: I001
 
 import json
 from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, Set, Union

--- a/great_expectations/experimental/rule_based_profiler/config/base.py
+++ b/great_expectations/experimental/rule_based_profiler/config/base.py
@@ -19,7 +19,7 @@ from great_expectations.experimental.rule_based_profiler.parameter_container imp
 )
 from great_expectations.types import DictDot, SerializableDictDot
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     deep_filter_properties_iterable,
     filter_properties_dict,
 )

--- a/great_expectations/experimental/rule_based_profiler/estimators/numeric_range_estimation_result.py
+++ b/great_expectations/experimental/rule_based_profiler/estimators/numeric_range_estimation_result.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List, Union
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.types import DictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     import numpy as np

--- a/great_expectations/experimental/rule_based_profiler/estimators/numeric_range_estimator.py
+++ b/great_expectations/experimental/rule_based_profiler/estimators/numeric_range_estimator.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     import numpy as np

--- a/great_expectations/experimental/rule_based_profiler/helpers/cardinality_checker.py
+++ b/great_expectations/experimental/rule_based_profiler/helpers/cardinality_checker.py
@@ -8,7 +8,7 @@ from typing import Union, cast
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.exceptions import ProfilerConfigurationError
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 
 @dataclass(frozen=True)

--- a/great_expectations/experimental/rule_based_profiler/helpers/configuration_reconciliation.py
+++ b/great_expectations/experimental/rule_based_profiler/helpers/configuration_reconciliation.py
@@ -11,7 +11,7 @@ from great_expectations.experimental.rule_based_profiler.helpers.util import (
     convert_variables_to_dict,
 )
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.experimental.rule_based_profiler.parameter_container import (

--- a/great_expectations/experimental/rule_based_profiler/helpers/runtime_environment.py
+++ b/great_expectations/experimental/rule_based_profiler/helpers/runtime_environment.py
@@ -10,7 +10,7 @@ from great_expectations.experimental.rule_based_profiler.helpers.util import (
     convert_variables_to_dict,
 )
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.experimental.rule_based_profiler.rule import Rule

--- a/great_expectations/experimental/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/experimental/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -56,7 +56,7 @@ from great_expectations.experimental.rule_based_profiler.parameter_container imp
     get_fully_qualified_parameter_names,
 )
 from great_expectations.types.attributes import Attributes
-from great_expectations.util import convert_to_json_serializable, is_parseable_date
+from great_expectations.util import convert_to_json_serializable, is_parseable_date  # noqa: TID251
 from great_expectations.validator.computed_metric import MetricValue  # noqa: TCH001
 from great_expectations.validator.exception_info import ExceptionInfo  # noqa: TCH001
 from great_expectations.validator.metric_configuration import MetricConfiguration

--- a/great_expectations/experimental/rule_based_profiler/parameter_container.py
+++ b/great_expectations/experimental/rule_based_profiler/parameter_container.py
@@ -19,7 +19,7 @@ from pyparsing import (
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.types import SerializableDictDot, SerializableDotDict
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.core.domain import Domain

--- a/great_expectations/experimental/rule_based_profiler/rule/rule.py
+++ b/great_expectations/experimental/rule_based_profiler/rule/rule.py
@@ -28,7 +28,7 @@ from great_expectations.experimental.rule_based_profiler.parameter_container imp
 from great_expectations.experimental.rule_based_profiler.rule.rule_state import RuleState
 from great_expectations.types import SerializableDictDot
 from great_expectations.util import (
-    convert_to_json_serializable,
+    convert_to_json_serializable,  # noqa: TID251
     deep_filter_properties_iterable,
     measure_execution_time,
 )

--- a/great_expectations/experimental/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/experimental/rule_based_profiler/rule_based_profiler.py
@@ -61,7 +61,7 @@ from great_expectations.experimental.rule_based_profiler.parameter_container imp
 )
 from great_expectations.experimental.rule_based_profiler.rule import Rule, RuleOutput
 from great_expectations.experimental.rule_based_profiler.rule.rule_state import RuleState
-from great_expectations.util import convert_to_json_serializable, filter_properties_dict
+from great_expectations.util import convert_to_json_serializable, filter_properties_dict  # noqa: TID251
 from great_expectations.validator.exception_info import ExceptionInfo
 
 if TYPE_CHECKING:

--- a/great_expectations/experimental/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/experimental/rule_based_profiler/rule_based_profiler.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # noqa: I001
+from __future__ import annotations
 
 import copy
 import datetime
@@ -61,7 +61,10 @@ from great_expectations.experimental.rule_based_profiler.parameter_container imp
 )
 from great_expectations.experimental.rule_based_profiler.rule import Rule, RuleOutput
 from great_expectations.experimental.rule_based_profiler.rule.rule_state import RuleState
-from great_expectations.util import convert_to_json_serializable, filter_properties_dict  # noqa: TID251
+from great_expectations.util import (
+    convert_to_json_serializable,  # noqa: TID251
+    filter_properties_dict,
+)
 from great_expectations.validator.exception_info import ExceptionInfo
 
 if TYPE_CHECKING:

--- a/great_expectations/experimental/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/experimental/rule_based_profiler/rule_based_profiler.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: I001
 
 import copy
 import datetime

--- a/great_expectations/experimental/rule_based_profiler/rule_based_profiler_result.py
+++ b/great_expectations/experimental/rule_based_profiler/rule_based_profiler_result.py
@@ -19,7 +19,7 @@ from great_expectations.experimental.rule_based_profiler.parameter_container imp
     ParameterNode,  # noqa: TCH001
 )
 from great_expectations.types import SerializableDictDot
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 if TYPE_CHECKING:
     from great_expectations.alias_types import JSONValues

--- a/great_expectations/types/attributes.py
+++ b/great_expectations/types/attributes.py
@@ -5,7 +5,7 @@ import logging
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import IDDict
 from great_expectations.types import SerializableDotDict
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/validator/exception_info.py
+++ b/great_expectations/validator/exception_info.py
@@ -5,7 +5,7 @@ import json
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import IDDict
 from great_expectations.types.base import SerializableDotDict
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 
 class ExceptionInfo(SerializableDotDict):

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -8,7 +8,7 @@ from great_expectations.core.domain import Domain
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.experimental.metric_repository.metrics import MetricTypes
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 
 @public_api

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -51,7 +51,7 @@ from great_expectations.expectations.registry import (
     get_expectation_impl,
     list_registered_expectation_implementations,
 )
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 from great_expectations.validator.exception_info import ExceptionInfo
 from great_expectations.validator.metrics_calculator import (
     MetricsCalculator,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -422,6 +422,7 @@ If you are working in a configuration file you may use the inline comment \
 "pydantic".msg = "Please do not import pydantic directly, import from great_expectations.compatibility.pydantic instead."
 "pkg_resources".msg = "pkg_resources module has been deprecated. Use importlib.resources or importlib.metada instead."
 "great_expectations.util.convert_to_json_serializable".msg = "Use pydantic for serialization."
+"great_expectations.util.ensure_json_serializable".msg = "Use pydantic for serialization."
 
 
 # -----------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -421,6 +421,7 @@ If you are working in a configuration file you may use the inline comment \
 # TODO: remove pydantic once our min version is pydantic v2
 "pydantic".msg = "Please do not import pydantic directly, import from great_expectations.compatibility.pydantic instead."
 "pkg_resources".msg = "pkg_resources module has been deprecated. Use importlib.resources or importlib.metada instead."
+"great_expectations.util.convert_to_json_serializable".msg = "Use pydantic for serialization."
 
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
Use of `convert_to_json_serializable` is a sign that we aren't properly using pydantic models for objects that require json serialization.

Ban the import of the function and add `# noqa: TID25` for existing violations.

Also ban `ensure_json_serializable` (maybe we don't care as much about this one?) 
