### PR TITLE
[BUGFIX] 0.18.x -  Prevent Error on Read Only Filesystem

### DIFF
--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -227,7 +227,7 @@ class InlineStoreBackend(StoreBackend):
                 context.config.to_yaml(outfile)
         # In environments where wrting to disk is not allowed, it is impossible to
         # save changes. As such, we log a warning but do not raise.
-        except PermissionError as e:
+        except (PermissionError, OSError) as e:
             logger.warning(f"Could not save project config to disk: {e}")
 
     @staticmethod

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -228,7 +228,7 @@ class InlineStoreBackend(StoreBackend):
         # In environments where wrting to disk is not allowed, it is impossible to
         # save changes. As such, we log a warning but do not raise.
         except (PermissionError, OSError) as e:
-            logger.warning(f"Could not save project config to disk: {e}")
+            logger.warning(f"Could not save project config to disk: {e!r}")
 
     @staticmethod
     def _determine_resource_name(key: tuple[str, ...]) -> str | None:


### PR DESCRIPTION
Fix allows for GX to run on a Read Only filesystem.

- resolves https://github.com/great-expectations/great_expectations/issues/9911

- Copied from https://github.com/great-expectations/great_expectations/pull/9945


## Note:
This may not resolve the `_scaffold_custom_data_docs` related issue. But need to test to confirm.
- https://github.com/great-expectations/great_expectations/issues/8697