### PR TITLE
[MAINTENANCE]: change expectation kwarg types (breaking change)

### DIFF
--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Sequence, Type, Union
 
 from great_expectations.expectations.expectation import (
     MulticolumnMapExpectation,

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union, Sequence
 
 from great_expectations.expectations.expectation import (
     MulticolumnMapExpectation,
@@ -168,7 +168,7 @@ class ExpectCompoundColumnsToBeUnique(MulticolumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    column_list: Union[tuple, list]
+    column_list: Sequence[str]
 
     # This dictionary contains metadata for display in the public gallery
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Sequence, Type, Union
 
 from great_expectations.expectations.expectation import (
     MulticolumnMapExpectation,

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union, Sequence
 
 from great_expectations.expectations.expectation import (
     MulticolumnMapExpectation,
@@ -173,7 +173,7 @@ class ExpectSelectColumnValuesToBeUniqueWithinRecord(MulticolumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    column_list: Union[tuple, list]
+    column_list: Sequence[str]
     ignore_row_if: str = "all_values_are_missing"
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -63,16 +63,10 @@
         },
         "column_list": {
             "title": "Column List",
-            "anyOf": [
-                {
-                    "type": "array",
-                    "items": {}
-                },
-                {
-                    "type": "array",
-                    "items": {}
-                }
-            ]
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         },
         "mostly": {
             "title": "Mostly",

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -63,16 +63,10 @@
         },
         "column_list": {
             "title": "Column List",
-            "anyOf": [
-                {
-                    "type": "array",
-                    "items": {}
-                },
-                {
-                    "type": "array",
-                    "items": {}
-                }
-            ]
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         },
         "mostly": {
             "title": "Mostly",


### PR DESCRIPTION
- change these field types to use `Sequence[str]` which simplifies the JSON schema by narrowing the element types to `str`