### PR TITLE
[FEATURE] Snowflake - Forward compatibility updates

### DIFF
--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -332,7 +332,7 @@ class SnowflakeDatasource(SQLDatasource):
         """
         modified_assets: list[str] = []
         try:
-            # if the incoming asset has a database_name, item we need to remove it and warn the user.
+            # if the incoming asset has a database_name, item we need to remove it.
             # future versions of GX will support a `database_name`.
             if assets:
                 for asset in assets:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -20,7 +20,7 @@ from great_expectations.compatibility.snowflake import URL
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.datasource.fluent import GxContextWarning
+from great_expectations.datasource.fluent import GxContextWarning, GxDatasourceWarning
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
     _check_config_substitutions_needed,
@@ -341,8 +341,11 @@ class SnowflakeDatasource(SQLDatasource):
                     if asset_name := asset.get("name") and (database or database_name):
                         modified_assets.append(asset_name)
             if modified_assets:
-                LOGGER.info(
-                    f"Assets modified for forward compatibility: {', '.join(modified_assets)}"
+                warnings.warn(
+                    f"Assets modified for forward compatibility: {', '.join(modified_assets)}."
+                    " Consider updating to the latest version of `great_expectations`.",
+                    category=GxDatasourceWarning,
+                    stacklevel=2,
                 )
         except Exception as e:
             LOGGER.error(f"Error attempting forward compatibility modifications: {e!r}")

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -340,10 +340,12 @@ class SnowflakeDatasource(SQLDatasource):
                     database_name = asset.pop("database_name", None)
                     if asset_name := asset.get("name") and (database or database_name):
                         modified_assets.append(asset_name)
+            if modified_assets:
+                LOGGER.info(
+                    f"Assets modified for forward compatibility: {', '.join(modified_assets)}"
+                )
         except Exception as e:
-            LOGGER.warning(
-                f"Error attempting forward compatibility modifications: {e!r}"
-            )
+            LOGGER.error(f"Error attempting forward compatibility modifications: {e!r}")
         return assets
 
     class Config:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -325,34 +325,6 @@ class SnowflakeDatasource(SQLDatasource):
             "Must provide either a connection string or a combination of account, user, and password."
         )
 
-    @pydantic.validator("connection_string")
-    def _check_for_required_query_params(
-        cls, connection_string: ConnectionDetails | SnowflakeDsn | ConfigUri
-    ) -> ConnectionDetails | SnowflakeDsn | ConfigUri:
-        """
-        If connection_string is a SnowflakeDsn,
-        check for required query parameters according to `REQUIRED_QUERY_PARAMS`.
-        """
-        if not isinstance(connection_string, (SnowflakeDsn, ConfigUri)):
-            return connection_string
-
-        missing_keys: set[str] = set(REQUIRED_QUERY_PARAMS)
-
-        if connection_string.query:
-            query_params: dict[str, list[str]] = urllib.parse.parse_qs(
-                connection_string.query
-            )
-
-            for key in REQUIRED_QUERY_PARAMS:
-                if key in query_params:
-                    missing_keys.remove(key)
-
-        if missing_keys:
-            raise _UrlMissingQueryError(
-                msg=f"missing {', '.join(sorted(missing_keys))}",
-            )
-        return connection_string
-
     @pydantic.validator("assets", pre=True)
     def _asset_forward_compatibility(cls, assets: list[dict]) -> list[dict]:
         """

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -30,6 +30,45 @@ VALID_DS_CONFIG_PARAMS: Final[Sequence[ParameterSet]] = [
         id="connection_string str",
     ),
     param(
+        {
+            "connection_string": "snowflake://my_user:password@my_account/d_public/s_public"
+            "?warehouse=my_wh&role=my_role",
+            "assets": [
+                {"name": "min_table_asset", "type": "table"},
+                {
+                    "name": "table_asset_all_standard_fields",
+                    "type": "table",
+                    "table_name": "my_table",
+                    "schema": "s_public",
+                },
+                {
+                    "name": "table_asset_all_forward_compatible_fields",
+                    "type": "table",
+                    "table_name": "my_table",
+                    "schema": "s_public",
+                    "database": "d_public",
+                    "database_name": "d_public",
+                },
+                {"name": "min_query_asset", "type": "query", "query": "SELECT 1"},
+                {
+                    "name": "query_asset_all_standard_fields",
+                    "type": "query",
+                    "query": "SELECT 1",
+                    "schema": "s_public",
+                },
+                {
+                    "name": "query_asset_all_forward_compatible_fields",
+                    "type": "query",
+                    "query": "SELECT 1",
+                    "schema": "s_public",
+                    "database": "d_public",
+                    "database_name": "d_public",
+                },
+            ],
+        },
+        id="heterogenous assets",
+    ),
+    param(
         {"connection_string": "snowflake://my_user:password@my_account"},
         id="min connection_string str",
     ),


### PR DESCRIPTION
Changes for `0.18.6` to enable forward compatibility with future versions of the package.

Specifically future versions of `gx` will add a `database` (or `database_name`) field to the Snowflake `TableAsset`. This change will prevent config validation errors if these fields are encountered.
 
