### PR TITLE
[DOCS] Clarify SQL Expectation Support in GX Cloud Docs

### DIFF
--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -8,6 +8,12 @@ An Expectation is a verifiable assertion about your data. They make implicit ass
 
 <!-- [//]: # (TODO: To learn more about Expectations, see Expectation.) -->
 
+:::info Custom SQL Query Expectations
+
+Support for custom SQL query Expectations is currently unavailable in GX Cloud. To create custom SQL query Expectations, see [Customize an Expectation Class](/core/create_expectations/expectations/manage_expectations.md#customize-an-expectation-class).
+
+:::
+
 ## Prerequisites
 
 - You have deployed the GX Agent. See [Deploy the GX Agent](../deploy_gx_agent.md).

--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -10,7 +10,7 @@ An Expectation is a verifiable assertion about your data. They make implicit ass
 
 :::info Custom SQL Query Expectations
 
-Support for custom SQL query Expectations is currently unavailable in GX Cloud. To create custom SQL query Expectations, see [Customize an Expectation Class](/core/create_expectations/expectations/manage_expectations.md#customize-an-expectation-class).
+To create custom SQL query Expectations, you'll need to use the GX API. See [Customize an Expectation Class](/core/create_expectations/expectations/manage_expectations.md#customize-an-expectation-class).
 
 :::
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
@@ -8,7 +8,7 @@ An Expectation is a verifiable assertion about your data. They make implicit ass
 
 :::info Custom SQL Query Expectations
 
-Support for custom SQL query Expectations is currently unavailable in GX Cloud. To create custom SQL query Expectations, see [Create a Custom Query Expectation](/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations.md).
+To create custom SQL query Expectations, you'll need to use the GX API. See [Create a Custom Query Expectation](/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations.md).
 
 :::
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
@@ -8,7 +8,7 @@ An Expectation is a verifiable assertion about your data. They make implicit ass
 
 :::info Custom SQL Query Expectations
 
-Support for custom SQL query Expectations is currently unavailable in GX Cloud. To create custom SQL query Expectations, see [Create a Custom Query Expectation](/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations/).
+Support for custom SQL query Expectations is currently unavailable in GX Cloud. To create custom SQL query Expectations, see [Create a Custom Query Expectation](/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations.md).
 
 :::
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
@@ -6,6 +6,12 @@ description: Create and manage Expectations in GX Cloud.
 
 An Expectation is a verifiable assertion about your data. They make implicit assumptions about your data explicit, and they provide a flexible, declarative language for describing expected behavior. They can help you better understand your data and help you improve data quality. An Expectation Suite contains multiple Expectations.
 
+:::info Custom SQL Query Expectations
+
+Support for custom SQL query Expectations is currently unavailable in GX Cloud. To create custom SQL query Expectations, see [Create a Custom Query Expectation](/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations/).
+
+:::
+
 To learn more about Expectations, see [Expectation](/reference/learn/terms/expectation.md).
 
 ## Prerequisites


### PR DESCRIPTION
@tannerbeam requested the addition of a statement that defines support for SQL Expectations to [Manage Expectations](https://docs.greatexpectations.io/docs/cloud/expectations/manage_expectations). This PR implements this change.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated
