### PR TITLE
[MAINTENANCE] Clean up extraneous GX Cloud enums

### DIFF
--- a/great_expectations/core/config_provider.py
+++ b/great_expectations/core/config_provider.py
@@ -196,9 +196,6 @@ class _CloudConfigurationProvider(_AbstractConfigurationProvider):
         cloud_values: Dict[str, str] = {
             GXCloudEnvironmentVariable.BASE_URL: base_url,
             GXCloudEnvironmentVariable.ACCESS_TOKEN: access_token,
-            # <GX_RENAME> Deprecated as of 0.15.37
-            GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,
-            GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,
         }
 
         # organization_id is nullable so we conditionally include it in the output
@@ -206,8 +203,6 @@ class _CloudConfigurationProvider(_AbstractConfigurationProvider):
             cloud_values.update(
                 {
                     GXCloudEnvironmentVariable.ORGANIZATION_ID: organization_id,
-                    # <GX_RENAME> Deprecated as of 0.15.37
-                    GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID: organization_id,
                 }
             )
 

--- a/great_expectations/data_context/cloud_constants.py
+++ b/great_expectations/data_context/cloud_constants.py
@@ -12,22 +12,15 @@ class GXCloudEnvironmentVariable(str, Enum):
     BASE_URL = "GX_CLOUD_BASE_URL"
     ORGANIZATION_ID = "GX_CLOUD_ORGANIZATION_ID"
     ACCESS_TOKEN = "GX_CLOUD_ACCESS_TOKEN"
-    # <GX_RENAME> Deprecated as of 0.15.37
-    _OLD_BASE_URL = "GE_CLOUD_BASE_URL"
-    _OLD_ORGANIZATION_ID = "GE_CLOUD_ORGANIZATION_ID"
-    _OLD_ACCESS_TOKEN = "GE_CLOUD_ACCESS_TOKEN"
 
 
 class GXCloudRESTResource(str, Enum):
-    BATCH = "batch"
     CHECKPOINT = "checkpoint"
     DATASOURCE = "datasource"
     DATA_ASSET = "data_asset"
     DATA_CONTEXT = "data_context"
     DATA_CONTEXT_VARIABLES = "data_context_variables"
-    EXPECTATION = "expectation"
     EXPECTATION_SUITE = "expectation_suite"
-    EXPECTATION_VALIDATION_RESULT = "expectation_validation_result"
     RENDERED_DATA_DOC = "rendered_data_doc"
-    VALIDATION_RESULT = "validation_result"
     VALIDATION_DEFINITION = "validation_definition"
+    VALIDATION_RESULT = "validation_result"

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -412,19 +412,19 @@ class CloudDataContext(SerializableDataContext):
         cloud_base_url = (
             cloud_base_url
             or cls._get_global_config_value(
-                primary_environment_variable=GXCloudEnvironmentVariable.BASE_URL,
+                environment_variable=GXCloudEnvironmentVariable.BASE_URL,
                 conf_file_section="ge_cloud_config",
                 conf_file_option="base_url",
             )
             or CLOUD_DEFAULT_BASE_URL
         )
         cloud_organization_id = cloud_organization_id or cls._get_global_config_value(
-            primary_environment_variable=GXCloudEnvironmentVariable.ORGANIZATION_ID,
+            environment_variable=GXCloudEnvironmentVariable.ORGANIZATION_ID,
             conf_file_section="ge_cloud_config",
             conf_file_option="organization_id",
         )
         cloud_access_token = cloud_access_token or cls._get_global_config_value(
-            primary_environment_variable=GXCloudEnvironmentVariable.ACCESS_TOKEN,
+            environment_variable=GXCloudEnvironmentVariable.ACCESS_TOKEN,
             conf_file_section="ge_cloud_config",
             conf_file_option="access_token",
         )

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -411,23 +411,20 @@ class CloudDataContext(SerializableDataContext):
     ) -> Dict[GXCloudEnvironmentVariable, Optional[str]]:
         cloud_base_url = (
             cloud_base_url
-            or cls._get_cloud_env_var(
+            or cls._get_global_config_value(
                 primary_environment_variable=GXCloudEnvironmentVariable.BASE_URL,
-                deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_BASE_URL,
                 conf_file_section="ge_cloud_config",
                 conf_file_option="base_url",
             )
             or CLOUD_DEFAULT_BASE_URL
         )
-        cloud_organization_id = cloud_organization_id or cls._get_cloud_env_var(
+        cloud_organization_id = cloud_organization_id or cls._get_global_config_value(
             primary_environment_variable=GXCloudEnvironmentVariable.ORGANIZATION_ID,
-            deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID,
             conf_file_section="ge_cloud_config",
             conf_file_option="organization_id",
         )
-        cloud_access_token = cloud_access_token or cls._get_cloud_env_var(
+        cloud_access_token = cloud_access_token or cls._get_global_config_value(
             primary_environment_variable=GXCloudEnvironmentVariable.ACCESS_TOKEN,
-            deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN,
             conf_file_section="ge_cloud_config",
             conf_file_option="access_token",
         )
@@ -436,33 +433,6 @@ class CloudDataContext(SerializableDataContext):
             GXCloudEnvironmentVariable.ORGANIZATION_ID: cloud_organization_id,
             GXCloudEnvironmentVariable.ACCESS_TOKEN: cloud_access_token,
         }
-
-    @classmethod
-    def _get_cloud_env_var(
-        cls,
-        primary_environment_variable: GXCloudEnvironmentVariable,
-        deprecated_environment_variable: GXCloudEnvironmentVariable,
-        conf_file_section: str,
-        conf_file_option: str,
-    ) -> Optional[str]:
-        """
-        Utility to gradually deprecate environment variables prefixed with `GE`.
-
-        This method is aimed to initially attempt retrieval with the `GX` prefix
-        and only attempt to grab the deprecated value if unsuccessful.
-        """
-        val = cls._get_global_config_value(
-            environment_variable=primary_environment_variable,
-            conf_file_section=conf_file_section,
-            conf_file_option=conf_file_option,
-        )
-        if val:
-            return val
-        return cls._get_global_config_value(
-            environment_variable=deprecated_environment_variable,
-            conf_file_section=conf_file_section,
-            conf_file_option=conf_file_option,
-        )
 
     @override
     def _init_datasources(self) -> None:

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -28,7 +28,6 @@ import requests
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.configuration import AbstractConfig  # noqa: TCH001
 from great_expectations.core.http import create_session
-from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
@@ -277,7 +276,7 @@ class CloudMigrator:
         # 20220928 - Chetan - We want to use the static lookup tables in GXCloudStoreBackend
         # to ensure the appropriate URL and payload shape. This logic should be moved to
         # a more central location.
-        resource_type = GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT
+        resource_type = "expectation_validation_result"
         resource_name = GXCloudStoreBackend.RESOURCE_PLURALITY_LOOKUP_DICT[resource_type]
         attributes_key = GXCloudStoreBackend.PAYLOAD_ATTRIBUTES_KEYS[resource_type]
 

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -278,7 +278,7 @@ class CloudMigrator:
         # a more central location.
         resource_type = "expectation_validation_result"
         resource_name = GXCloudStoreBackend.RESOURCE_PLURALITY_LOOKUP_DICT[resource_type]
-        attributes_key = GXCloudStoreBackend.PAYLOAD_ATTRIBUTES_KEYS[resource_type]
+        attributes_key = GXCloudStoreBackend.PAYLOAD_ATTRIBUTES_KEYS[resource_type]  # type: ignore[index]
 
         unsuccessful_validations = {}
 

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -75,15 +75,12 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         GXCloudRESTResource.DATA_CONTEXT: "data_context_config",
         GXCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
         GXCloudRESTResource.EXPECTATION_SUITE: "suite",
-        GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "result",
-        GXCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_doc",
         GXCloudRESTResource.VALIDATION_RESULT: "result",
         GXCloudRESTResource.VALIDATION_DEFINITION: "validation_definition",
     }
 
     ALLOWED_SET_KWARGS_BY_RESOURCE_TYPE: Dict[GXCloudRESTResource, Set[str]] = {
         GXCloudRESTResource.EXPECTATION_SUITE: {"clause_id"},
-        GXCloudRESTResource.RENDERED_DATA_DOC: {"source_type", "source_id"},
         GXCloudRESTResource.VALIDATION_RESULT: {
             "checkpoint_id",
             "expectation_suite_id",
@@ -92,17 +89,13 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     RESOURCE_PLURALITY_LOOKUP_DICT: bidict = bidict(  # type: ignore[misc] # Keywords must be str
         **{  # type: ignore[arg-type]
-            GXCloudRESTResource.BATCH: "batches",
             GXCloudRESTResource.CHECKPOINT: "checkpoints",
+            GXCloudRESTResource.DATASOURCE: "datasources",
             GXCloudRESTResource.DATA_ASSET: "data_assets",
             GXCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
-            GXCloudRESTResource.DATASOURCE: "datasources",
-            GXCloudRESTResource.EXPECTATION: "expectations",
             GXCloudRESTResource.EXPECTATION_SUITE: "expectation_suites",
-            GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "expectation_validation_results",
-            GXCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_docs",
-            GXCloudRESTResource.VALIDATION_RESULT: "validation_results",
             GXCloudRESTResource.VALIDATION_DEFINITION: "validation_definitions",
+            GXCloudRESTResource.VALIDATION_RESULT: "validation_results",
         }
     )
 
@@ -112,10 +105,8 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         GXCloudRESTResource.DATA_CONTEXT: EndpointVersion.V0,
         GXCloudRESTResource.DATA_CONTEXT_VARIABLES: EndpointVersion.V0,
         GXCloudRESTResource.EXPECTATION_SUITE: EndpointVersion.V1,
-        GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT: EndpointVersion.V0,
-        GXCloudRESTResource.RENDERED_DATA_DOC: EndpointVersion.V0,
-        GXCloudRESTResource.VALIDATION_RESULT: EndpointVersion.V0,
         GXCloudRESTResource.VALIDATION_DEFINITION: EndpointVersion.V0,
+        GXCloudRESTResource.VALIDATION_RESULT: EndpointVersion.V0,
     }
     # we want to support looking up EndpointVersion from either GXCloudRESTResource
     # or a pluralized version of it, as defined by RESOURCE_PLURALITY_LOOKUP_DICT.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2159,15 +2159,12 @@ def ge_cloud_config_e2e() -> GXCloudConfig:
 
     base_url = env_vars.get(
         GXCloudEnvironmentVariable.BASE_URL,
-        env_vars.get(GXCloudEnvironmentVariable._OLD_BASE_URL),
     )
     organization_id = env_vars.get(
         GXCloudEnvironmentVariable.ORGANIZATION_ID,
-        env_vars.get(GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID),
     )
     access_token = env_vars.get(
         GXCloudEnvironmentVariable.ACCESS_TOKEN,
-        env_vars.get(GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN),
     )
     cloud_config = GXCloudConfig(
         base_url=base_url,  # type: ignore[arg-type]

--- a/tests/core/test_config_provider.py
+++ b/tests/core/test_config_provider.py
@@ -27,9 +27,6 @@ organization_id = "0dcf5ce1-806f-4199-9e69-e24dfba5e62a"
                 GXCloudEnvironmentVariable.BASE_URL: base_url,
                 GXCloudEnvironmentVariable.ACCESS_TOKEN: access_token,
                 GXCloudEnvironmentVariable.ORGANIZATION_ID: organization_id,
-                GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,
-                GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,
-                GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID: organization_id,
             },
             id="include_org_id",
         ),
@@ -38,8 +35,6 @@ organization_id = "0dcf5ce1-806f-4199-9e69-e24dfba5e62a"
             {
                 GXCloudEnvironmentVariable.BASE_URL: base_url,
                 GXCloudEnvironmentVariable.ACCESS_TOKEN: access_token,
-                GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,
-                GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,
             },
             id="omit_org_id",
         ),


### PR DESCRIPTION
A lot of these are unnecessary and create a false image regarding what the GXCloudStoreBackend can do.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
