### PR TITLE
[FEATURE] Restrict substitutable sections for `Snowflake.connection_string`

### DIFF
--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -176,21 +176,19 @@ class ConfigUri(AnyUrl, ConfigStr):  # type: ignore[misc] # Mixin "validate" sig
         Ensure that only the `user` and `password` parts have config template strings.
         Also validate that all parts of the URI are valid.
         """
-        validated_parts = AnyUrl.validate_parts(parts, validate_port)
+        allowed_substitutions = sorted(cls.ALLOWED_SUBSTITUTIONS)
 
-        name: UriParts
-        for name, part in validated_parts.items():
+        for name, part in parts.items():
             if not part:
                 continue
             if (
-                cls.str_contains_config_template(part)
+                cls.str_contains_config_template(part)  # type: ignore[arg-type] # is str
                 and name not in cls.ALLOWED_SUBSTITUTIONS
             ):
                 raise ValueError(
-                    f"ConfigUri - '{name}' part of URI is not allowed to be substituted"
+                    f"Only {', '.join(allowed_substitutions)} may use config substitution; '{name}' substitution not allowed"
                 )
-
-        return validated_parts
+        return AnyUrl.validate_parts(parts, validate_port)
 
     @override
     def get_config_value(self, config_provider: _ConfigurationProvider) -> AnyUrl:

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -51,8 +51,9 @@
                 },
                 {
                     "type": "string",
-                    "writeOnly": true,
-                    "format": "password"
+                    "minLength": 1,
+                    "maxLength": 65536,
+                    "format": "uri"
                 },
                 {
                     "type": "string",

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -27,6 +27,7 @@ from great_expectations.core._docs_decorators import (
 from great_expectations.datasource.fluent import GxContextWarning, GxDatasourceWarning
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
+    ConfigUri,
     _check_config_substitutions_needed,
 )
 from great_expectations.datasource.fluent.constants import (
@@ -95,9 +96,9 @@ def _extract_path_sections(url_path: str) -> dict[str, str]:
 def _get_config_substituted_connection_string(
     datasource: SnowflakeDatasource,
     warning_msg: str = "Unable to perform config substitution",
-) -> str | None:
-    if not isinstance(datasource.connection_string, ConfigStr):
-        raise TypeError("Config substitution is only supported for `ConfigStr`")
+) -> AnyUrl | None:
+    if not isinstance(datasource.connection_string, ConfigUri):
+        raise TypeError("Config substitution is only supported for `ConfigUri`")
     if not datasource._data_context:
         warnings.warn(
             f"{warning_msg} for {datasource.connection_string.template_str}. Likely missing a context.",
@@ -253,7 +254,7 @@ class SnowflakeDatasource(SQLDatasource):
 
     type: Literal["snowflake"] = "snowflake"  # type: ignore[assignment]
     # TODO: rename this to `connection` for v1?
-    connection_string: Union[ConnectionDetails, ConfigStr, SnowflakeDsn]  # type: ignore[assignment] # Deviation from parent class as individual args are supported for connection
+    connection_string: Union[ConnectionDetails, ConfigUri, SnowflakeDsn]  # type: ignore[assignment] # Deviation from parent class as individual args are supported for connection
 
     # TODO: add props for account, user, password, etc?
 

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -24,11 +24,11 @@ class TestSnowflake:
         "connection_string",
         [
             param(
-                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci",
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@oca29081.us-east-1/ci/public?warehouse=ci",
                 id="missing role",
             ),
             param(
-                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=ci_no_select",
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@oca29081.us-east-1/ci/public?warehouse=ci&role=ci_no_select",
                 id="role wo select",
             ),
         ],
@@ -78,11 +78,11 @@ class TestSnowflake:
         "connection_string",
         [
             param(
-                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=ci&database=ci&schema=public",
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@oca29081.us-east-1/ci/public?warehouse=ci&role=ci&database=ci&schema=public",
                 id="full connection string",
             ),
             param(
-                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?role=ci&database=ci&schema=public",
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@oca29081.us-east-1/ci/public?role=ci&database=ci&schema=public",
                 id="missing warehouse",
             ),
         ],

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -364,10 +364,10 @@ def snowflake_ds(
         pytest.skip("no snowflake credentials")
     ds = context.sources.add_snowflake(
         "snowflake",
-        connection_string="snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci"
+        connection_string="snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@oca29081.us-east-1/ci"
         f"/{RAND_SCHEMA}?warehouse=ci&role=ci",
         # NOTE: uncomment this and set SNOWFLAKE_USER to run tests against your own snowflake account
-        # connection_string="snowflake://${SNOWFLAKE_USER}@${SNOWFLAKE_CI_ACCOUNT}/DEMO_DB/RESTAURANTS?warehouse=COMPUTE_WH&role=PUBLIC&authenticator=externalbrowser",
+        # connection_string="snowflake://${SNOWFLAKE_USER}@oca29081.us-east-1/DEMO_DB/RESTAURANTS?warehouse=COMPUTE_WH&role=PUBLIC&authenticator=externalbrowser",
     )
     return ds
 

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -30,16 +30,16 @@ VALID_DS_CONFIG_PARAMS: Final[Sequence[ParameterSet]] = [
         id="connection_string str",
     ),
     param(
-        {"connection_string": "${MY_CONN_STR_PARTIAL}@${MY_PATH}?${MY_QUERY_PARAMS}"},
-        id="connection_string ConfigStr with required query params",
+        {
+            "connection_string": "snowflake://my_user:${MY_PASSWORD}@my_account/d_public/s_public"
+        },
+        id="connection_string ConfigStr - password sub",
     ),
     param(
-        {"connection_string": "${MY_CONN_STR_FULL}"},
-        id="connection_string ConfigStr - required params part of sub",
-    ),
-    param(
-        {"connection_string": "${MY_CONN_STR_MIN}?${MY_QUERY_PARAMS}"},
-        id="connection_string ConfigStr - dedicated query params sub",
+        {
+            "connection_string": "snowflake://${MY_USER}:${MY_PASSWORD}@my_account/d_public/s_public"
+        },
+        id="connection_string ConfigStr - user + password sub",
     ),
     param(
         {
@@ -70,16 +70,7 @@ VALID_DS_CONFIG_PARAMS: Final[Sequence[ParameterSet]] = [
 
 @pytest.fixture
 def seed_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MY_CONN_STR_PARTIAL", "snowflake://my_user:password")
-    monkeypatch.setenv(
-        "MY_CONN_STR_MIN", "snowflake://my_user:password@my_account/my_db/my_schema"
-    )
-    monkeypatch.setenv(
-        "MY_CONN_STR_FULL",
-        "snowflake://my_user:password@my_account/my_db/my_schema?warehouse=my_wh&role=my_role",
-    )
-    monkeypatch.setenv("MY_PATH", "my_account/my_db/my_schema")
-    monkeypatch.setenv("MY_QUERY_PARAMS", "warehouse=my_wh&role=my_role")
+    monkeypatch.setenv("MY_USER", "my_user")
     monkeypatch.setenv("MY_PASSWORD", "my_password")
 
 
@@ -112,10 +103,6 @@ def test_snowflake_dsn():
                 "database": "d_public",
             },
             id="old config format - top level keys",
-        ),
-        param(
-            {"connection_string": "${MY_CONN_STR_MIN}"},
-            id="connection_string ConfigStr missing query params",
         ),
     ],
 )

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -130,6 +130,78 @@ def test_valid_config(
     ["connection_string", "expected_errors"],
     [
         pytest.param(
+            "${MY_CONFIG_VAR}",
+            [
+                {
+                    "loc": ("connection_string", "__root__"),
+                    "msg": "Only password, user may use config substitution;"
+                    " 'domain' substitution not allowed",
+                    "type": "value_error",
+                },
+                {
+                    "loc": ("__root__",),
+                    "msg": "Must provide either a connection string or a combination of account, "
+                    "user, and password.",
+                    "type": "value_error",
+                },
+            ],
+            id="illegal config substitution - full connection string",
+        ),
+        pytest.param(
+            "snowflake://my_user:password@${MY_CONFIG_VAR}/db/schema",
+            [
+                {
+                    "loc": ("connection_string", "__root__"),
+                    "msg": "Only password, user may use config substitution;"
+                    " 'domain' substitution not allowed",
+                    "type": "value_error",
+                },
+                {
+                    "loc": ("__root__",),
+                    "msg": "Must provide either a connection string or a combination of account, "
+                    "user, and password.",
+                    "type": "value_error",
+                },
+            ],
+            id="illegal config substitution - account (domain)",
+        ),
+        pytest.param(
+            "snowflake://my_user:password@account/${MY_CONFIG_VAR}/schema",
+            [
+                {
+                    "loc": ("connection_string", "__root__"),
+                    "msg": "Only password, user may use config substitution;"
+                    " 'path' substitution not allowed",
+                    "type": "value_error",
+                },
+                {
+                    "loc": ("__root__",),
+                    "msg": "Must provide either a connection string or a combination of account, "
+                    "user, and password.",
+                    "type": "value_error",
+                },
+            ],
+            id="illegal config substitution - database (path)",
+        ),
+        pytest.param(
+            "snowflake://my_user:password@account/db/${MY_CONFIG_VAR}",
+            [
+                {
+                    "loc": ("connection_string", "__root__"),
+                    "msg": "Only password, user may use config substitution;"
+                    " 'path' substitution not allowed",
+                    "type": "value_error",
+                },
+                {
+                    "loc": ("__root__",),
+                    "msg": "Must provide either a connection string or a combination of account, "
+                    "user, and password.",
+                    "type": "value_error",
+                },
+            ],
+            id="illegal config substitution - schema (path)",
+        ),
+        pytest.param(
             "snowflake://my_user:password@my_account",
             [
                 {

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -24,12 +24,12 @@ RANDOM_SCHEMA: Final[str] = f"i{uuid.uuid4().hex}"
 def connection_string() -> str:
     if os.getenv("SNOWFLAKE_CI_USER_PASSWORD") and os.getenv("SNOWFLAKE_CI_ACCOUNT"):
         return (
-            "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci"
+            "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@oca29081.us-east-1/ci"
             f"/{RANDOM_SCHEMA}?warehouse=ci&role=ci"
         )
     elif os.getenv("SNOWFLAKE_USER") and os.getenv("SNOWFLAKE_CI_ACCOUNT"):
         return (
-            "snowflake://${SNOWFLAKE_USER}@${SNOWFLAKE_CI_ACCOUNT}/DEMO_DB"
+            "snowflake://${SNOWFLAKE_USER}@oca29081.us-east-1/DEMO_DB"
             f"/{RANDOM_SCHEMA}?warehouse=COMPUTE_WH&role=PUBLIC&authenticator=externalbrowser"
         )
     else:


### PR DESCRIPTION
Disallow config substitution for `SnowflakeDatasource.connection_string` outside of the `user:password` sections.

- See #10000 for additional details 

