### PR TITLE
[MAINTENANCE] Temporary: xfail tests that hit fastapi

### DIFF
--- a/tests/integration/cloud/end_to_end/test_pandas_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_pandas_datasource.py
@@ -130,6 +130,9 @@ def expectation_suite(
     return expectation_suite
 
 
+@pytest.mark.xfail(
+    reason="Fails due reuse of expectation suite fixture, but we will not support this flow in v1"
+)
 @pytest.mark.cloud
 def test_interactive_validator(
     context: CloudDataContext,

--- a/tests/integration/cloud/end_to_end/test_pandas_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_pandas_datasource.py
@@ -130,9 +130,7 @@ def expectation_suite(
     return expectation_suite
 
 
-@pytest.mark.xfail(
-    reason="Fails due reuse of expectation suite fixture, but we will not support this flow in v1"
-)
+@pytest.mark.xfail(reason="Test setup failure; will resolve separately", strict=True)
 @pytest.mark.cloud
 def test_interactive_validator(
     context: CloudDataContext,

--- a/tests/integration/cloud/end_to_end/test_spark_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_spark_datasource.py
@@ -127,6 +127,7 @@ def expectation_suite(
     return expectation_suite
 
 
+@pytest.mark.xfail(reason="Test setup failure; will resolve separately", strict=True)
 @pytest.mark.cloud
 def test_interactive_validator(
     context: CloudDataContext,

--- a/tests/integration/cloud/end_to_end/test_spark_filesystem_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_spark_filesystem_datasource.py
@@ -126,6 +126,7 @@ def expectation_suite(
     return expectation_suite
 
 
+@pytest.mark.xfail(reason="Test setup failure; will resolve separately", strict=True)
 @pytest.mark.cloud
 def test_interactive_validator(
     context: CloudDataContext,


### PR DESCRIPTION
In mercury, we recently removed the flast v1 endpoints in favor of the fastapi ones. This appears to have broken OSS tests, as they are running against a mercury image that only runs flask.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
