### PR TITLE
[BUGFIX] Handle OSError during save on read-only file system.

### DIFF
--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -223,8 +223,8 @@ class InlineStoreBackend(StoreBackend):
                 context.config.to_yaml(outfile)
         # In environments where wrting to disk is not allowed, it is impossible to
         # save changes. As such, we log a warning but do not raise.
-        except PermissionError as e:
-            logger.warning(f"Could not save project config to disk: {e}")
+        except (PermissionError, OSError) as e:
+            logger.warning(f"Could not save project config to disk: {e!r}")
 
     @staticmethod
     def _determine_resource_name(key: tuple[str, ...]) -> str | None:


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
