### PR TITLE
[FEATURE] Snowflake - use `Datasource` level `schema` when creating `TableAsset`

### DIFF
--- a/great_expectations/datasource/fluent/__init__.py
+++ b/great_expectations/datasource/fluent/__init__.py
@@ -8,6 +8,7 @@ from great_expectations.datasource.fluent.interfaces import (
     Sorter,
     BatchMetadata,
     GxDatasourceWarning,
+    GxContextWarning,
     TestConnectionError,
 )
 from great_expectations.datasource.fluent.invalid_datasource import (

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -54,8 +54,15 @@ class ConfigStr(SecretStr):
         return f"{self.__class__.__name__}({self._display()!r})"
 
     @classmethod
-    def _validate_template_str_format(cls, v):
-        if TEMPLATE_STR_REGEX.search(v):
+    def str_contains_config_template(cls, v: str) -> bool:
+        """
+        Returns True if the input string contains a config template string.
+        """
+        return TEMPLATE_STR_REGEX.search(v) is not None
+
+    @classmethod
+    def _validate_template_str_format(cls, v: STR) -> STR | None:
+        if cls.str_contains_config_template(v):
             return v
         raise ValueError(
             cls.__name__

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -61,7 +61,7 @@ class ConfigStr(SecretStr):
         return TEMPLATE_STR_REGEX.search(v) is not None
 
     @classmethod
-    def _validate_template_str_format(cls, v: STR) -> STR | None:
+    def _validate_template_str_format(cls, v: str) -> str | None:
         if cls.str_contains_config_template(v):
             return v
         raise ValueError(

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -90,6 +90,14 @@ class GxDatasourceWarning(UserWarning):
     """
 
 
+class GxContextWarning(GxDatasourceWarning):
+    """
+    Warning related to a Datasource that with a missing context.
+    Usually because the Datasource was created directly rather than using a
+    `context.sources` factory method.
+    """
+
+
 class GxSerializationWarning(GxDatasourceWarning):
     pass
 

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -468,7 +468,7 @@
         },
         "ConnectionDetails": {
             "title": "ConnectionDetails",
-            "description": "Information needed to connect to a Snowflake database.\nAlternative to a connection string.",
+            "description": "Information needed to connect to a Snowflake database.\nAlternative to a connection string.\n\nhttps://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#additional-connection-parameters",
             "type": "object",
             "properties": {
                 "account": {

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -494,10 +494,12 @@
                 },
                 "database": {
                     "title": "Database",
+                    "description": "`database` that the Datasource is mapped to.",
                     "type": "string"
                 },
                 "schema": {
                     "title": "Schema",
+                    "description": "`schema` that the Datasource is mapped to.",
                     "type": "string"
                 },
                 "warehouse": {

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -195,12 +195,20 @@ class SnowflakeDsn(AnyUrl):
     @property
     def database(self) -> str:
         assert self.path
-        return self.path.split("/")[0]
+        return self.path.split("/")[1]
 
     @property
     def schema(self) -> str:
         assert self.path
-        return self.path.split("/")[1]
+        return self.path.split("/")[2]
+
+    @property
+    def warehouse(self) -> str | None:
+        return self.params.get("warehouse", [None])[0]
+
+    @property
+    def role(self) -> str | None:
+        return self.params.get("role", [None])[0]
 
 
 class ConnectionDetails(FluentBaseModel):

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -113,9 +113,12 @@ class ConnectionDetails(FluentBaseModel):
     account: str
     user: str
     password: Union[ConfigStr, str]
-    database: str
+    database: str = pydantic.Field(
+        ...,
+        description="`database` that the Datasource is mapped to.",
+    )
     schema_: str = pydantic.Field(
-        ..., alias="schema"
+        ..., alias="schema", description="`schema` that the Datasource is mapped to."
     )  # schema is a reserved attr in BaseModel
     warehouse: Optional[str] = None
     role: Optional[str] = None

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -21,7 +21,7 @@ from great_expectations.compatibility.snowflake import URL
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.datasource.fluent import GxContextWarning
+from great_expectations.datasource.fluent import GxContextWarning, GxDatasourceWarning
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
     _check_config_substitutions_needed,
@@ -307,8 +307,22 @@ class SnowflakeDatasource(SQLDatasource):
             The table asset that is added to the datasource.
             The type of this object will match the necessary type for this datasource.
         """
+        if schema_name is not None:
+            warnings.warn(
+                "The `schema_name argument` is deprecated and will be removed in a future release."
+                " The schema now comes from the datasource.",
+                category=DeprecationWarning,
+            )
+            if schema_name != self.schema_:
+                warnings.warn(
+                    f"schema_name {schema_name} does not match datasource schema {self.schema_}",
+                    category=GxDatasourceWarning,
+                )
+
         schema_name = schema_name or self.schema_
-        # TODO: ensure schema is set, even if using `ConfigStr`
+        if not schema_name:
+            raise ValueError(f"Unable to determine schema for {table_name}")
+
         return super().add_table_asset(
             name=name,
             table_name=table_name,

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import functools
 import logging
 import urllib.parse
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -19,6 +21,7 @@ from great_expectations.compatibility.snowflake import URL
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
+from great_expectations.datasource.fluent import GxContextWarning
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
     _check_config_substitutions_needed,
@@ -39,7 +42,6 @@ if TYPE_CHECKING:
     from great_expectations.compatibility.pydantic.networks import Parts
     from great_expectations.datasource.fluent.interfaces import (
         BatchMetadata,
-        Sorter,
         SortersDefinition,
     )
     from great_expectations.execution_engine import SqlAlchemyExecutionEngine
@@ -49,9 +51,54 @@ LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 REQUIRED_QUERY_PARAMS: Final[
     Iterable[str]
 ] = {  # errors will be thrown if any of these are missing
-    "database",
-    "schema",
 }
+
+
+def _extract_query_section(url: str) -> str | None:
+    """
+    Extracts the query section of a URL if it exists.
+
+    snowflake://user:password@account?warehouse=warehouse&role=role
+    """
+    return url.partition("?")[2]
+
+
+@functools.lru_cache(maxsize=4)
+def _extract_path_sections(url_path: str) -> dict[str, str]:
+    """
+    Extracts the database and schema from the path of a URL.
+
+    Raises UrlPathError if the path is missing database/schema.
+
+    snowflake://user:password@account/database/schema
+    """
+    try:
+        _, database, schema, *_ = url_path.split("/")
+    except (ValueError, AttributeError) as e:
+        LOGGER.info(f"Unable to split path - {e!r}")
+        raise UrlPathError() from e
+    if not database:
+        raise UrlPathError(msg="missing database")
+    if not schema:
+        raise UrlPathError(msg="missing schema")
+    return {"database": database, "schema": schema}
+
+
+def _get_config_substituted_connection_string(
+    datasource: SnowflakeDatasource,
+    warning_msg: str = "Unable to perform config substitution",
+) -> str | None:
+    if not isinstance(datasource.connection_string, ConfigStr):
+        raise TypeError("Config substitution is only supported for `ConfigStr`")
+    if not datasource._data_context:
+        warnings.warn(
+            f"{warning_msg} for {datasource.connection_string.template_str}. Likely missing a context.",
+            category=GxContextWarning,
+        )
+        return None
+    return datasource.connection_string.get_config_value(
+        datasource._data_context.config_provider
+    )
 
 
 class _UrlPasswordError(pydantic.UrlError):
@@ -70,6 +117,18 @@ class _UrlDomainError(pydantic.UrlError):
 
     code = "url.domain"
     msg_template = "URL domain invalid"
+
+
+class UrlPathError(pydantic.UrlError):
+    """
+    Custom Pydantic error for missing path in SnowflakeDsn.
+    """
+
+    code = "url.path"
+    msg_template = "URL path missing database/schema"
+
+    def __init__(self, **ctx: Any) -> None:
+        super().__init__(**ctx)
 
 
 class _UrlMissingQueryError(pydantic.UrlError):
@@ -107,13 +166,46 @@ class SnowflakeDsn(AnyUrl):
         if domain is None:
             raise _UrlDomainError()
 
-        return AnyUrl.validate_parts(parts=parts, validate_port=validate_port)
+        validated_parts = AnyUrl.validate_parts(
+            parts=parts, validate_port=validate_port
+        )
+
+        path: str = parts["path"]
+        # raises UrlPathError if path is missing database/schema
+        _extract_path_sections(path)
+
+        return validated_parts
+
+    @property
+    def params(self) -> dict[str, list[str]]:
+        """The query parameters as a dictionary."""
+        if not self.query:
+            return {}
+        return urllib.parse.parse_qs(self.query)
+
+    @property
+    def account_identifier(self) -> str:
+        """Alias for host."""
+        assert self.host
+        return self.host
+
+    @property
+    def database(self) -> str:
+        assert self.path
+        return self.path.split("/")[0]
+
+    @property
+    def schema(self) -> str:
+        assert self.path
+        return self.path.split("/")[1]
 
 
 class ConnectionDetails(FluentBaseModel):
     """
     Information needed to connect to a Snowflake database.
     Alternative to a connection string.
+
+    https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#additional-connection-parameters
     """
 
     account: str
@@ -158,26 +250,69 @@ class SnowflakeDatasource(SQLDatasource):
         """
         if isinstance(self.connection_string, ConnectionDetails):
             return self.connection_string.schema_
-        elif isinstance(self.connection_string, SnowflakeDsn):
-            # extra database and schema query parameters for the url
-            for key, value in self.connection_string.query_params():
-                if key.lower() == "schema":
-                    return value
-        # TODO: attempt to parse schema from a ConfigStr
-        return None
+        elif isinstance(self.connection_string, ConfigStr):
+            subbed_str: str | None = _get_config_substituted_connection_string(
+                self, warning_msg="Unable to determine schema"
+            )
+            if not subbed_str:
+                return None
+            url_path: str = urllib.parse.urlparse(subbed_str).path
+        else:
+            assert self.connection_string.path
+            url_path = self.connection_string.path
+
+        return _extract_path_sections(url_path)["schema"]
 
     @property
     def database(self) -> str | None:
         """Convenience property to get the `database` regardless of the connection string format."""
         if isinstance(self.connection_string, ConnectionDetails):
             return self.connection_string.database
-        elif isinstance(self.connection_string, SnowflakeDsn):
-            # extra database and schema query parameters for the url
-            for key, value in self.connection_string.query_params():
-                if key.lower() == "database":
-                    return value
-        # TODO: attempt to parse database from a ConfigStr
-        return None
+        elif isinstance(self.connection_string, ConfigStr):
+            subbed_str: str | None = _get_config_substituted_connection_string(
+                self, warning_msg="Unable to determine database"
+            )
+            if not subbed_str:
+                return None
+            url_path: str = urllib.parse.urlparse(subbed_str).path
+        else:
+            assert self.connection_string.path
+            url_path = self.connection_string.path
+
+        return _extract_path_sections(url_path)["database"]
+
+    @public_api
+    @override
+    def add_table_asset(  # noqa: PLR0913
+        self,
+        name: str,
+        table_name: str = "",
+        schema_name: Optional[str] = None,  # TODO: remove this as an arg
+        order_by: Optional[SortersDefinition] = None,
+        batch_metadata: Optional[BatchMetadata] = None,
+    ) -> TableAsset:
+        """Adds a table asset to this datasource.
+
+        Args:
+            name: The name of this table asset.
+            table_name: The table where the data resides.
+            schema_name: The schema that holds the table. Will use the datasource schema if not provided.
+            order_by: A list of Sorters or Sorter strings.
+            batch_metadata: BatchMetadata we want to associate with this DataAsset and all batches derived from it.
+
+        Returns:
+            The table asset that is added to the datasource.
+            The type of this object will match the necessary type for this datasource.
+        """
+        schema_name = schema_name or self.schema_
+        # TODO: ensure schema is set, even if using `ConfigStr`
+        return super().add_table_asset(
+            name=name,
+            table_name=table_name,
+            schema_name=schema_name,
+            order_by=order_by,
+            batch_metadata=batch_metadata,
+        )
 
     @pydantic.root_validator(pre=True)
     def _convert_root_connection_detail_fields(cls, values: dict) -> dict:
@@ -242,9 +377,9 @@ class SnowflakeDatasource(SQLDatasource):
 
         missing_keys: set[str] = set(REQUIRED_QUERY_PARAMS)
         if isinstance(connection_string, ConfigStr):
-            query_str = connection_string.template_str.partition("?")[2]
+            query_str = _extract_query_section(connection_string.template_str)
             # best effort: query could be part of the config substitution. Have to check this when adding assets.
-            if not query_str:
+            if not query_str or ConfigStr.str_contains_config_template(query_str):
                 LOGGER.info(
                     f"Unable to validate query parameters for {connection_string}"
                 )
@@ -298,9 +433,9 @@ class SnowflakeDatasource(SQLDatasource):
 
         For Snowflake specifically we may represent the connection_string as a dict, which is not supported by SQLAlchemy.
         """
-        gx_execution_engine_type: Type[
-            SqlAlchemyExecutionEngine
-        ] = self.execution_engine_type
+        gx_execution_engine_type: Type[SqlAlchemyExecutionEngine] = (
+            self.execution_engine_type
+        )
 
         connection_string: str | None = (
             self.connection_string if isinstance(self.connection_string, str) else None
@@ -379,36 +514,3 @@ class SnowflakeDatasource(SQLDatasource):
         connect_args.update(kwargs)
         url = URL(**connect_args)
         return sa.create_engine(url)
-
-    @public_api
-    @override
-    def add_table_asset(  # noqa: PLR0913
-        self,
-        name: str,
-        table_name: str = "",
-        schema_name: Optional[str] = None,  # TODO: remove this as an arg
-        order_by: Optional[SortersDefinition] = None,
-        batch_metadata: Optional[BatchMetadata] = None,
-    ) -> TableAsset:
-        """Adds a table asset to this datasource.
-
-        Args:
-            name: The name of this table asset.
-            table_name: The table where the data resides.
-            schema_name: The schema that holds the table. Will use the datasource schema if not provided.
-            order_by: A list of Sorters or Sorter strings.
-            batch_metadata: BatchMetadata we want to associate with this DataAsset and all batches derived from it.
-
-        Returns:
-            The table asset that is added to the datasource.
-            The type of this object will match the necessary type for this datasource.
-        """
-        schema_name = schema_name or self.schema_
-        # TODO: ensure schema is set, even if using `ConfigStr`
-        return super().add_table_asset(
-            name=name,
-            table_name=table_name,
-            schema_name=schema_name,
-            order_by=order_by,
-            batch_metadata=batch_metadata,
-        )

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -321,6 +321,7 @@ class SnowflakeDatasource(SQLDatasource):
             # using MISSING to indicate that the user did not provide a value
             schema_name = self.schema_
         else:
+            # deprecated-v0.18.16
             warnings.warn(
                 "The `schema_name argument` is deprecated and will be removed in a future release."
                 " The schema now comes from the datasource.",

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -20,7 +20,10 @@ from great_expectations.compatibility.pydantic import AnyUrl, errors
 from great_expectations.compatibility.snowflake import URL
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core._docs_decorators import public_api
+from great_expectations.core._docs_decorators import (
+    deprecated_method_or_class,
+    public_api,
+)
 from great_expectations.datasource.fluent import GxContextWarning, GxDatasourceWarning
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
@@ -292,13 +295,18 @@ class SnowflakeDatasource(SQLDatasource):
 
         return _extract_path_sections(url_path)["database"]
 
+    @deprecated_method_or_class(
+        version="0.18.16",
+        message="`schema_name` is deprecated."
+        " The schema now comes from the datasource.",
+    )
     @public_api
     @override
     def add_table_asset(  # noqa: PLR0913
         self,
         name: str,
         table_name: str = "",
-        schema_name: Optional[str] = None,  # TODO: remove this as an arg
+        schema_name: Optional[str] = None,  # TODO: remove in V1
         order_by: Optional[SortersDefinition] = None,
         batch_metadata: Optional[BatchMetadata] = None,
     ) -> TableAsset:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -50,8 +50,7 @@ LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 REQUIRED_QUERY_PARAMS: Final[
     Iterable[str]
-] = {  # errors will be thrown if any of these are missing
-}
+] = {}  # errors will be thrown if any of these are missing
 
 
 def _extract_query_section(url: str) -> str | None:
@@ -433,9 +432,9 @@ class SnowflakeDatasource(SQLDatasource):
 
         For Snowflake specifically we may represent the connection_string as a dict, which is not supported by SQLAlchemy.
         """
-        gx_execution_engine_type: Type[SqlAlchemyExecutionEngine] = (
-            self.execution_engine_type
-        )
+        gx_execution_engine_type: Type[
+            SqlAlchemyExecutionEngine
+        ] = self.execution_engine_type
 
         connection_string: str | None = (
             self.connection_string if isinstance(self.connection_string, str) else None

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -264,35 +264,29 @@ class SnowflakeDatasource(SQLDatasource):
         """
         if isinstance(self.connection_string, ConnectionDetails):
             return self.connection_string.schema_
-        elif isinstance(self.connection_string, ConfigStr):
-            subbed_str: str | None = _get_config_substituted_connection_string(
-                self, warning_msg="Unable to determine schema"
-            )
-            if not subbed_str:
-                return None
-            url_path: str = urllib.parse.urlparse(subbed_str).path
-        else:
-            assert self.connection_string.path
-            url_path = self.connection_string.path
+        elif isinstance(self.connection_string, SnowflakeDsn):
+            return self.connection_string.schema
 
+        subbed_str: str | None = _get_config_substituted_connection_string(
+            self, warning_msg="Unable to determine schema"
+        )
+        if not subbed_str:
+            return None
+        url_path: str = urllib.parse.urlparse(subbed_str).path
         return _extract_path_sections(url_path)["schema"]
 
     @property
     def database(self) -> str | None:
         """Convenience property to get the `database` regardless of the connection string format."""
-        if isinstance(self.connection_string, ConnectionDetails):
+        if isinstance(self.connection_string, (ConnectionDetails, SnowflakeDsn)):
             return self.connection_string.database
-        elif isinstance(self.connection_string, ConfigStr):
-            subbed_str: str | None = _get_config_substituted_connection_string(
-                self, warning_msg="Unable to determine database"
-            )
-            if not subbed_str:
-                return None
-            url_path: str = urllib.parse.urlparse(subbed_str).path
-        else:
-            assert self.connection_string.path
-            url_path = self.connection_string.path
 
+        subbed_str: str | None = _get_config_substituted_connection_string(
+            self, warning_msg="Unable to determine database"
+        )
+        if not subbed_str:
+            return None
+        url_path: str = urllib.parse.urlparse(subbed_str).path
         return _extract_path_sections(url_path)["database"]
 
     @deprecated_method_or_class(

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -50,7 +50,11 @@ LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 REQUIRED_QUERY_PARAMS: Final[
     Iterable[str]
-] = {}  # errors will be thrown if any of these are missing
+] = {  # errors will be thrown if any of these are missing
+    # TODO: require warehouse and role
+    # "warehouse",
+    # "role",
+}
 
 
 def _extract_query_section(url: str) -> str | None:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -203,7 +203,7 @@ class SnowflakeDsn(AnyUrl):
         return self.path.split("/")[1]
 
     @property
-    def schema(self) -> str:
+    def schema_(self) -> str:
         assert self.path
         return self.path.split("/")[2]
 
@@ -264,10 +264,8 @@ class SnowflakeDatasource(SQLDatasource):
 
         `schema_` to avoid conflict with Pydantic models schema property.
         """
-        if isinstance(self.connection_string, ConnectionDetails):
+        if isinstance(self.connection_string, (ConnectionDetails, SnowflakeDsn)):
             return self.connection_string.schema_
-        elif isinstance(self.connection_string, SnowflakeDsn):
-            return self.connection_string.schema
 
         subbed_str: str | None = _get_config_substituted_connection_string(
             self, warning_msg="Unable to determine schema"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8415,3 +8415,20 @@ def filter_gx_datasource_warnings() -> Generator[None, None, None]:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=GxDatasourceWarning)
         yield
+
+
+@pytest.fixture(scope="function")
+def param_id(request: pytest.FixtureRequest) -> str:
+    """Return the parameter id of the current test.
+
+    Example:
+
+    ```python
+    @pytest.mark.parametrize("my_param", ["a", "b", "c"], ids=lambda x: x.upper())
+    def test_something(param_id: str, my_param: str):
+        assert my_param != param_id
+        assert my_param.upper() == param_id
+    ```
+    """
+    raw_name: str = request.node.name
+    return raw_name.split("[")[1].split("]")[0]

--- a/tests/datasource/fluent/great_expectations.yml
+++ b/tests/datasource/fluent/great_expectations.yml
@@ -194,7 +194,7 @@ fluent_datasources:
           abs_container: "this_is_always_required"
   my_snowflake_ds:
     type: snowflake
-    connection_string: "snowflake://user_login_name:password@account_identifier?database=testdb&schema=public"
+    connection_string: "snowflake://user_login_name:password@account_identifier/database/public"
     assets:
       my_table_asset_wo_splitters:
         id: d8b22f50-d3f9-4d04-9b4c-cfed86b157ff

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -24,11 +24,11 @@ class TestSnowflake:
         "connection_string",
         [
             param(
-                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&database=ci&schema=public",
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci",
                 id="missing role",
             ),
             param(
-                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=ci_no_select&database=ci&schema=public",
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=ci_no_select",
                 id="role wo select",
             ),
         ],

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -498,9 +498,7 @@ class TestTableIdentifiers:
         )
         print(f"snowflake tables:\n{pf(table_names)}))")
 
-        snowflake_ds.add_table_asset(
-            asset_name, table_name=table_name, schema_name=schema
-        )
+        snowflake_ds.add_table_asset(asset_name, table_name=table_name)
 
     @pytest.mark.sqlite
     def test_sqlite(
@@ -521,6 +519,9 @@ class TestTableIdentifiers:
 
         sqlite_ds.add_table_asset(asset_name, table_name=table_name)
 
+    @pytest.mark.filterwarnings(  # snowflake `add_table_asset` raises warning on passing a schema
+        "once::great_expectations.datasource.fluent.GxDatasourceWarning"
+    )
     @pytest.mark.parametrize(
         "datasource_type,schema",
         [
@@ -767,6 +768,9 @@ def _raw_query_check_column_exists(
         return True
 
 
+@pytest.mark.filterwarnings(  # snowflake `add_table_asset` raises warning on passing a schema
+    "once::great_expectations.datasource.fluent.GxDatasourceWarning"
+)
 @pytest.mark.parametrize(
     "column_name",
     [

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -363,8 +363,8 @@ def snowflake_ds(
         pytest.skip("no snowflake credentials")
     ds = context.sources.add_snowflake(
         "snowflake",
-        connection_string="snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public"
-        f"?warehouse=ci&role=ci&database=ci&schema={RAND_SCHEMA}",
+        connection_string="snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci"
+        f"/{RAND_SCHEMA}?warehouse=ci&role=ci",
         # NOTE: uncomment this and set SNOWFLAKE_USER to run tests against your own snowflake account
         # connection_string="snowflake://${SNOWFLAKE_USER}@${SNOWFLAKE_CI_ACCOUNT}/DEMO_DB/RESTAURANTS?warehouse=COMPUTE_WH&role=PUBLIC&authenticator=externalbrowser",
     )
@@ -768,9 +768,9 @@ def _raw_query_check_column_exists(
         return True
 
 
-@pytest.mark.filterwarnings(  # snowflake `add_table_asset` raises warning on passing a schema
-    "once::great_expectations.datasource.fluent.GxDatasourceWarning"
-)
+@pytest.mark.filterwarnings(
+    "once::DeprecationWarning"
+)  # snowflake `add_table_asset` raises warning on passing a schema
 @pytest.mark.parametrize(
     "column_name",
     [

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -6,6 +6,7 @@ import pathlib
 import shutil
 import sys
 import uuid
+import warnings
 from pprint import pformat as pf
 from typing import (
     TYPE_CHECKING,
@@ -486,7 +487,7 @@ class TestTableIdentifiers:
         if not snowflake_ds:
             pytest.skip("no snowflake datasource")
         # create table
-        schema = get_random_identifier_name()
+        schema = RAND_SCHEMA
         table_factory(
             gx_engine=snowflake_ds.get_execution_engine(),
             table_names={table_name},
@@ -558,9 +559,12 @@ class TestTableIdentifiers:
             schema=schema,
         )
 
-        asset = datasource.add_table_asset(
-            asset_name, table_name=table_name, schema_name=schema
-        )
+        with warnings.catch_warnings():
+            # passing a schema to snowflake tables is deprecated
+            warnings.simplefilter("once", DeprecationWarning)
+            asset = datasource.add_table_asset(
+                asset_name, table_name=table_name, schema_name=schema
+            )
 
         suite = context.add_expectation_suite(
             expectation_suite_name=f"{datasource.name}-{asset.name}"

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -83,6 +83,21 @@ def seed_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MY_PASSWORD", "my_password")
 
 
+@pytest.mark.unit
+def test_snowflake_dsn():
+    dsn = pydantic.parse_obj_as(
+        SnowflakeDsn,
+        "snowflake://my_user:password@my_account/my_db/my_schema?role=my_role&warehouse=my_wh",
+    )
+    assert dsn.user == "my_user"
+    assert dsn.password == "password"
+    assert dsn.account_identifier == "my_account"
+    assert dsn.database == "my_db"
+    assert dsn.schema == "my_schema"
+    assert dsn.role == "my_role"
+    assert dsn.warehouse == "my_wh"
+
+
 @pytest.mark.snowflake  # TODO: make this a unit test
 @pytest.mark.parametrize(
     "config_kwargs",

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -120,9 +120,12 @@ def test_snowflake_dsn():
     ],
 )
 def test_valid_config(
-    empty_file_context: AbstractDataContext, seed_env_vars: None, config_kwargs: dict
+    empty_file_context: AbstractDataContext,
+    seed_env_vars: None,
+    config_kwargs: dict,
+    param_id: str,
 ):
-    my_sf_ds_1 = SnowflakeDatasource(name="my_sf_ds_1", **config_kwargs)
+    my_sf_ds_1 = SnowflakeDatasource(name=f"my_sf {param_id}", **config_kwargs)
     assert my_sf_ds_1
 
     my_sf_ds_1._data_context = (
@@ -584,10 +587,9 @@ class TestConvenienceProperties:
         self,
         ds_config: dict,
         seed_env_vars: None,
-        request: pytest.FixtureRequest,
+        param_id: str,
         ephemeral_context_with_defaults: AbstractDataContext,
     ):
-        param_id = request.node.name
         datasource = SnowflakeDatasource(name=param_id, **ds_config)
         if isinstance(datasource.connection_string, ConfigStr):
             # expect a warning if connection string is a ConfigStr
@@ -604,10 +606,9 @@ class TestConvenienceProperties:
         self,
         ds_config: dict,
         seed_env_vars: None,
-        request: pytest.FixtureRequest,
+        param_id: str,
         ephemeral_context_with_defaults: AbstractDataContext,
     ):
-        param_id = request.node.name
         datasource = SnowflakeDatasource(name=param_id, **ds_config)
         if isinstance(datasource.connection_string, ConfigStr):
             # expect a warning if connection string is a ConfigStr

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -93,7 +93,7 @@ def test_snowflake_dsn():
     assert dsn.password == "password"
     assert dsn.account_identifier == "my_account"
     assert dsn.database == "my_db"
-    assert dsn.schema == "my_schema"
+    assert dsn.schema_ == "my_schema"
     assert dsn.role == "my_role"
     assert dsn.warehouse == "my_wh"
 

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -581,6 +581,7 @@ def test_get_engine_correctly_sets_application_query_param(
     assert application_query_param == expected_query_param
 
 
+@pytest.mark.snowflake
 @pytest.mark.parametrize("ds_config", VALID_DS_CONFIG_PARAMS)
 class TestConvenienceProperties:
     def test_schema(

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -24,13 +24,13 @@ RANDOM_SCHEMA: Final[str] = f"i{uuid.uuid4().hex}"
 def connection_string() -> str:
     if os.getenv("SNOWFLAKE_CI_USER_PASSWORD") and os.getenv("SNOWFLAKE_CI_ACCOUNT"):
         return (
-            "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public"
-            f"?database=ci&schema={RANDOM_SCHEMA}&warehouse=ci&role=ci"
+            "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci"
+            f"/{RANDOM_SCHEMA}?warehouse=ci&role=ci"
         )
     elif os.getenv("SNOWFLAKE_USER") and os.getenv("SNOWFLAKE_CI_ACCOUNT"):
         return (
             "snowflake://${SNOWFLAKE_USER}@${SNOWFLAKE_CI_ACCOUNT}/DEMO_DB"
-            f"?database=ci&schema={RANDOM_SCHEMA}&warehouse=COMPUTE_WH&role=PUBLIC&authenticator=externalbrowser"
+            f"/{RANDOM_SCHEMA}?warehouse=COMPUTE_WH&role=PUBLIC&authenticator=externalbrowser"
         )
     else:
         pytest.skip("no snowflake credentials")
@@ -101,9 +101,7 @@ def data_asset(
         schema_name=RANDOM_SCHEMA,
     )
     asset_name = f"i{uuid.uuid4().hex}"
-    _ = datasource.add_table_asset(
-        name=asset_name, table_name=table_name, schema_name=RANDOM_SCHEMA
-    )
+    _ = datasource.add_table_asset(name=asset_name, table_name=table_name)
     table_asset = datasource.get_asset(asset_name=asset_name)
     yield table_asset
     datasource.delete_asset(asset_name=asset_name)


### PR DESCRIPTION
The most significant change is to use the `Datasource` level `schema` when creating a `TableAsset` via `my_sf_datasource.add_table_asset(...)`.

In addition, several changes were made to make working with `Datasource` level `schema_` + `database` more accessible.

### Convienence properties 
Several properties were added to that can be accessed regardless of the underlying `connection_string` type (`ConnectionDetails`, `SnowflakeDsn` or `ConfigStr`).

1. `Snowflake`
  a. `Snowflake.database`
  b. `Snowflake.schema_`
2. `SnowflakeDsn`
  a. `SnowflakeDsn.schema_`
  b. `SnowflakeDsn.database`
  c. `SnowflakeDsn.account_identifier`
  d. `SnowflakeDsn.warehouse`
  e. `SnowflakeDsn.role`

## Deprecations
Providing a `schema_name` via `SnowflakeDatasource.add_table_asset()` has been deprecated.
