### PR TITLE
[MAINTENANCE] Move `mostly` to correct Expectation classes 

### DIFF
--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column_A": {
             "title": "Column A",
             "description": "The first column name.",
@@ -81,6 +72,15 @@
             "description": "The second column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "mostly": {
+            "title": "Mostly",
+            "default": 1.0,
+            "description": "Successful if at least `mostly` fraction of values match the expectation.",
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "multipleOf": 0.01
         },
         "or_equal": {
             "title": "Or Equal",

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column_A": {
             "title": "Column A",
             "description": "The first column name.",
@@ -81,6 +72,15 @@
             "description": "The second column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "mostly": {
+            "title": "Mostly",
+            "default": 1.0,
+            "description": "Successful if at least `mostly` fraction of values match the expectation.",
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "multipleOf": 0.01
         },
         "ignore_row_if": {
             "title": "Ignore Row If",

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column_A": {
             "title": "Column A",
             "description": "The first column name.",
@@ -81,6 +72,15 @@
             "description": "The second column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "mostly": {
+            "title": "Mostly",
+            "default": 1.0,
+            "description": "Successful if at least `mostly` fraction of values match the expectation.",
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "multipleOf": 0.01
         },
         "value_pairs_set": {
             "title": "Value Pairs Set",

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "type": "string"

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -61,6 +61,12 @@
             "title": "Condition Parser",
             "type": "string"
         },
+        "column": {
+            "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
+            "type": "string"
+        },
         "mostly": {
             "title": "Mostly",
             "default": 1.0,
@@ -69,12 +75,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
-        },
-        "column": {
-            "title": "Column",
-            "description": "The column name.",
-            "minLength": 1,
-            "type": "string"
         },
         "value_set": {
             "title": "Value Set",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -62,6 +62,12 @@
             "default": "pandas",
             "type": "string"
         },
+        "column": {
+            "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
+            "type": "string"
+        },
         "mostly": {
             "title": "Mostly",
             "default": 1.0,
@@ -70,12 +76,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
-        },
-        "column": {
-            "title": "Column",
-            "description": "The column name.",
-            "minLength": 1,
-            "type": "string"
         },
         "type_list": {
             "title": "Type List",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -62,6 +62,12 @@
             "default": "pandas",
             "type": "string"
         },
+        "column": {
+            "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
+            "type": "string"
+        },
         "mostly": {
             "title": "Mostly",
             "default": 1.0,
@@ -70,12 +76,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
-        },
-        "column": {
-            "title": "Column",
-            "description": "The column name.",
-            "minLength": 1,
-            "type": "string"
         },
         "metadata": {
             "type": "object",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -61,6 +61,12 @@
             "title": "Condition Parser",
             "type": "string"
         },
+        "column": {
+            "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
+            "type": "string"
+        },
         "mostly": {
             "title": "Mostly",
             "default": 1.0,
@@ -69,12 +75,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
-        },
-        "column": {
-            "title": "Column",
-            "description": "The column name.",
-            "minLength": 1,
-            "type": "string"
         },
         "type_": {
             "title": "Type ",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -61,6 +61,12 @@
             "title": "Condition Parser",
             "type": "string"
         },
+        "column": {
+            "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
+            "type": "string"
+        },
         "mostly": {
             "title": "Mostly",
             "default": 1.0,
@@ -69,12 +75,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
-        },
-        "column": {
-            "title": "Column",
-            "description": "The column name.",
-            "minLength": 1,
-            "type": "string"
         },
         "metadata": {
             "type": "object",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -61,6 +61,12 @@
             "title": "Condition Parser",
             "type": "string"
         },
+        "column": {
+            "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
+            "type": "string"
+        },
         "mostly": {
             "title": "Mostly",
             "default": 1.0,
@@ -69,12 +75,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
-        },
-        "column": {
-            "title": "Column",
-            "description": "The column name.",
-            "minLength": 1,
-            "type": "string"
         },
         "metadata": {
             "type": "object",

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column_list": {
             "title": "Column List",
             "anyOf": [
@@ -82,6 +73,15 @@
                     "items": {}
                 }
             ]
+        },
+        "mostly": {
+            "title": "Mostly",
+            "default": 1.0,
+            "description": "Successful if at least `mostly` fraction of values match the expectation.",
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "multipleOf": 0.01
         },
         "ignore_row_if": {
             "title": "Ignore Row If",

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -61,6 +61,13 @@
             "title": "Condition Parser",
             "type": "string"
         },
+        "column_list": {
+            "title": "Column List",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "mostly": {
             "title": "Mostly",
             "default": 1.0,
@@ -69,13 +76,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
-        },
-        "column_list": {
-            "title": "Column List",
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
         },
         "ignore_row_if": {
             "title": "Ignore Row If",

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column_list": {
             "title": "Column List",
             "anyOf": [
@@ -82,6 +73,15 @@
                     "items": {}
                 }
             ]
+        },
+        "mostly": {
+            "title": "Mostly",
+            "default": 1.0,
+            "description": "Successful if at least `mostly` fraction of values match the expectation.",
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "multipleOf": 0.01
         },
         "ignore_row_if": {
             "title": "Ignore Row If",

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "min_value": {
             "title": "Min Value",
             "anyOf": [

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "value": {
             "title": "Value",
             "anyOf": [

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column_list": {
             "title": "Column List",
             "description": "The column names, in the correct order.",

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column_set": {
             "title": "Column Set",
             "anyOf": [

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "min_value": {
             "title": "Min Value",
             "description": "The minimum number of rows, inclusive.",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "value": {
             "title": "Value",
             "description": "The expected number of rows.",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "other_table_name": {
             "title": "Other Table Name",
             "type": "string"

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1506,7 +1506,6 @@ class BatchExpectation(Expectation, ABC):
     batch_id: Union[str, None] = None
     row_condition: Union[str, None] = None
     condition_parser: Union[str, None] = None
-    mostly: Mostly = 1.0
 
     domain_keys: ClassVar[Tuple[str, ...]] = (
         "batch_id",
@@ -1848,6 +1847,7 @@ class ColumnMapExpectation(BatchExpectation, ABC):
     """  # noqa: E501
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
+    mostly: Mostly = 1.0
 
     catch_exceptions: bool = True
 
@@ -2113,6 +2113,7 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
 
     column_A: StrictStr = Field(min_length=1, description=COLUMN_A_DESCRIPTION)
     column_B: StrictStr = Field(min_length=1, description=COLUMN_B_DESCRIPTION)
+    mostly: Mostly = 1.0
 
     catch_exceptions: bool = True
 
@@ -2366,6 +2367,7 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
     """  # noqa: E501
 
     column_list: List[StrictStr]
+    mostly: Mostly = 1.0
 
     ignore_row_if: Literal["all_values_are_missing", "any_value_is_missing", "never"] = (
         "all_values_are_missing"

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -751,9 +751,10 @@ def _raw_query_check_column_exists(
 )
 class TestColumnIdentifiers:
     @pytest.mark.parametrize(
-        "expectation_type",
+        "expectation_type,kwargs",
         [
-            "expect_column_values_to_not_be_null",
+            ("expect_column_to_exist", {"column": None}),
+            ("expect_column_values_to_not_be_null", {"column": None, "mostly": 1}),
         ],
     )
     def test_column_expectation(
@@ -763,6 +764,7 @@ class TestColumnIdentifiers:
         table_factory: TableFactory,
         column_name: str | quoted_name,
         expectation_type: str,
+        kwargs: dict,
         request: pytest.FixtureRequest,
     ):
         param_id = request.node.callspec.id
@@ -784,6 +786,7 @@ class TestColumnIdentifiers:
 
         print(f"\ncolumn_name:\n  {column_name!r}")
         print(f"type:\n  {type(column_name)}\n")
+        kwargs["column"] = column_name
 
         table_factory(
             gx_engine=datasource.get_execution_engine(),
@@ -818,10 +821,7 @@ class TestColumnIdentifiers:
         suite.add_expectation_configuration(
             expectation_configuration=ExpectationConfiguration(
                 type=expectation_type,
-                kwargs={
-                    "column": column_name,
-                    "mostly": 1,
-                },
+                kwargs=kwargs,
             )
         )
         suite.save()

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -753,7 +753,6 @@ class TestColumnIdentifiers:
     @pytest.mark.parametrize(
         "expectation_type",
         [
-            "expect_column_values_to_be_null",
             "expect_column_values_to_not_be_null",
         ],
     )

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -751,10 +751,10 @@ def _raw_query_check_column_exists(
 )
 class TestColumnIdentifiers:
     @pytest.mark.parametrize(
-        "expectation_type,kwargs",
+        "expectation_type",
         [
-            ("expect_column_to_exist", {"column": None}),
-            ("expect_column_values_to_not_be_null", {"column": None, "mostly": 1}),
+            "expect_column_to_exist",
+            "expect_column_values_to_not_be_null",
         ],
     )
     def test_column_expectation(
@@ -764,7 +764,6 @@ class TestColumnIdentifiers:
         table_factory: TableFactory,
         column_name: str | quoted_name,
         expectation_type: str,
-        kwargs: dict,
         request: pytest.FixtureRequest,
     ):
         param_id = request.node.callspec.id
@@ -786,7 +785,6 @@ class TestColumnIdentifiers:
 
         print(f"\ncolumn_name:\n  {column_name!r}")
         print(f"type:\n  {type(column_name)}\n")
-        kwargs["column"] = column_name
 
         table_factory(
             gx_engine=datasource.get_execution_engine(),
@@ -821,7 +819,9 @@ class TestColumnIdentifiers:
         suite.add_expectation_configuration(
             expectation_configuration=ExpectationConfiguration(
                 type=expectation_type,
-                kwargs=kwargs,
+                kwargs={
+                    "column": column_name,
+                },
             )
         )
         suite.save()

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -753,7 +753,7 @@ class TestColumnIdentifiers:
     @pytest.mark.parametrize(
         "expectation_type",
         [
-            "expect_column_to_exist",
+            "expect_column_values_to_be_null",
             "expect_column_values_to_not_be_null",
         ],
     )

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -238,13 +238,11 @@ def test_expectation_configuration_property_recognizes_state_changes():
     expectation.column = "bar"
     expectation.min_value = 5
     expectation.max_value = 15
-    expectation.mostly = 0.95
 
     assert expectation.configuration == ExpectationConfiguration(
         type="expect_column_max_to_be_between",
         kwargs={
             "column": "bar",
-            "mostly": 0.95,
             "min_value": 5,
             "max_value": 15,
         },


### PR DESCRIPTION


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
