### PR TITLE
[MAINTENANCE] Add `metadata` property to Expectation schemas

### DIFF
--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -181,7 +181,7 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
@@ -181,7 +181,7 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -206,21 +206,30 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnMaxToBeBetween]) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -181,7 +181,7 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -206,9 +206,8 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnMaxToBeBetween]) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -229,8 +228,8 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -250,9 +250,8 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnMeanToBeBetween]) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -273,8 +272,8 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -250,21 +250,30 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnMeanToBeBetween]) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
@@ -172,7 +172,7 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -172,7 +172,7 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -172,7 +172,7 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -201,21 +201,30 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
             schema: Dict[str, Any], model: Type[ExpectColumnMedianToBeBetween]
         ) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
@@ -168,7 +168,7 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -168,7 +168,7 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[Dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -168,7 +168,7 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[Dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],
@@ -201,9 +201,8 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
             schema: Dict[str, Any], model: Type[ExpectColumnMedianToBeBetween]
         ) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -224,8 +223,8 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -174,7 +174,7 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -205,9 +205,8 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnMinToBeBetween]) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -228,8 +227,8 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
@@ -174,7 +174,7 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -205,21 +205,30 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnMinToBeBetween]) -> None:
             ColumnAggregateExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -174,7 +174,7 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MAX_DESCRIPTION)
     strict_max: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column aggregate expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -201,9 +201,8 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeInSet]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -224,8 +223,8 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     def _prescriptive_template(

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -201,21 +201,30 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeInSet]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -170,7 +170,7 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
 
     value_set: Union[list, set, SuiteParameterDict] = pydantic.Field([])
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -170,7 +170,7 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
 
     value_set: Union[list, set, SuiteParameterDict] = pydantic.Field([])
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -170,7 +170,7 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
 
     value_set: Union[list, set, SuiteParameterDict] = pydantic.Field([])
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -193,7 +193,7 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         description=TYPE_LIST_DESCRIPTION
     )
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -193,7 +193,7 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         description=TYPE_LIST_DESCRIPTION
     )
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -225,9 +225,8 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeInTypeList]
         ) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -248,8 +247,8 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -225,21 +225,30 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeInTypeList]
         ) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -193,7 +193,7 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         description=TYPE_LIST_DESCRIPTION
     )
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -174,9 +174,8 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeNull]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -197,8 +196,8 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     def _prescriptive_template(

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -157,7 +157,7 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
         "condition_parser",
     )
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -174,21 +174,30 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeNull]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -157,7 +157,7 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
         "condition_parser",
     )
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -157,7 +157,7 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
         "condition_parser",
     )
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -242,9 +242,8 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeOfType]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -265,8 +264,8 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @override
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -213,7 +213,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
 
     type_: str = pydantic.Field(description=TYPE__DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -213,7 +213,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
 
     type_: str = pydantic.Field(description=TYPE__DESCRIPTION)
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -242,21 +242,30 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeOfType]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @override

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -213,7 +213,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
 
     type_: str = pydantic.Field(description=TYPE__DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -149,7 +149,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -167,9 +167,8 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeUnique]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -190,8 +189,8 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -167,21 +167,30 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnValuesToBeUnique]) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.expectation import (
@@ -149,7 +149,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.expectation import (
@@ -149,7 +149,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -172,9 +172,8 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
             schema: Dict[str, Any], model: Type[ExpectColumnValuesToNotBeNull]
         ) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -195,8 +194,8 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type, Union
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.metric_function_types import (
@@ -153,7 +153,7 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -172,21 +172,30 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
             schema: Dict[str, Any], model: Type[ExpectColumnValuesToNotBeNull]
         ) -> None:
             ColumnMapExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -153,7 +153,7 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -153,7 +153,7 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -175,21 +175,30 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
             schema: Dict[str, Any], model: Type[ExpectTableColumnsToMatchOrderedList]
         ) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -149,7 +149,7 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
         description=COLUMN_LIST_DESCRIPTION
     )
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.core.suite_parameters import (
@@ -149,7 +149,7 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
         description=COLUMN_LIST_DESCRIPTION
     )
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -149,7 +149,7 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
         description=COLUMN_LIST_DESCRIPTION
     )
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -175,9 +175,8 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
             schema: Dict[str, Any], model: Type[ExpectTableColumnsToMatchOrderedList]
         ) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -198,8 +197,8 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     def _prescriptive_template(

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -144,7 +144,7 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
         default=None, description=MAX_VALUE_DESCRIPTION
     )
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -144,7 +144,7 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
         default=None, description=MAX_VALUE_DESCRIPTION
     )
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -171,9 +171,8 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
             schema: Dict[str, Any], model: Type[ExpectTableRowCountToBeBetween]
         ) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -194,8 +193,8 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -171,21 +171,30 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
             schema: Dict[str, Any], model: Type[ExpectTableRowCountToBeBetween]
         ) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -144,7 +144,7 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
         default=None, description=MAX_VALUE_DESCRIPTION
     )
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -141,21 +141,30 @@ class ExpectTableRowCountToEqual(BatchExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectTableRowCountToEqual]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["data_quality_issues"] = {
-                "type": "array",
-                "const": DATA_QUALITY_ISSUES,
-            }
-            schema["properties"]["library_metadata"] = {
+            schema["properties"]["metadata"] = {
                 "type": "object",
-                "const": model._library_metadata,
-            }
-            schema["properties"]["short_description"] = {
-                "type": "string",
-                "const": EXPECTATION_SHORT_DESCRIPTION,
-            }
-            schema["properties"]["supported_data_sources"] = {
-                "type": "array",
-                "const": SUPPORTED_DATASOURCES,
+                "properties": {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATASOURCES,
+                    },
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -141,9 +141,8 @@ class ExpectTableRowCountToEqual(BatchExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ExpectTableRowCountToEqual]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "data_quality_issues": {
                         "title": "Data Quality Issues",
                         "type": "array",
@@ -164,8 +163,8 @@ class ExpectTableRowCountToEqual(BatchExpectation):
                         "type": "array",
                         "const": SUPPORTED_DATASOURCES,
                     },
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -123,7 +123,7 @@ class ExpectTableRowCountToEqual(BatchExpectation):
 
     value: Union[int, SuiteParameterDict] = pydantic.Field(description=VALUE_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -123,7 +123,7 @@ class ExpectTableRowCountToEqual(BatchExpectation):
 
     value: Union[int, SuiteParameterDict] = pydantic.Field(description=VALUE_DESCRIPTION)
 
-    library_metadata: ClassVar[dict[str, str | list | bool]] = {
+    library_metadata: ClassVar[dict[str, Union[str, list, bool]]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
@@ -123,7 +123,7 @@ class ExpectTableRowCountToEqual(BatchExpectation):
 
     value: Union[int, SuiteParameterDict] = pydantic.Field(description=VALUE_DESCRIPTION)
 
-    library_metadata = {
+    library_metadata: ClassVar[dict[str, str | list | bool]] = {
         "maturity": "production",
         "tags": ["core expectation", "table expectation"],
         "contributors": ["@great_expectations"],

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -117,11 +117,6 @@
             "default": false,
             "type": "boolean"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Aggregate"
-        },
         "metadata": {
             "type": "object",
             "properties": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -118,8 +118,8 @@
             "type": "boolean"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -131,29 +131,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Aggregate"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Numerical Data"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the column maximum to be between a minimum value and a maximum value."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Numerical Data"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column aggregate expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the column maximum to be between a minimum value and a maximum value."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -117,23 +117,6 @@
             "default": false,
             "type": "boolean"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column aggregate expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -120,6 +120,11 @@
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Aggregate"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -118,8 +118,8 @@
             "type": "boolean"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -131,7 +131,8 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "kwargs_json_schema_base_properties": {
             "title": "Kwargs Json Schema Base Properties",
@@ -297,22 +298,47 @@
             "const": "column",
             "description": "Column Aggregate"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Numerical Data"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the column mean to be between a minimum value and a maximum value (inclusive)."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Numerical Data"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column aggregate expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the column mean to be between a minimum value and a maximum value (inclusive)."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -276,14 +276,14 @@
             },
             "type": "object"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Aggregate"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Aggregate"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -117,23 +117,6 @@
             "default": false,
             "type": "boolean"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column aggregate expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "kwargs_json_schema_base_properties": {
             "title": "Kwargs Json Schema Base Properties",
             "default": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -118,8 +118,8 @@
             "type": "boolean"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -131,29 +131,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Aggregate"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Numerical Data"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the column median to be between a minimum value and a maximum value."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Numerical Data"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column aggregate expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the column median to be between a minimum value and a maximum value."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -117,11 +117,6 @@
             "default": false,
             "type": "boolean"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Aggregate"
-        },
         "metadata": {
             "type": "object",
             "properties": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -117,23 +117,6 @@
             "default": false,
             "type": "boolean"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column aggregate expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -120,6 +120,11 @@
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Aggregate"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -117,14 +117,14 @@
             "default": false,
             "type": "boolean"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Aggregate"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Aggregate"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -118,8 +118,8 @@
             "type": "boolean"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -131,29 +131,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Aggregate"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Numerical Data"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the column minimum to be between a minimum value and a maximum value."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Numerical Data"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column aggregate expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the column minimum to be between a minimum value and a maximum value."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -117,23 +117,6 @@
             "default": false,
             "type": "boolean"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column aggregate expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -91,14 +91,14 @@
                 }
             ]
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Map"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Map"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -92,8 +92,8 @@
             ]
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -105,29 +105,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Map"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Sets"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect each column value to be in a given set."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Sets"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column map expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect each column value to be in a given set."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -91,23 +91,6 @@
                 }
             ]
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column map expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -89,14 +89,14 @@
                 }
             ]
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Map"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Map"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -89,23 +89,6 @@
                 }
             ]
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column map expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -90,8 +90,8 @@
             ]
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -103,29 +103,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Map"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Schema"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect a column to contain values from a specified type list."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Schema"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column map expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect a column to contain values from a specified type list."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -74,23 +74,6 @@
             "description": "The column name.",
             "type": "string"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column map expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -74,14 +74,14 @@
             "description": "The column name.",
             "type": "string"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Map"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Map"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -75,8 +75,8 @@
             "type": "string"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -88,29 +88,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Map"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Missingness"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the column values to be null."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Missingness"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column map expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the column values to be null."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -78,14 +78,14 @@
             "description": "\n    A string representing the data type that each column should have as entries.     Valid types are defined by the current backend implementation and are dynamically loaded.\n    ",
             "type": "string"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Map"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Map"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -78,23 +78,6 @@
             "description": "\n    A string representing the data type that each column should have as entries.     Valid types are defined by the current backend implementation and are dynamically loaded.\n    ",
             "type": "string"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column map expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -79,8 +79,8 @@
             "type": "string"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -92,29 +92,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Map"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Schema"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect a column to contain values of a specified data type."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Schema"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column map expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect a column to contain values of a specified data type."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -74,8 +74,8 @@
             "type": "string"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -87,29 +87,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Map"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Cardinality"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect each column value to be unique."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Cardinality"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column map expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect each column value to be unique."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -73,14 +73,14 @@
             "description": "The column name.",
             "type": "string"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Map"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Map"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -73,23 +73,6 @@
             "description": "The column name.",
             "type": "string"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column map expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -73,14 +73,14 @@
             "description": "The column name.",
             "type": "string"
         },
-        "domain_type": {
-            "type": "string",
-            "const": "column",
-            "description": "Column Map"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "column",
+                    "description": "Column Map"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -73,23 +73,6 @@
             "description": "The column name.",
             "type": "string"
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "column map expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "column",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -74,8 +74,8 @@
             "type": "string"
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -87,29 +87,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "column",
             "description": "Column Map"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Missingness"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the column values to not be null."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Missingness"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "column map expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the column values to not be null."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -87,8 +87,8 @@
             ]
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -100,29 +100,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "table",
             "description": "Batch"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Schema"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the columns to exactly match a specified list."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Schema"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "table expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the columns to exactly match a specified list."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "additionalProperties": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -86,23 +86,6 @@
                 }
             ]
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "table expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "table",

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -86,14 +86,14 @@
                 }
             ]
         },
-        "domain_type": {
-            "type": "string",
-            "const": "table",
-            "description": "Batch"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "table",
+                    "description": "Batch"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -101,8 +101,8 @@
             ]
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -114,29 +114,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "table",
             "description": "Batch"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Volume"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the number of rows to be between two values."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Volume"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "table expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the number of rows to be between two values."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "additionalProperties": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -100,14 +100,14 @@
                 }
             ]
         },
-        "domain_type": {
-            "type": "string",
-            "const": "table",
-            "description": "Batch"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "table",
+                    "description": "Batch"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -100,23 +100,6 @@
                 }
             ]
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "table expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "table",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -81,8 +81,8 @@
             ]
         },
         "library_metadata": {
-            "type": "object",
-            "const": {
+            "title": "Library Metadata",
+            "default": {
                 "maturity": "production",
                 "tags": [
                     "core expectation",
@@ -94,29 +94,55 @@
                 "requirements": [],
                 "has_full_test_suite": true,
                 "manually_reviewed_code": true
-            }
+            },
+            "type": "object"
         },
         "domain_type": {
             "type": "string",
             "const": "table",
             "description": "Batch"
         },
-        "data_quality_issues": {
-            "type": "array",
-            "const": [
-                "Volume"
-            ]
-        },
-        "short_description": {
-            "type": "string",
-            "const": "Expect the number of rows to equal a value."
-        },
-        "supported_data_sources": {
-            "type": "array",
-            "const": [
-                "Snowflake",
-                "PostgreSQL"
-            ]
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Volume"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "production",
+                        "tags": [
+                            "core expectation",
+                            "table expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect the number of rows to equal a value."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Snowflake",
+                        "PostgreSQL"
+                    ]
+                }
+            }
         }
     },
     "required": [

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -80,14 +80,14 @@
                 }
             ]
         },
-        "domain_type": {
-            "type": "string",
-            "const": "table",
-            "description": "Batch"
-        },
         "metadata": {
             "type": "object",
             "properties": {
+                "domain_type": {
+                    "type": "string",
+                    "const": "table",
+                    "description": "Batch"
+                },
                 "data_quality_issues": {
                     "title": "Data Quality Issues",
                     "type": "array",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -80,23 +80,6 @@
                 }
             ]
         },
-        "library_metadata": {
-            "title": "Library Metadata",
-            "default": {
-                "maturity": "production",
-                "tags": [
-                    "core expectation",
-                    "table expectation"
-                ],
-                "contributors": [
-                    "@great_expectations"
-                ],
-                "requirements": [],
-                "has_full_test_suite": true,
-                "manually_reviewed_code": true
-            },
-            "type": "object"
-        },
         "domain_type": {
             "type": "string",
             "const": "table",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1512,10 +1512,15 @@ class BatchExpectation(Expectation, ABC):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[BatchExpectation]) -> None:
             Expectation.Config.schema_extra(schema, model)
-            schema["properties"]["domain_type"] = {
-                "type": "string",
-                "const": model.domain_type,
-                "description": "Batch",
+            schema["properties"]["metadata"] = {
+                "type": "object",
+                "properties": {
+                    "domain_type": {
+                        "type": "string",
+                        "const": model.domain_type,
+                        "description": "Batch",
+                    }
+                },
             }
 
     @override
@@ -1784,17 +1789,28 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
 
     column: str = Field(description=COLUMN_FIELD_DESCRIPTION)
 
-    domain_keys = ("batch_id", "table", "column", "row_condition", "condition_parser")
-    domain_type = MetricDomainTypes.COLUMN
+    domain_keys: ClassVar[tuple[str, ...]] = (
+        "batch_id",
+        "table",
+        "column",
+        "row_condition",
+        "condition_parser",
+    )
+    domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.COLUMN
 
     class Config:
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ColumnAggregateExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["domain_type"] = {
-                "type": "string",
-                "const": model.domain_type,
-                "description": "Column Aggregate",
+            schema["properties"]["metadata"] = {
+                "type": "object",
+                "properties": {
+                    "domain_type": {
+                        "type": "string",
+                        "const": model.domain_type,
+                        "description": "Column Aggregate",
+                    }
+                },
             }
 
 
@@ -1840,10 +1856,15 @@ class ColumnMapExpectation(BatchExpectation, ABC):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ColumnMapExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["domain_type"] = {
-                "type": "string",
-                "const": model.domain_type,
-                "description": "Column Map",
+            schema["properties"]["metadata"] = {
+                "type": "object",
+                "properties": {
+                    "domain_type": {
+                        "type": "string",
+                        "const": model.domain_type,
+                        "description": "Column Map",
+                    }
+                },
             }
 
     @classmethod
@@ -2094,17 +2115,22 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
         "row_condition",
         "condition_parser",
     )
-    domain_type = MetricDomainTypes.COLUMN_PAIR
+    domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.COLUMN_PAIR
     success_keys: ClassVar[Tuple[str, ...]] = ("mostly",)
 
     class Config:
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ColumnPairMapExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["domain_type"] = {
-                "type": "string",
-                "const": model.domain_type,
-                "description": "Column Pair Map",
+            schema["properties"]["metadata"] = {
+                "type": "object",
+                "properties": {
+                    "domain_type": {
+                        "type": "string",
+                        "const": model.domain_type,
+                        "description": "Column Pair Map",
+                    }
+                },
             }
 
     @classmethod
@@ -2345,17 +2371,22 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
         "condition_parser",
         "ignore_row_if",
     )
-    domain_type = MetricDomainTypes.MULTICOLUMN
+    domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.MULTICOLUMN
     success_keys = ("mostly",)
 
     class Config:
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[MulticolumnMapExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["domain_type"] = {
-                "type": "string",
-                "const": model.domain_type,
-                "description": "Multicolumn Map",
+            schema["properties"]["metadata"] = {
+                "type": "object",
+                "properties": {
+                    "domain_type": {
+                        "type": "string",
+                        "const": model.domain_type,
+                        "description": "Multicolumn Map",
+                    }
+                },
             }
 
     @classmethod

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -319,6 +319,10 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[Expectation]) -> None:
             schema["title"] = model._format_title(schema_title=schema.get("title", ""))
+            schema["properties"]["metadata"] = {
+                "type": "object",
+                "properties": {},
+            }
 
     id: Union[str, None] = None
     meta: Union[dict, None] = None
@@ -1512,16 +1516,15 @@ class BatchExpectation(Expectation, ABC):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[BatchExpectation]) -> None:
             Expectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "domain_type": {
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Batch",
                     }
-                },
-            }
+                }
+            )
 
     @override
     def get_validation_dependencies(
@@ -1802,16 +1805,15 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ColumnAggregateExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "domain_type": {
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Column Aggregate",
                     }
-                },
-            }
+                }
+            )
 
 
 class ColumnMapExpectation(BatchExpectation, ABC):
@@ -1856,16 +1858,15 @@ class ColumnMapExpectation(BatchExpectation, ABC):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ColumnMapExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "domain_type": {
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Column Map",
                     }
-                },
-            }
+                }
+            )
 
     @classmethod
     @override
@@ -2122,16 +2123,15 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[ColumnPairMapExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "domain_type": {
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Column Pair Map",
                     }
-                },
-            }
+                }
+            )
 
     @classmethod
     @override
@@ -2378,16 +2378,15 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: Type[MulticolumnMapExpectation]) -> None:
             BatchExpectation.Config.schema_extra(schema, model)
-            schema["properties"]["metadata"] = {
-                "type": "object",
-                "properties": {
+            schema["properties"]["metadata"]["properties"].update(
+                {
                     "domain_type": {
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Multicolumn Map",
                     }
-                },
-            }
+                }
+            )
 
     @classmethod
     @override

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1519,6 +1519,7 @@ class BatchExpectation(Expectation, ABC):
             schema["properties"]["metadata"]["properties"].update(
                 {
                     "domain_type": {
+                        "title": "Domain Type",
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Batch",
@@ -1808,6 +1809,7 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
             schema["properties"]["metadata"]["properties"].update(
                 {
                     "domain_type": {
+                        "title": "Domain Type",
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Column Aggregate",
@@ -1861,6 +1863,7 @@ class ColumnMapExpectation(BatchExpectation, ABC):
             schema["properties"]["metadata"]["properties"].update(
                 {
                     "domain_type": {
+                        "title": "Domain Type",
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Column Map",
@@ -2126,6 +2129,7 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
             schema["properties"]["metadata"]["properties"].update(
                 {
                     "domain_type": {
+                        "title": "Domain Type",
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Column Pair Map",
@@ -2381,6 +2385,7 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
             schema["properties"]["metadata"]["properties"].update(
                 {
                     "domain_type": {
+                        "title": "Domain Type",
                         "type": "string",
                         "const": model.domain_type,
                         "description": "Multicolumn Map",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1789,7 +1789,7 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
 
     column: str = Field(description=COLUMN_FIELD_DESCRIPTION)
 
-    domain_keys: ClassVar[tuple[str, ...]] = (
+    domain_keys: ClassVar[Tuple[str, ...]] = (
         "batch_id",
         "table",
         "column",


### PR DESCRIPTION


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
