### PR TITLE
[BUGFIX] Show FDS Asset name in DataDocs

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -3880,6 +3880,8 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         self,
         resource_identifier: ExpectationSuiteIdentifier
         | ValidationResultIdentifier
+        | GXCloudIdentifier
+        | str
         | None = None,
         site_name: Optional[str] = None,
         only_if_exists: bool = True,

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4801,7 +4801,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         validations_store_name=None,
         failed_only=False,
         include_rendered_content=None,
-    ) -> ExpectationValidationResult:
+    ) -> ExpectationValidationResult | dict:
         """Get validation results from a configured store.
 
         Args:
@@ -4839,7 +4839,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             # run_id_set = set([key.run_id for key in filtered_key_list])
             if len(filtered_key_list) == 0:
                 logger.warning("No valid run_id values found.")
-                return {}  # type: ignore[return-value]
+                return {}
 
             filtered_key_list = sorted(filtered_key_list, key=lambda x: x.run_id)
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -169,7 +169,9 @@ if TYPE_CHECKING:
     )
     from great_expectations.data_context.store.validations_store import ValidationsStore
     from great_expectations.data_context.types.resource_identifiers import (
+        ExpectationSuiteIdentifier,
         GXCloudIdentifier,
+        ValidationResultIdentifier,
     )
     from great_expectations.datasource import LegacyDatasource
     from great_expectations.datasource.fluent.interfaces import (
@@ -3875,9 +3877,11 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
 
     def get_docs_sites_urls(
         self,
-        resource_identifier=None,
+        resource_identifier: ExpectationSuiteIdentifier
+        | ValidationResultIdentifier
+        | None = None,
         site_name: Optional[str] = None,
-        only_if_exists=True,
+        only_if_exists: bool = True,
         site_names: Optional[List[str]] = None,
     ) -> List[Dict[str, str]]:
         """
@@ -5272,11 +5276,13 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
     @public_api
     def build_data_docs(
         self,
-        site_names=None,
-        resource_identifiers=None,
-        dry_run=False,
+        site_names: list[str] | None = None,
+        resource_identifiers: list[ExpectationSuiteIdentifier]
+        | list[ValidationResultIdentifier]
+        | None = None,
+        dry_run: bool = False,
         build_index: bool = True,
-    ):
+    ) -> dict[str, str]:
         """Build Data Docs for your project.
 
         --Documentation--

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -152,6 +152,9 @@ if TYPE_CHECKING:
     from great_expectations.core.expectation_configuration import (
         ExpectationConfiguration,
     )
+    from great_expectations.core.expectation_validation_result import (
+        ExpectationValidationResult,
+    )
     from great_expectations.data_context.data_context_variables import (
         DataContextVariables,
     )
@@ -169,9 +172,7 @@ if TYPE_CHECKING:
     )
     from great_expectations.data_context.store.validations_store import ValidationsStore
     from great_expectations.data_context.types.resource_identifiers import (
-        ExpectationSuiteIdentifier,
         GXCloudIdentifier,
-        ValidationResultIdentifier,
     )
     from great_expectations.datasource import LegacyDatasource
     from great_expectations.datasource.fluent.interfaces import (
@@ -4798,7 +4799,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         validations_store_name=None,
         failed_only=False,
         include_rendered_content=None,
-    ):
+    ) -> ExpectationValidationResult:
         """Get validation results from a configured store.
 
         Args:

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4839,7 +4839,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             # run_id_set = set([key.run_id for key in filtered_key_list])
             if len(filtered_key_list) == 0:
                 logger.warning("No valid run_id values found.")
-                return {}
+                return {}  # type: ignore[return-value]
 
             filtered_key_list = sorted(filtered_key_list, key=lambda x: x.run_id)
 

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import logging
 import os
 import pathlib
 import traceback
 import urllib
 from collections import OrderedDict
-from typing import Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from great_expectations import exceptions
 from great_expectations.core import ExpectationSuite
@@ -22,6 +24,9 @@ from great_expectations.data_context.types.resource_identifiers import (
 )
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.render.util import resource_key_passes_run_name_filter
+
+if TYPE_CHECKING:
+    from great_expectations.data_context import AbstractDataContext
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +119,7 @@ class SiteBuilder:
 
     def __init__(  # noqa: C901, PLR0912, PLR0913
         self,
-        data_context,
+        data_context: AbstractDataContext,
         store_backend,
         site_name=None,
         site_index_builder=None,
@@ -347,7 +352,7 @@ class DefaultSiteSectionBuilder:
     def __init__(  # noqa: PLR0913
         self,
         name,
-        data_context,
+        data_context: AbstractDataContext,
         target_store,
         source_store_name,
         custom_styles_directory=None,
@@ -516,7 +521,7 @@ class DefaultSiteIndexBuilder:
         self,
         name,
         site_name,
-        data_context,
+        data_context: AbstractDataContext,
         target_store,
         site_section_builders_config,
         custom_styles_directory=None,

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -952,6 +952,14 @@ diagnose and repair the underlying issue.  Detailed information follows:
                     batch_kwargs = validation.meta.get("batch_kwargs", {})
                     batch_spec = validation.meta.get("batch_spec", {})
 
+                    asset_name = batch_kwargs.get("data_asset_name") or batch_spec.get(
+                        "data_asset_name"
+                    )
+                    # FDS does not store data_asset_name in batch_kwargs or batch_spec
+                    active_batch = validation.meta.get("active_batch_definition", {})
+                    if not asset_name and active_batch:
+                        asset_name = active_batch.get("data_asset_name")
+
                     self.add_resource_info_to_index_links_dict(
                         index_links_dict=index_links_dict,
                         expectation_suite_name=validation_result_key.expectation_suite_identifier.expectation_suite_name,
@@ -961,8 +969,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                         validation_success=validation_success,
                         run_time=validation_result_key.run_id.run_time,
                         run_name=validation_result_key.run_id.run_name,
-                        asset_name=batch_kwargs.get("data_asset_name")
-                        or batch_spec.get("data_asset_name"),
+                        asset_name=asset_name,
                         batch_kwargs=batch_kwargs,
                         batch_spec=batch_spec,
                     )

--- a/tests/render/conftest.py
+++ b/tests/render/conftest.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import json
 import os
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,9 +13,14 @@ from great_expectations.data_context.data_context.file_data_context import (
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.self_check.util import expectationSuiteValidationResultSchema
 
+if TYPE_CHECKING:
+    from great_expectations.core.expectation_validation_result import (
+        ExpectationSuiteValidationResult,
+    )
+
 
 @pytest.fixture(scope="module")
-def empty_data_context_module_scoped(tmp_path_factory):
+def empty_data_context_module_scoped(tmp_path_factory) -> FileDataContext:
     # Re-enable GE_USAGE_STATS
     project_path = str(tmp_path_factory.mktemp("empty_data_context"))
     context = gx.data_context.FileDataContext.create(project_path)
@@ -23,7 +31,7 @@ def empty_data_context_module_scoped(tmp_path_factory):
 
 
 @pytest.fixture
-def titanic_profiled_name_column_evrs():
+def titanic_profiled_name_column_evrs() -> ExpectationSuiteValidationResult:
     # This is a janky way to fetch expectations matching a specific name from an EVR suite.
     # TODO: It will no longer be necessary once we implement ValidationResultSuite._group_evrs_by_column
     from great_expectations.render.renderer.renderer import Renderer

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -594,7 +594,6 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_start(
     )
 
 
-@pytest.mark.big
 def test_asset_name_is_part_of_resource_info_index(mocker: MockerFixture):
     """
     DefaultSiteIndexBuilder.add_resource_info_to_index_links_dict is what supplies the

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -589,3 +589,35 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_start(
         rendered_validation_results
         == ValidationResultsPageRenderer_render_with_run_info_at_start
     )
+
+
+@pytest.mark.big
+def test_fds_asset_name_is_rendered_in_data_doc():
+    import great_expectations as gx
+
+    context = gx.get_context(mode="ephemeral")
+
+    validator = context.sources.pandas_default.read_csv(
+        "https://raw.githubusercontent.com/great-expectations/gx_tutorials/main/data/yellow_tripdata_sample_2019-01.csv",
+        asset_name="my_asset",
+    )
+
+    validator.expect_column_values_to_not_be_null("pickup_datetime")
+    validator.expect_column_values_to_be_between(
+        "passenger_count", min_value=1, max_value=6
+    )
+    validator.save_expectation_suite(discard_failed_expectations=False)
+
+    checkpoint = context.add_or_update_checkpoint(
+        name="my_quickstart_checkpoint",
+        validator=validator,
+    )
+
+    checkpoint_result = checkpoint.run()
+    data_asset_names = checkpoint_result.list_data_asset_names()
+    assert "my_asset" in data_asset_names
+    print(f"checkpoint_result: {pf(checkpoint_result, depth=1)}")
+
+    assert False
+    # TODO: don't actually open it just look at the results
+    context.view_validation_result(checkpoint_result)

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import json
 import re
+from typing import TYPE_CHECKING
 
 import mistune
 import pytest
 
-from great_expectations import DataContext
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.data_context.util import file_relative_path
@@ -16,6 +18,12 @@ from great_expectations.render.renderer import (
 )
 from great_expectations.render.renderer_configuration import MetaNotesFormat
 
+if TYPE_CHECKING:
+    from great_expectations.core.expectation_validation_result import (
+        ExpectationValidationResult,
+    )
+    from great_expectations.data_context import AbstractDataContext
+
 # module level markers
 pytestmark = pytest.mark.filesystem
 
@@ -23,7 +31,7 @@ pytestmark = pytest.mark.filesystem
 def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
     empty_data_context,
 ):
-    context: DataContext = empty_data_context
+    context: AbstractDataContext = empty_data_context
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
             expectation_suite_name="test", meta={"notes": "*hi*"}, data_context=context
@@ -139,9 +147,9 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
 
 
 def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_suite_notes(
-    empty_data_context,
+    empty_data_context: AbstractDataContext,
 ):
-    context: ExpectationSuite = empty_data_context
+    context: AbstractDataContext = empty_data_context
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
             expectation_suite_name="test",
@@ -206,14 +214,16 @@ def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_
     )
 
 
-def test_ProfilingResultsPageRenderer(titanic_profiled_evrs_1):
+def test_ProfilingResultsPageRenderer(
+    titanic_profiled_evrs_1: ExpectationValidationResult,
+):
     document = ProfilingResultsPageRenderer().render(titanic_profiled_evrs_1)
     assert isinstance(document, RenderedDocumentContent)
     assert len(document.sections) == 8
 
 
 def test_ValidationResultsPageRenderer_render_validation_header(
-    titanic_profiled_evrs_1,
+    titanic_profiled_evrs_1: ExpectationValidationResult,
 ):
     validation_header = ValidationResultsPageRenderer._render_validation_header(
         titanic_profiled_evrs_1
@@ -269,7 +279,9 @@ def test_ValidationResultsPageRenderer_render_validation_header(
     assert validation_header == expected_validation_header
 
 
-def test_ValidationResultsPageRenderer_render_validation_info(titanic_profiled_evrs_1):
+def test_ValidationResultsPageRenderer_render_validation_info(
+    titanic_profiled_evrs_1: ExpectationValidationResult,
+):
     validation_info = ValidationResultsPageRenderer._render_validation_info(
         titanic_profiled_evrs_1
     ).to_json_dict()
@@ -532,7 +544,7 @@ def ValidationResultsPageRenderer_render_with_run_info_at_start():
 
 
 def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_end(
-    titanic_profiled_evrs_1,
+    titanic_profiled_evrs_1: ExpectationValidationResult,
     ValidationResultsPageRenderer_render_with_run_info_at_end,
 ):
     validation_results_page_renderer = ValidationResultsPageRenderer(
@@ -556,7 +568,7 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_end(
 
 
 def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_start(
-    titanic_profiled_evrs_1,
+    titanic_profiled_evrs_1: ExpectationValidationResult,
     ValidationResultsPageRenderer_render_with_run_info_at_start,
 ):
     validation_results_page_renderer = ValidationResultsPageRenderer(

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -619,9 +619,11 @@ def checkpoint_results(request: pytest.FixtureRequest) -> CheckpointResult:
         )
 
         checkpoint_result = checkpoint.run()
+        assert len(re.findall("my_asset", str(checkpoint_result))) == 6
     else:
         pass
 
+    context.view_validation_result(checkpoint_result)
     return checkpoint_result
 
 
@@ -630,7 +632,3 @@ def test_asset_name_is_rendered_in_data_doc(checkpoint_results: CheckpointResult
     data_asset_names = checkpoint_results.list_data_asset_names()
     assert "my_asset" in data_asset_names
     print(f"checkpoint_result: {pf(checkpoint_results, depth=1)}")
-
-    assert False
-    # TODO: don't actually open it just look at the results
-    context.view_validation_result(checkpoint_results)


### PR DESCRIPTION
Fix missing `Asset Name` for Fluent Datasources in the Datadocs Home/index page.

See issue below for detailed description of the problem.
- https://github.com/great-expectations/great_expectations/issues/8790


Also updates some related type annotations.


### Before

![image](https://github.com/great-expectations/great_expectations/assets/13108583/575f4d63-2453-4a0f-b2af-14639e5adb3a)

### After

![image](https://github.com/great-expectations/great_expectations/assets/13108583/1dffb111-5a49-4f45-93a5-6ef9a241f8d9)




