### PR TITLE
[MAINTENANCE] Ignore user warnings for pandas + sqlalchemy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,6 @@ jobs:
           # TODO: would like to adopt `actionlint` pre-commit hook
           # but false positive here and inability to do an inline ignore
           # prevents this https://github.com/rhysd/actionlint/issues/237
-          - python-version: ${{ github.event_name == 'pull_request' && '3.9' }}
           - python-version: ${{ github.event_name == 'pull_request' && '3.10' }}
           - python-version: ${{ github.event_name == 'pull_request' && '3.11' }}
           - python-version: ${{ github.event_name == 'merge_group' && '3.9' }}

--- a/great_expectations/compatibility/sqlalchemy_compatibility_wrappers.py
+++ b/great_expectations/compatibility/sqlalchemy_compatibility_wrappers.py
@@ -194,6 +194,19 @@ def add_dataframe_to_db(  # noqa: PLR0913
             # but using the base class here since sqlalchemy is an optional dependency and this
             # warning type only exists in sqlalchemy < 2.0.
             warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            # To filter:
+            # UserWarning: pandas only supports SQLAlchemy connectable (engine/connection)
+            # or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects
+            # are not tested. Please consider using SQLAlchemy.
+            # This warning is being raised in:
+            # "marker-tests (athena or clickhouse or openpyxl or pyarrow or project
+            # or sqlite or aws_creds, 3.9)" - also python 3.10, 3.11
+            # tests using the following dependencies:
+            # pyathena-2.25.2
+            # pandas-2.2.2
+            # sqlalchemy-1.4.52
+            # clickhouse-driver-0.2.8 clickhouse-sqlalchemy-0.2.6
+            warnings.filterwarnings(action="ignore", category=UserWarning)
             df.to_sql(
                 name=name,
                 con=con,


### PR DESCRIPTION
See comment in the code for more info. Filter and ignore UserWarning when creating tables in test databases for integration testing.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
