### PR TITLE
[FEATURE] Add serialization logic to Expectation models

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -295,7 +295,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     description: ClassVar[Union[str, None]] = None
 
     catch_exceptions: bool = False
-    rendered_content: Optional[List[RenderedAtomicContent]] = Field(default=None, exclude=True)
+    rendered_content: Optional[List[RenderedAtomicContent]] = None
 
     version: ClassVar[str] = ge_version
     domain_keys: ClassVar[Tuple[str, ...]] = ()

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -296,7 +296,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                 .lstrip()
                 .split(" ")
             )
-            join_multi_caps_and_nums = []
+            join_multi_caps_and_nums: list[str] = []
             for idx, token in enumerate(split_between_caps_and_nums):
                 if idx > 0:
                     consecutive_caps = (

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -286,7 +286,38 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[Expectation]) -> None:
             # transforms model titles (e.g. "ExpectColumnToExist" -> "Expect Column To Exist")
-            schema["title"] = re.sub(r"(\w)([A-Z])", r"\1 \2", schema.get("title", ""))
+            split_between_caps_and_nums = (
+                "".join(
+                    [
+                        " " + c if (c.isdigit() or c == c.upper()) else c
+                        for c in schema.get("title", "")
+                    ]
+                )
+                .lstrip()
+                .split(" ")
+            )
+            join_multi_caps_and_nums = []
+            for idx, token in enumerate(split_between_caps_and_nums):
+                if idx > 0:
+                    consecutive_caps = (
+                        token.upper() == token
+                        and split_between_caps_and_nums[idx - 1].upper()
+                        == split_between_caps_and_nums[idx - 1]
+                    )
+                    consecutive_digits = (
+                        token.isdigit() and split_between_caps_and_nums[idx - 1].isdigit()
+                    )
+                    if (
+                        len(token) == 1
+                        and len(split_between_caps_and_nums[idx - 1]) == 1
+                        and (consecutive_caps or consecutive_digits)
+                    ):
+                        join_multi_caps_and_nums[-1] = join_multi_caps_and_nums[-1] + token
+                    else:
+                        join_multi_caps_and_nums.append(token)
+                else:
+                    join_multi_caps_and_nums.append(token)
+            schema["title"] = " ".join(join_multi_caps_and_nums)
 
     id: Union[str, None] = None
     meta: Union[dict, None] = None

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -295,7 +295,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     description: ClassVar[Union[str, None]] = None
 
     catch_exceptions: bool = False
-    rendered_content: ClassVar[Optional[List[RenderedAtomicContent]]] = None
+    rendered_content: Optional[List[RenderedAtomicContent]] = Field(default=None, exclude=True)
 
     version: ClassVar[str] = ge_version
     domain_keys: ClassVar[Tuple[str, ...]] = ()

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -283,6 +283,11 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         extra = pydantic.Extra.forbid
         json_encoders = {RenderedAtomicContent: lambda data: data.to_json_dict()}
 
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], model: Type[Expectation]) -> None:
+            # transforms model titles (e.g. "ExpectColumnToExist" -> "Expect Column To Exist")
+            schema["title"] = re.sub(r"(\w)([A-Z])", r"\1 \2", schema.get("title"))
+
     id: Union[str, None] = None
     meta: Union[dict, None] = None
     notes: Union[str, List[str], None] = None
@@ -290,7 +295,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     description: ClassVar[Union[str, None]] = None
 
     catch_exceptions: bool = False
-    rendered_content: Optional[List[RenderedAtomicContent]] = None
+    rendered_content: ClassVar[Optional[List[RenderedAtomicContent]]] = None
 
     version: ClassVar[str] = ge_version
     domain_keys: ClassVar[Tuple[str, ...]] = ()

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -286,7 +286,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[Expectation]) -> None:
             # transforms model titles (e.g. "ExpectColumnToExist" -> "Expect Column To Exist")
-            schema["title"] = re.sub(r"(\w)([A-Z])", r"\1 \2", schema.get("title"))
+            schema["title"] = re.sub(r"(\w)([A-Z])", r"\1 \2", schema.get("title", ""))
 
     id: Union[str, None] = None
     meta: Union[dict, None] = None

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -926,7 +926,8 @@ class RenderedAtomicContent(RenderedContent):
     @classmethod
     def validate(cls, v):
         if not isinstance(v, RenderedAtomicContent):
-            raise TypeError(f"Invalid type {type(v)} for RenderedAtomicContent")  # noqa: TRY003
+            invalid_type = f"Invalid type {type(v)} for RenderedAtomicContent"
+            raise TypeError(invalid_type)
         return v
 
     @classmethod

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -926,8 +926,8 @@ class RenderedAtomicContent(RenderedContent):
     @classmethod
     def validate(cls, v):
         if not isinstance(v, RenderedAtomicContent):
-            invalid_type = f"Invalid type {type(v)} for RenderedAtomicContent"
-            raise TypeError(invalid_type)
+            invalid_type_msg = f"Invalid type {type(v)} for RenderedAtomicContent"
+            raise TypeError(invalid_type_msg)
         return v
 
     @classmethod

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -4,7 +4,7 @@ import json
 from copy import deepcopy
 from enum import Enum
 from string import Template as pTemplate
-from typing import TYPE_CHECKING, Final, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Final, List, Optional, Union
 
 from marshmallow import Schema, fields, post_dump, post_load
 
@@ -15,6 +15,7 @@ from great_expectations.render.exceptions import InvalidRenderedContentError
 from great_expectations.types import DictDot
 
 if TYPE_CHECKING:
+    from great_expectations.compatibility.pydantic import fields as pydantic_fields
     from great_expectations.render.renderer_configuration import (
         MetaNotes,
         RendererTableValue,
@@ -917,6 +918,22 @@ class RenderedAtomicContent(RenderedContent):
     @override
     def __str__(self) -> str:
         return json.dumps(self.to_json_dict(), indent=2)
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, RenderedAtomicContent):
+            raise TypeError(f"Invalid type {type(v)} for RenderedAtomicContent")  # noqa: TRY003
+        return v
+
+    @classmethod
+    def __modify_schema__(
+        cls, field_schema: dict[str, Any], field: pydantic_fields.ModelField | None
+    ):
+        field_schema.update(type="object")
 
     @public_api
     @override

--- a/tests/expectations/core/test_core_model_serialization.py
+++ b/tests/expectations/core/test_core_model_serialization.py
@@ -18,7 +18,7 @@ def test_all_core_model_schemas_are_serializable():
 
 
 @pytest.mark.unit
-def test_title_serialization():
+def test_schema_title():
     expectation = core.ExpectColumnValuesToNotBeNull
     title = expectation.schema()["title"]
     assert title == "Expect Column Values To Not Be Null"

--- a/tests/expectations/core/test_core_model_serialization.py
+++ b/tests/expectations/core/test_core_model_serialization.py
@@ -1,13 +1,15 @@
 from great_expectations.expectations import core
-from great_expectations.expectations.expectation import Expectation
+from great_expectations.expectations.expectation import MetaExpectation
 
 
 def test_all_core_models_are_serializable():
     all_models = [
         expectation
-        for name, expectation in core.__dict__.items()
-        if isinstance(expectation, Expectation)
+        for expectation in core.__dict__.values()
+        if isinstance(expectation, MetaExpectation)
     ]
+    # are they still there?
+    assert len(all_models) > 50
     for model in all_models:
         model.schema_json()
 

--- a/tests/expectations/core/test_core_model_serialization.py
+++ b/tests/expectations/core/test_core_model_serialization.py
@@ -1,7 +1,7 @@
 import pytest
 
 from great_expectations.expectations import core
-from great_expectations.expectations.expectation import MetaExpectation
+from great_expectations.expectations.expectation import Expectation, MetaExpectation
 
 
 @pytest.mark.unit
@@ -17,8 +17,25 @@ def test_all_core_model_schemas_are_serializable():
         model.schema_json()
 
 
+class ExpectJSONToBeFoo(Expectation): ...
+
+
+class Expect123ToBeNumbers(Expectation): ...
+
+
+class Expect_ToBeAToken(Expectation): ...
+
+
 @pytest.mark.unit
-def test_schema_title():
-    expectation = core.ExpectColumnValuesToNotBeNull
-    title = expectation.schema()["title"]
-    assert title == "Expect Column Values To Not Be Null"
+@pytest.mark.parametrize(
+    ("expectation", "expected_title"),
+    (
+        (core.ExpectColumnValuesToNotBeNull, "Expect Column Values To Not Be Null"),
+        (ExpectJSONToBeFoo, "Expect JSON To Be Foo"),
+        (Expect123ToBeNumbers, "Expect 123 To Be Numbers"),
+        (Expect_ToBeAToken, "Expect _ To Be A Token"),
+    ),
+)
+def test_schema_title(expectation, expected_title):
+    actual_title = expectation.schema()["title"]
+    assert actual_title == expected_title

--- a/tests/expectations/core/test_core_model_serialization.py
+++ b/tests/expectations/core/test_core_model_serialization.py
@@ -5,7 +5,7 @@ from great_expectations.expectations.expectation import MetaExpectation
 
 
 @pytest.mark.unit
-def test_all_core_models_are_serializable():
+def test_all_core_model_schemas_are_serializable():
     all_models = [
         expectation
         for expectation in core.__dict__.values()

--- a/tests/expectations/core/test_core_model_serialization.py
+++ b/tests/expectations/core/test_core_model_serialization.py
@@ -1,7 +1,10 @@
+import pytest
+
 from great_expectations.expectations import core
 from great_expectations.expectations.expectation import MetaExpectation
 
 
+@pytest.mark.unit
 def test_all_core_models_are_serializable():
     all_models = [
         expectation
@@ -14,6 +17,7 @@ def test_all_core_models_are_serializable():
         model.schema_json()
 
 
+@pytest.mark.unit
 def test_title_serialization():
     expectation = core.ExpectColumnValuesToNotBeNull
     title = expectation.schema()["title"]

--- a/tests/expectations/core/test_core_model_serialization.py
+++ b/tests/expectations/core/test_core_model_serialization.py
@@ -1,0 +1,18 @@
+from great_expectations.expectations import core
+from great_expectations.expectations.expectation import Expectation
+
+
+def test_all_core_models_are_serializable():
+    all_models = [
+        expectation
+        for name, expectation in core.__dict__.items()
+        if isinstance(expectation, Expectation)
+    ]
+    for model in all_models:
+        model.schema_json()
+
+
+def test_title_serialization():
+    expectation = core.ExpectColumnValuesToNotBeNull
+    title = expectation.schema()["title"]
+    assert title == "Expect Column Values To Not Be Null"


### PR DESCRIPTION
1. Add serialization logic to Expectation models
2. Apply spacing to model titles

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
