### PR TITLE
[FEATURE] Add new `ConfigUri` type

### DIFF
--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -208,7 +208,7 @@ class ConfigUri(AnyUrl, ConfigStr):  # type: ignore[misc] # Mixin "validate" sig
         # one or more validators may be yielded which will be called in the
         # order to validate the input, each validator will receive as an input
         # the value returned from the previous validator
-        yield AnyUrl.validate
+        yield ConfigStr._validate_template_str_format
         yield cls.validate  # equivalent to AnyUrl.validate
 
 

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -200,9 +200,7 @@ class ConfigUri(AnyUrl, ConfigStr):  # type: ignore[misc] # Mixin "validate" sig
         Parse the resolved URI string into an `AnyUrl` object.
         """
         LOGGER.info(f"Substituting '{self}'")
-        print(self.template_str)
         raw_value = config_provider.substitute_config(self.template_str)
-        print(raw_value)
         return parse_obj_as(AnyUrl, raw_value)
 
     @classmethod

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -2,28 +2,30 @@ from __future__ import annotations
 
 import logging
 import warnings
-from pprint import pformat as pf
-from typing import TYPE_CHECKING, Generic, Mapping, TypeVar, get_args
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Literal,
+    Mapping,
+    Optional,
+    TypedDict,
+    TypeVar,
+)
 
-from great_expectations.compatibility.pydantic import SecretStr, parse_obj_as
+from great_expectations.compatibility.pydantic import AnyUrl, SecretStr, parse_obj_as
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.config_substitutor import TEMPLATE_STR_REGEX
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     from great_expectations.core.config_provider import _ConfigurationProvider
     from great_expectations.datasource.fluent import Datasource
 
 LOGGER = logging.getLogger(__name__)
 
-T = TypeVar("T")
 
-# https://github.com/pydantic/pydantic/blob/main/pydantic/v1/generics.py
-
-
-class ConfigStr(
-    SecretStr,
-    Generic[T],
-):
+class ConfigStr(SecretStr):
     """
     Special type that enables great_expectation config variable substitution.
 
@@ -49,32 +51,6 @@ class ConfigStr(
         """
         LOGGER.info(f"Substituting '{self}'")
         return config_provider.substitute_config(self.template_str)
-
-    def get_config_value_as_type(self, config_provider: _ConfigurationProvider) -> T:
-        """
-        Resolve the config template string to its value according to the passed
-        _ConfigurationProvider and cast it to the type of the `ConfigStr`.
-        """
-        substituted_value = self.get_config_value(config_provider)
-        bases = self.__orig_bases__
-        print(bases)
-        generic_base = bases[1]
-        print(generic_base)
-        generic_args = get_args(generic_base)
-        print(generic_args)
-        t = generic_args[0]
-        print(dir(t))
-        print(f"{pf(t.__dict__)}")
-        print(f"{pf(t.__slots__)}")
-        print(f"{t.__bound__}")
-        print(get_args(t))
-        print(f"{pf(self.__dict__)}")
-        print(f"{pf(dir(self))}")
-        print("\n")
-        print(f"{self.__parameters__!r}")
-        print(self.__class_getitem__())
-        parsed_value: T = parse_obj_as(t, substituted_value)
-        return parsed_value
 
     def _display(self) -> str:
         return str(self)
@@ -111,6 +87,120 @@ class ConfigStr(
         # the value returned from the previous validator
         yield cls._validate_template_str_format
         yield cls.validate
+
+
+UriParts: TypeAlias = (
+    Literal[  # https://docs.pydantic.dev/1.10/usage/types/#url-properties
+        "scheme", "host", "user", "password", "port", "path", "query", "fragment", "tld"
+    ]
+)
+
+
+class UriPartsDict(TypedDict, total=False):
+    scheme: str
+    user: str | None
+    password: str | None
+    ipv4: str | None
+    ipv6: str | None
+    domain: str | None
+    port: str | None
+    path: str | None
+    query: str | None
+    fragment: str | None
+
+
+class ConfigUri(AnyUrl, ConfigStr):
+    """
+    Special type that enables great_expectation config variable substitution for the
+    `user` and `password` section of a URI.
+
+    Example:
+    ```
+    "snowflake://${MY_USER}:${MY_PASSWORD}@account/database/schema/table"
+    ```
+
+    Note: this type is meant to used as part of pydantic model.
+    To use this outside of a model see the pydantic docs below.
+    https://docs.pydantic.dev/usage/models/#parsing-data-into-a-specified-type
+    """
+
+    ALLOWED_SUBSTITUTIONS: ClassVar[set[UriParts]] = {"user", "password"}
+
+    def __init__(
+        self,
+        template_str: str,
+        *,
+        scheme: str,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        host: Optional[str] = None,
+        tld: Optional[str] = None,
+        host_type: str = "domain",
+        port: Optional[str] = None,
+        path: Optional[str] = None,
+        query: Optional[str] = None,
+        fragment: Optional[str] = None,
+    ) -> None:
+        if template_str:  # may have already been set in __new__
+            self.template_str: str = template_str
+        self._secret_value = template_str  # for compatibility with SecretStr
+        super().__init__(
+            template_str,
+            scheme=scheme,
+            user=user,
+            password=password,
+            host=host,
+            tld=tld,
+            host_type=host_type,
+            port=port,
+            path=path,
+            query=query,
+            fragment=fragment,
+        )
+
+    def __new__(cls, template_str: Optional[str], **kwargs) -> object:
+        """custom __new__ for compatibility with pydantic.parse_obj_as()"""
+        built_url = cls.build(**kwargs) if template_str is None else template_str
+        instance = str.__new__(cls, built_url)
+        instance.template_str = str(instance)
+        return instance
+
+    @classmethod
+    def validate_parts(
+        cls, parts: UriPartsDict, validate_port: bool = True
+    ) -> UriPartsDict:
+        """
+        Ensure that only the `user` and `password` parts have config template strings.
+        Also validate that all parts of the URI are valid.
+        """
+        validated_parts = AnyUrl.validate_parts(parts, validate_port)
+
+        name: UriParts
+        for name, part in validated_parts.items():
+            if not part:
+                continue
+            if (
+                cls.str_contains_config_template(part)
+                and name not in cls.ALLOWED_SUBSTITUTIONS
+            ):
+                raise ValueError(
+                    f"ConfigUri - '{name}' part of URI is not allowed to be substituted"
+                )
+
+        return validated_parts
+
+    @override
+    def get_config_value(self, config_provider: _ConfigurationProvider) -> AnyUrl:
+        """
+        Resolve the config template string to its string value according to the passed
+        _ConfigurationProvider.
+        Parse the resolved URI string into an `AnyUrl` object.
+        """
+        LOGGER.info(f"Substituting '{self}'")
+        print(self.template_str)
+        raw_value = config_provider.substitute_config(self.template_str)
+        print(raw_value)
+        return parse_obj_as(AnyUrl, raw_value)
 
 
 def _check_config_substitutions_needed(

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -110,7 +110,7 @@ class UriPartsDict(TypedDict, total=False):
     fragment: str | None
 
 
-class ConfigUri(AnyUrl, ConfigStr):
+class ConfigUri(AnyUrl, ConfigStr):  # type: ignore[misc] # Mixin "validate" signature mismatch
     """
     Special type that enables great_expectation config variable substitution for the
     `user` and `password` section of a URI.
@@ -208,19 +208,11 @@ class ConfigUri(AnyUrl, ConfigStr):
         return parse_obj_as(AnyUrl, raw_value)
 
     @classmethod
-    @override  # type: ignore[override] # incompatible with SecretStr validate
-    def validate(
-        cls, value: Any, field: fields.ModelField, config: BaseConfig
-    ) -> AnyUrl:
-        # override AnyUrl.validate to prevent mypy multiple inheritance error
-        return AnyUrl.validate(value, field, config)
-
-    @classmethod
     def __get_validators__(cls):
         # one or more validators may be yielded which will be called in the
         # order to validate the input, each validator will receive as an input
         # the value returned from the previous validator
-        yield ConfigStr._validate_template_str_format
+        yield AnyUrl.validate
         yield cls.validate  # equivalent to AnyUrl.validate
 
 

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -10,7 +10,6 @@ from typing import (
     Mapping,
     Optional,
     TypedDict,
-    TypeVar,
 )
 
 from great_expectations.compatibility.pydantic import AnyUrl, SecretStr, parse_obj_as

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -4,7 +4,6 @@ import logging
 import warnings
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     Literal,
     Mapping,
@@ -19,7 +18,6 @@ from great_expectations.core.config_substitutor import TEMPLATE_STR_REGEX
 if TYPE_CHECKING:
     from typing_extensions import Self, TypeAlias
 
-    from great_expectations.compatibility.pydantic import BaseConfig, fields
     from great_expectations.core.config_provider import _ConfigurationProvider
     from great_expectations.datasource.fluent import Datasource
 

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import TYPE_CHECKING, Generic, Mapping, TypeVar
+from pprint import pformat as pf
+from typing import TYPE_CHECKING, Generic, Mapping, TypeVar, get_args
 
 from great_expectations.compatibility.pydantic import SecretStr, parse_obj_as
 from great_expectations.compatibility.typing_extensions import override
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+# https://github.com/pydantic/pydantic/blob/main/pydantic/v1/generics.py
 
 
 class ConfigStr(
@@ -53,9 +56,24 @@ class ConfigStr(
         _ConfigurationProvider and cast it to the type of the `ConfigStr`.
         """
         substituted_value = self.get_config_value(config_provider)
-        bases = self.__class__.__bases__
+        bases = self.__orig_bases__
         print(bases)
-        parsed_value: T = parse_obj_as(bases[0], substituted_value)
+        generic_base = bases[1]
+        print(generic_base)
+        generic_args = get_args(generic_base)
+        print(generic_args)
+        t = generic_args[0]
+        print(dir(t))
+        print(f"{pf(t.__dict__)}")
+        print(f"{pf(t.__slots__)}")
+        print(f"{t.__bound__}")
+        print(get_args(t))
+        print(f"{pf(self.__dict__)}")
+        print(f"{pf(dir(self))}")
+        print("\n")
+        print(f"{self.__parameters__!r}")
+        print(self.__class_getitem__())
+        parsed_value: T = parse_obj_as(t, substituted_value)
         return parsed_value
 
     def _display(self) -> str:

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -130,7 +130,7 @@ class ConfigUri(AnyUrl, ConfigStr):
     min_length: int = 1
     max_length: int = 2**16
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 # for compatibility with AnyUrl
         self,
         template_str: str,
         *,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,8 +349,8 @@ filterwarnings = [
     # We likely won't be updating to `marhsmallow` 4, these errors should be filtered out
     "error::marshmallow.warnings.RemovedInMarshmallow4Warning",
     # pkg_resources is deprecated as an API, but third party libraries still use it
-    "once: pkg_resources is deprecated as an API.:DeprecationWarning",
-    'once: Deprecated call to `pkg_resources.declare_namespace\(.*\)`',
+    "ignore: pkg_resources is deprecated as an API.:DeprecationWarning",
+    'ignore: Deprecated call to `pkg_resources.declare_namespace\(.*\)`',
 
 
     # --------------------------------------- Great Expectations Warnings ----------------------------------

--- a/tests/datasource/fluent/test_config_str.py
+++ b/tests/datasource/fluent/test_config_str.py
@@ -14,7 +14,6 @@ from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
     ConfigUri,
     SecretStr,
-    UriPartsDict,
 )
 from great_expectations.datasource.fluent.fluent_base_model import FluentBaseModel
 from great_expectations.exceptions import MissingConfigVariableError


### PR DESCRIPTION
Added new `ConfigUri` type that behaves like a `ConfigStr` except config substitution is only allowed in the `user` + `password` section of a URL.

It also must be a valid URL as defined by [pydantic.AnyUrl](https://docs.pydantic.dev/1.10/usage/types/#urls).


### Example Usage

```python
from typing import Literal

import great_expectations as gx
from great_expectations.datasource.fluent import SqlDatasource

class MyCustomDatasource(SqlDatasource):
    type: Literal["custom_sql"] = "custom_sql"
    connection_string: ConfigUri


context = gx.get_context()

my_ds = context.sources.add_custom_sql(
    "my_datasource",
    connection_string="my_protocol+my_connector://user:${MY_PASSWORD}@host/a/b"
)
print(my_ds.scheme)
print(my_ds.path)
print(my_ds.password)
```
```sh
my_protocol+my_connector
a/b
${MY_PASSWORD}
```

### Invalid Usage Examples

```python
context.sources.add_custom_sql(
    "no_config_template_str",
    connection_string="my_protocol+my_connector://user:password@host/a/b"
)

context.sources.add_custom_sql(
    "config_sub_outside_of_user:password",
    connection_string="my_protocol+my_connector://user:password@${INVALID}"
)

context.sources.add_custom_sql(
    "must_seperate_config_templates_for_user_and_password",
    connection_string="my_protocol+my_connector://${INVALID}@host/a/b"
)

```



