### PR TITLE
[MAINTENANCE] Ensure that validation definitions and checkpoints save before running

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -146,7 +146,7 @@ class Checkpoint(BaseModel):
         run_id: RunIdentifier | None = None,
     ) -> CheckpointResult:
         if not self.id:
-            self._save_before_run()
+            self._add_to_store()
 
         run_id = run_id or RunIdentifier(run_time=dt.datetime.now(dt.timezone.utc))
         run_results = self._run_validation_definitions(
@@ -252,7 +252,12 @@ class Checkpoint(BaseModel):
 
         store.update(key=key, value=self)
 
-    def _save_before_run(self) -> None:
+    def _add_to_store(self) -> None:
+        """This is used to persist a checkpoint before we run it.
+
+        We need to persist a checkpoint before it can be run. If user calls runs but hasn't
+        persisted it we add it for them.
+        """
         from great_expectations import project_manager
 
         store = project_manager.get_checkpoints_store()

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -145,6 +145,9 @@ class Checkpoint(BaseModel):
         expectation_parameters: Dict[str, Any] | None = None,
         run_id: RunIdentifier | None = None,
     ) -> CheckpointResult:
+        if not self.id:
+            self.save()
+
         run_id = run_id or RunIdentifier(run_time=dt.datetime.now(dt.timezone.utc))
         run_results = self._run_validation_definitions(
             batch_parameters=batch_parameters,
@@ -247,7 +250,10 @@ class Checkpoint(BaseModel):
         store = project_manager.get_checkpoints_store()
         key = store.get_key(name=self.name, id=self.id)
 
-        store.update(key=key, value=self)
+        if self.id:
+            store.update(key=key, value=self)
+        else:
+            store.add(key=key, value=self)
 
 
 class CheckpointResult(BaseModel):

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -153,11 +153,7 @@ class Checkpoint(BaseModel):
             run_id=run_id,
         )
 
-        checkpoint_result = CheckpointResult(
-            run_id=run_id,
-            run_results=run_results,
-            checkpoint_config=self,
-        )
+        checkpoint_result = self._construct_result(run_id=run_id, run_results=run_results)
         self._run_actions(checkpoint_result=checkpoint_result)
 
         return checkpoint_result
@@ -198,6 +194,20 @@ class Checkpoint(BaseModel):
             ),
             run_id=run_id,
             batch_identifier=batch_identifier,
+        )
+
+    def _construct_result(
+        self,
+        run_id: RunIdentifier,
+        run_results: Dict[ValidationResultIdentifier, ExpectationSuiteValidationResult],
+    ) -> CheckpointResult:
+        for result in run_results.values():
+            result.meta["checkpoint_id"] = self.id
+
+        return CheckpointResult(
+            run_id=run_id,
+            run_results=run_results,
+            checkpoint_config=self,
         )
 
     def _run_actions(

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -146,7 +146,7 @@ class Checkpoint(BaseModel):
         run_id: RunIdentifier | None = None,
     ) -> CheckpointResult:
         if not self.id:
-            self.save()
+            self._save_before_run()
 
         run_id = run_id or RunIdentifier(run_time=dt.datetime.now(dt.timezone.utc))
         run_results = self._run_validation_definitions(
@@ -250,10 +250,15 @@ class Checkpoint(BaseModel):
         store = project_manager.get_checkpoints_store()
         key = store.get_key(name=self.name, id=self.id)
 
-        if self.id:
-            store.update(key=key, value=self)
-        else:
-            store.add(key=key, value=self)
+        store.update(key=key, value=self)
+
+    def _save_before_run(self) -> None:
+        from great_expectations import project_manager
+
+        store = project_manager.get_checkpoints_store()
+        key = store.get_key(name=self.name, id=self.id)
+
+        store.add(key=key, value=self)
 
 
 class CheckpointResult(BaseModel):

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -199,7 +199,7 @@ class ValidationDefinition(BaseModel):
         run_id: RunIdentifier | None = None,
     ) -> ExpectationSuiteValidationResult:
         if not self.id:
-            self.save()
+            self._save_before_run()
 
         validator = Validator(
             batch_definition=self.batch_definition,
@@ -285,7 +285,12 @@ class ValidationDefinition(BaseModel):
         store = project_manager.get_validation_definition_store()
         key = store.get_key(name=self.name, id=self.id)
 
-        if self.id:
-            store.update(key=key, value=self)
-        else:
-            store.add(key=key, value=self)
+        store.update(key=key, value=self)
+
+    def _save_before_run(self) -> None:
+        from great_expectations import project_manager
+
+        store = project_manager.get_validation_definition_store()
+        key = store.get_key(name=self.name, id=self.id)
+
+        store.add(key=key, value=self)

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -198,6 +198,9 @@ class ValidationDefinition(BaseModel):
         result_format: ResultFormat | dict = ResultFormat.SUMMARY,
         run_id: RunIdentifier | None = None,
     ) -> ExpectationSuiteValidationResult:
+        if not self.id:
+            self.save()
+
         validator = Validator(
             batch_definition=self.batch_definition,
             batch_parameters=batch_parameters,
@@ -274,3 +277,15 @@ class ValidationDefinition(BaseModel):
         self.suite.identifier_bundle()
 
         return _IdentifierBundle(name=self.name, id=self.id)
+
+    @public_api
+    def save(self) -> None:
+        from great_expectations import project_manager
+
+        store = project_manager.get_validation_definition_store()
+        key = store.get_key(name=self.name, id=self.id)
+
+        if self.id:
+            store.update(key=key, value=self)
+        else:
+            store.add(key=key, value=self)

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -199,7 +199,7 @@ class ValidationDefinition(BaseModel):
         run_id: RunIdentifier | None = None,
     ) -> ExpectationSuiteValidationResult:
         if not self.id:
-            self._save_before_run()
+            self._add_to_store()
 
         validator = Validator(
             batch_definition=self.batch_definition,
@@ -287,7 +287,12 @@ class ValidationDefinition(BaseModel):
 
         store.update(key=key, value=self)
 
-    def _save_before_run(self) -> None:
+    def _add_to_store(self) -> None:
+        """This is used to persist a validation_definition before we run it.
+
+        We need to persist a validation_definition before it can be run. If user calls runs but
+        hasn't persisted it we add it for them."""
+
         from great_expectations import project_manager
 
         store = project_manager.get_validation_definition_store()

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -204,6 +204,7 @@ class ValidationDefinition(BaseModel):
             result_format=result_format,
         )
         results = validator.validate_expectation_suite(self.suite, suite_parameters)
+        results.meta["validation_id"] = self.id
 
         # NOTE: We should promote this to a top-level field of the result.
         #       Meta should be reserved for user-defined information.

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -226,9 +226,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 str(response.text),
                 str(jsonError),
             )
-            raise StoreBackendError(
+            raise StoreBackendError(  # noqa: TRY003
                 f"Unable to get object in GX Cloud Store Backend: {jsonError}"
-            ) from jsonError  # noqa: TRY003
+            ) from jsonError
         except requests.HTTPError as http_err:
             raise StoreBackendError(  # noqa: TRY003
                 f"Unable to get object in GX Cloud Store Backend: {get_user_friendly_error_message(http_err)}"  # noqa: E501
@@ -512,9 +512,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ) from timeout_exc
         except Exception as e:
             logger.debug(str(e))
-            raise StoreBackendError(
+            raise StoreBackendError(  # noqa: TRY003
                 f"Unable to delete object in GX Cloud Store Backend: {e!r}"
-            ) from e  # noqa: TRY003
+            ) from e
 
     def _get_one_or_none_from_response_data(
         self,

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -231,6 +231,10 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             raise StoreBackendError(  # noqa: TRY003
                 f"Unable to get object in GX Cloud Store Backend: {get_user_friendly_error_message(http_err)}"  # noqa: E501
             )
+        except requests.ConnectionError as conn_err:
+            raise StoreBackendError(  # noqa: TRY003
+                f"Unable to get object in GX Cloud Store Backend: {conn_err}"
+            )
         except requests.Timeout as timeout_exc:
             logger.exception(timeout_exc)  # noqa: TRY401
             raise StoreBackendTransientError(  # noqa: TRY003

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -226,20 +226,20 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 str(response.text),
                 str(jsonError),
             )
-            raise StoreBackendError(f"Unable to get object in GX Cloud Store Backend: {jsonError}")  # noqa: TRY003
+            raise StoreBackendError(f"Unable to get object in GX Cloud Store Backend: {jsonError}") from jsonError # noqa: TRY003
         except requests.HTTPError as http_err:
             raise StoreBackendError(  # noqa: TRY003
                 f"Unable to get object in GX Cloud Store Backend: {get_user_friendly_error_message(http_err)}"  # noqa: E501
-            )
+            ) from http_err
         except requests.ConnectionError as conn_err:
             raise StoreBackendError(  # noqa: TRY003
                 f"Unable to get object in GX Cloud Store Backend: {conn_err}"
-            )
+            ) from conn_err
         except requests.Timeout as timeout_exc:
             logger.exception(timeout_exc)  # noqa: TRY401
             raise StoreBackendTransientError(  # noqa: TRY003
                 "Unable to get object in GX Cloud Store Backend: This is likely a transient error. Please try again."  # noqa: E501
-            )
+            ) from timeout_exc
 
     @override
     def _move(self) -> None:  # type: ignore[override]
@@ -305,12 +305,12 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         except requests.HTTPError as http_exc:
             raise StoreBackendError(  # noqa: TRY003
                 f"Unable to update object in GX Cloud Store Backend: {get_user_friendly_error_message(http_exc)}"  # noqa: E501
-            )
+            ) from http_exc
         except requests.Timeout as timeout_exc:
             logger.exception(timeout_exc)  # noqa: TRY401
             raise StoreBackendTransientError(  # noqa: TRY003
                 "Unable to update object in GX Cloud Store Backend: This is likely a transient error. Please try again."  # noqa: E501
-            )
+            ) from timeout_exc
         except Exception as e:
             logger.debug(repr(e))
             raise StoreBackendError(  # noqa: TRY003
@@ -399,7 +399,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             logger.exception(timeout_exc)  # noqa: TRY401
             raise StoreBackendTransientError(  # noqa: TRY003
                 "Unable to set object in GX Cloud Store Backend: This is likely a transient error. Please try again."  # noqa: E501
-            )
+            ) from timeout_exc
         except Exception as e:
             logger.debug(str(e))
             raise StoreBackendError(f"Unable to set object in GX Cloud Store Backend: {e}") from e  # noqa: TRY003
@@ -449,7 +449,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             return keys
         except Exception as e:
             logger.debug(str(e))
-            raise StoreBackendError(f"Unable to list keys in GX Cloud Store Backend: {e}")  # noqa: TRY003
+            raise StoreBackendError(f"Unable to list keys in GX Cloud Store Backend: {e}") from e # noqa: TRY003
 
     @override
     def get_url_for_key(  # type: ignore[override]
@@ -502,15 +502,15 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             logger.exception(http_exc)  # noqa: TRY401
             raise StoreBackendError(  # noqa: TRY003
                 f"Unable to delete object in GX Cloud Store Backend: {get_user_friendly_error_message(http_exc)}"  # noqa: E501
-            )
+            ) from http_exc
         except requests.Timeout as timeout_exc:
             logger.exception(timeout_exc)  # noqa: TRY401
             raise StoreBackendTransientError(  # noqa: TRY003
                 "Unable to delete object in GX Cloud Store Backend: This is likely a transient error. Please try again."  # noqa: E501
-            )
+            ) from timeout_exc
         except Exception as e:
             logger.debug(str(e))
-            raise StoreBackendError(f"Unable to delete object in GX Cloud Store Backend: {e!r}")  # noqa: TRY003
+            raise StoreBackendError(f"Unable to delete object in GX Cloud Store Backend: {e!r}") from e # noqa: TRY003
 
     def _get_one_or_none_from_response_data(
         self,
@@ -612,10 +612,10 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         resource_type, _id, _resource_name = key
         try:
             GXCloudRESTResource(resource_type)
-        except ValueError:
+        except ValueError as e:
             raise TypeError(  # noqa: TRY003
                 f"The provided resource_type {resource_type} is not a valid GXCloudRESTResource"
-            )
+            ) from e
 
     @classmethod
     def construct_versioned_url(

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -226,7 +226,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 str(response.text),
                 str(jsonError),
             )
-            raise StoreBackendError(f"Unable to get object in GX Cloud Store Backend: {jsonError}") from jsonError # noqa: TRY003
+            raise StoreBackendError(
+                f"Unable to get object in GX Cloud Store Backend: {jsonError}"
+            ) from jsonError  # noqa: TRY003
         except requests.HTTPError as http_err:
             raise StoreBackendError(  # noqa: TRY003
                 f"Unable to get object in GX Cloud Store Backend: {get_user_friendly_error_message(http_err)}"  # noqa: E501
@@ -449,7 +451,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             return keys
         except Exception as e:
             logger.debug(str(e))
-            raise StoreBackendError(f"Unable to list keys in GX Cloud Store Backend: {e}") from e # noqa: TRY003
+            raise StoreBackendError(f"Unable to list keys in GX Cloud Store Backend: {e}") from e  # noqa: TRY003
 
     @override
     def get_url_for_key(  # type: ignore[override]
@@ -510,7 +512,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ) from timeout_exc
         except Exception as e:
             logger.debug(str(e))
-            raise StoreBackendError(f"Unable to delete object in GX Cloud Store Backend: {e!r}") from e # noqa: TRY003
+            raise StoreBackendError(
+                f"Unable to delete object in GX Cloud Store Backend: {e!r}"
+            ) from e  # noqa: TRY003
 
     def _get_one_or_none_from_response_data(
         self,

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -642,7 +642,7 @@ class TestCheckpointResult:
         }
         assert actual == expected
 
-    def _build_file_backed_checkpoint(self, tmp_path: pathlib.Path):
+    def _build_file_backed_checkpoint(self, tmp_path: pathlib.Path) -> Checkpoint:
         with working_directory(tmp_path):
             context = gx.get_context(mode="file")
 
@@ -745,7 +745,8 @@ class TestCheckpointResult:
     def test_checkpoint_run_adds_requisite_ids(self, tmp_path: pathlib.Path):
         checkpoint = self._build_file_backed_checkpoint(tmp_path)
 
-        # A checkpoint that has not been persisted before running should obtain one during the run
+        # A checkpoint that has not been persisted before running
+        # should be saved during the run
         # This is also true for its nested validation definitions
         assert checkpoint.id is None
         assert checkpoint.validation_definitions[0].id is None

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -678,6 +678,7 @@ class TestCheckpointResult:
         checkpoint = Checkpoint(
             name=self.checkpoint_name, validation_definitions=[validation_definition]
         )
+        checkpoint = context.checkpoints.add(checkpoint)
         result = checkpoint.run()
 
         assert result.success is False
@@ -737,3 +738,15 @@ class TestCheckpointResult:
                 },
             ],
         }
+
+        run_results = tuple(result.run_results.values())
+        assert len(run_results) == 1
+
+        meta = run_results[0].meta
+        assert sorted(meta.keys()) == ["checkpoint_id", "run_id", "validation_id"]
+
+        for identifier in ("checkpoint_id", "validation_id"):
+            try:
+                uuid.UUID(meta[identifier])
+            except ValueError:
+                pytest.fail(f"{meta[identifier]} is not a valid UUID.")

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -68,7 +68,7 @@ def test_checkpoint_save_success(mocker: MockerFixture):
     store_key = context.checkpoint_store.get_key.return_value
     checkpoint.save()
 
-    context.checkpoint_store.add.assert_called_once_with(key=store_key, value=checkpoint)
+    context.checkpoint_store.update.assert_called_once_with(key=store_key, value=checkpoint)
 
 
 @pytest.fixture

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -68,7 +68,7 @@ def test_checkpoint_save_success(mocker: MockerFixture):
     store_key = context.checkpoint_store.get_key.return_value
     checkpoint.save()
 
-    context.checkpoint_store.update.assert_called_once_with(key=store_key, value=checkpoint)
+    context.checkpoint_store.add.assert_called_once_with(key=store_key, value=checkpoint)
 
 
 @pytest.fixture
@@ -486,6 +486,7 @@ class TestCheckpointResult:
         checkpoint = Checkpoint(
             name=self.checkpoint_name, validation_definitions=[validation_definition]
         )
+
         result = checkpoint.run()
 
         run_results = result.run_results
@@ -641,8 +642,7 @@ class TestCheckpointResult:
         }
         assert actual == expected
 
-    @pytest.mark.filesystem
-    def test_checkpoint_run_filesytem_e2e(self, tmp_path: pathlib.Path):
+    def _build_file_backed_checkpoint(self, tmp_path: pathlib.Path):
         with working_directory(tmp_path):
             context = gx.get_context(mode="file")
 
@@ -675,10 +675,12 @@ class TestCheckpointResult:
             name=self.validation_definition_name, data=batch_definition, suite=suite
         )
 
-        checkpoint = Checkpoint(
-            name=self.checkpoint_name, validation_definitions=[validation_definition]
-        )
-        checkpoint = context.checkpoints.add(checkpoint)
+        return Checkpoint(name=self.checkpoint_name, validation_definitions=[validation_definition])
+
+    @pytest.mark.filesystem
+    def test_checkpoint_run_result_shape(self, tmp_path: pathlib.Path):
+        checkpoint = self._build_file_backed_checkpoint(tmp_path)
+
         result = checkpoint.run()
 
         assert result.success is False
@@ -739,14 +741,23 @@ class TestCheckpointResult:
             ],
         }
 
-        run_results = tuple(result.run_results.values())
-        assert len(run_results) == 1
+    @pytest.mark.filesystem
+    def test_checkpoint_run_adds_requisite_ids(self, tmp_path: pathlib.Path):
+        checkpoint = self._build_file_backed_checkpoint(tmp_path)
 
+        # A checkpoint that has not been persisted before running should obtain one during the run
+        # This is also true for its nested validation definitions
+        assert checkpoint.id is None
+        assert checkpoint.validation_definitions[0].id is None
+
+        result = checkpoint.run()
+
+        assert checkpoint.id is not None
+        assert checkpoint.validation_definitions[0].id is not None
+
+        # The meta attribute of each run result should contain the requisite IDs
+        run_results = tuple(result.run_results.values())
         meta = run_results[0].meta
         assert sorted(meta.keys()) == ["checkpoint_id", "run_id", "validation_id"]
-
-        for identifier in ("checkpoint_id", "validation_id"):
-            try:
-                uuid.UUID(meta[identifier])
-            except ValueError:
-                pytest.fail(f"{meta[identifier]} is not a valid UUID.")
+        assert meta["checkpoint_id"] == checkpoint.id
+        assert meta["validation_id"] == checkpoint.validation_definitions[0].id

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -9,6 +9,7 @@ import pytest
 
 import great_expectations as gx
 import great_expectations.expectations as gxe
+from great_expectations import set_context
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.expectation_validation_result import (
@@ -18,6 +19,7 @@ from great_expectations.core.expectation_validation_result import (
 from great_expectations.core.result_format import ResultFormat
 from great_expectations.core.serdes import _IdentifierBundle
 from great_expectations.core.validation_definition import ValidationDefinition
+from great_expectations.data_context.data_context.abstract_data_context import AbstractDataContext
 from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
@@ -654,3 +656,16 @@ def test_identifier_bundle_no_id(validation_definition: ValidationDefinition):
 
     assert actual.dict() == expected
     assert actual.id is not None
+
+
+@pytest.mark.unit
+def test_save_success(mocker: MockerFixture, validation_definition: ValidationDefinition):
+    context = mocker.Mock(spec=AbstractDataContext)
+    set_context(project=context)
+
+    store_key = context.validation_definition_store.get_key.return_value
+    validation_definition.save()
+
+    context.validation_definition_store.add.assert_called_once_with(
+        key=store_key, value=validation_definition
+    )

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -666,6 +666,6 @@ def test_save_success(mocker: MockerFixture, validation_definition: ValidationDe
     store_key = context.validation_definition_store.get_key.return_value
     validation_definition.save()
 
-    context.validation_definition_store.add.assert_called_once_with(
+    context.validation_definition_store.update.assert_called_once_with(
         key=store_key, value=validation_definition
     )

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -242,7 +242,6 @@ class TestValidationRun:
         assert key.batch_identifier == BATCH_ID
         assert value.success is True
 
-    @pytest.mark.xfail  # TODO: Figure out before merging
     @mock.patch.object(ValidationResultsStore, "set")
     @pytest.mark.unit
     def test_persists_validation_results_for_cloud(
@@ -266,7 +265,6 @@ class TestValidationRun:
         assert isinstance(key, GXCloudIdentifier)
         assert value.success is True
 
-    @pytest.mark.xfail  # TODO: Figure out before merging
     @mock.patch.object(ValidationResultsStore, "set")
     @pytest.mark.unit
     def test_cloud_validation_def_creates_rendered_content(

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -179,6 +179,8 @@ class TestValidationRun:
 
         output = validation_definition.run()
 
+        # Ignore meta for purposes of this test
+        output["meta"] = {}
         assert output == ExpectationSuiteValidationResult(
             results=graph_validate_results,
             success=True,
@@ -189,10 +191,23 @@ class TestValidationRun:
                 "unsuccessful_expectations": 0,
                 "success_percent": 100.0,
             },
-            meta={
-                "validation_id": None,
-            },
+            meta={},
         )
+
+    @pytest.mark.unit
+    def test_adds_requisite_ids(
+        self,
+        mock_validator: MagicMock,
+        validation_definition: ValidationDefinition,
+    ):
+        mock_validator.graph_validate.return_value = []
+
+        assert validation_definition.id is None
+
+        output = validation_definition.run()
+
+        assert validation_definition.id is not None
+        assert output.meta == {"validation_id": validation_definition.id}
 
     @mock.patch.object(ValidationResultsStore, "set")
     @pytest.mark.unit

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -189,6 +189,9 @@ class TestValidationRun:
                 "unsuccessful_expectations": 0,
                 "success_percent": 100.0,
             },
+            meta={
+                "validation_id": None,
+            },
         )
 
     @mock.patch.object(ValidationResultsStore, "set")

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -242,6 +242,7 @@ class TestValidationRun:
         assert key.batch_identifier == BATCH_ID
         assert value.success is True
 
+    @pytest.mark.xfail  # TODO: Figure out before merging
     @mock.patch.object(ValidationResultsStore, "set")
     @pytest.mark.unit
     def test_persists_validation_results_for_cloud(
@@ -265,6 +266,7 @@ class TestValidationRun:
         assert isinstance(key, GXCloudIdentifier)
         assert value.success is True
 
+    @pytest.mark.xfail  # TODO: Figure out before merging
     @mock.patch.object(ValidationResultsStore, "set")
     @pytest.mark.unit
     def test_cloud_validation_def_creates_rendered_content(

--- a/tests/datasource/fluent/_fake_cloud_api.py
+++ b/tests/datasource/fluent/_fake_cloud_api.py
@@ -115,6 +115,8 @@ FakeDBTypedDict = TypedDict(
         "expectation_suites": Dict[str, dict],
         "CHECKPOINT_NAMES": Set[str],
         "checkpoints": Dict[str, dict],
+        "VALIDATION_DEFINITION_NAMES": Set[str],
+        "validation_definitions": Dict[str, dict],
     },
 )
 

--- a/tests/datasource/fluent/_fake_cloud_api.py
+++ b/tests/datasource/fluent/_fake_cloud_api.py
@@ -945,7 +945,7 @@ def gx_cloud_api_fake_ctx(
         )
         resp_mocker.add_callback(
             responses.POST,
-            f"{org_url_base_V0}/validation-definitions",
+            urllib.parse.urljoin(org_url_base_V0,"validation-definitions"),
             post_validation_definitions_cb,
         )
 

--- a/tests/datasource/fluent/_fake_cloud_api.py
+++ b/tests/datasource/fluent/_fake_cloud_api.py
@@ -945,7 +945,7 @@ def gx_cloud_api_fake_ctx(
         )
         resp_mocker.add_callback(
             responses.POST,
-            urllib.parse.urljoin(org_url_base_V0,"validation-definitions"),
+            urllib.parse.urljoin(org_url_base_V0, "validation-definitions"),
             post_validation_definitions_cb,
         )
 


### PR DESCRIPTION
Ensure that `ValidationDefinition` and `Checkpoint` persist themselves to their respective stores at the start of their `run` methods (if they haven't already been saved). This will ensure that invariably, we will have references to them in the DB and ensure that any foreign keys generated in the result object will point to real data.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
