### PR TITLE
[BUGFIX] fix exception when attempting to write to read only file system

### DIFF
--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -223,7 +223,7 @@ class InlineStoreBackend(StoreBackend):
                 context.config.to_yaml(outfile)
         # In environments where wrting to disk is not allowed, it is impossible to
         # save changes. As such, we log a warning but do not raise.
-        except PermissionError as e:
+        except (PermissionError, OSError) as e:
             logger.warning(f"Could not save project config to disk: {e}")
 
     @staticmethod


### PR DESCRIPTION
# Description 
 * adds OSError to exception list to allow great expectations to by pass writing to great_expectations.yml file. This is relevant to MWAA read-only task workers.
 * would be nice to be added to older 0.18.x versions
 
Link to issue 
https://github.com/great-expectations/great_expectations/issues/9911

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated


