### PR TITLE
[MAINTENANCE] Move `mostly` to correct Expectation classes

### DIFF
--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -61,15 +61,6 @@
             "title": "Condition Parser",
             "type": "string"
         },
-        "mostly": {
-            "title": "Mostly",
-            "default": 1.0,
-            "description": "Successful if at least `mostly` fraction of values match the expectation.",
-            "type": "number",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "multipleOf": 0.01
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
