### PR TITLE
[DOCS] Updates broken links to code examples in github

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_add_support_for_the_auto_initializing_framework_to_a_custom_expectation.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_add_support_for_the_auto_initializing_framework_to_a_custom_expectation.md
@@ -47,14 +47,14 @@ The `DomainBuilder` configuration requries a `class_name` and `module_name`.  In
   - `MapMetricColumnDomainBuilder`: This `DomainBuilder` allows you to choose columns based on Map Metrics, which give a yes/no answer for individual values or rows.
   - `CategoricalColumnDomainBuilder`: This `DomainBuilder` allows you to choose columns based on their cardinality (number of unique values).
   :::note
-  `CategoricalColumnDomainBuilder` will take in various `cardinality_limit_mode` values for cardinality. For a full listing of valid modes, along with the associated values, please refer to [the `CardinalityLimitMode` enum in the source code on our GitHub](https://github.com/great-expectations/great_expectations/blob/develop/great_expectations/rule_based_profiler/helpers/cardinality_checker.py).
+  `CategoricalColumnDomainBuilder` will take in various `cardinality_limit_mode` values for cardinality. For a full listing of valid modes, along with the associated values, please refer to [the `CardinalityLimitMode` enum in the source code on our GitHub](https://github.com/great-expectations/great_expectations/blob/develop/great_expectations/experimental/rule_based_profiler/helpers/cardinality_checker.py).
   :::
 
 - **`module_name`**: is `great_expectations.rule_based_profiler.domain_builder`, which is common for all `DomainBuilders`.
 
 ### Modify the `ParameterBuilder`
 
-Our example contains a configuration for one `ParamterBuilder`, a `NumericMetricRangeMultiBatchParameterBuilder`.  You can find the other types of `ParameterBuilder` by browsing [the source code in our GitHub](https://github.com/great-expectations/great_expectations/tree/develop/great_expectations/rule_based_profiler/parameter_builder).  For the `NumericMetricRangeMultiBatchParameterBuilder` the configuration key-value pairs consist of:
+Our example contains a configuration for one `ParamterBuilder`, a `NumericMetricRangeMultiBatchParameterBuilder`.  You can find the other types of `ParameterBuilder` by browsing [the source code in our GitHub](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/great_expectations/experimental/rule_based_profiler/parameter_builder/parameter_builder.py#L4).  For the `NumericMetricRangeMultiBatchParameterBuilder` the configuration key-value pairs consist of:
 
 * `name`: an arbitrary name assigned to this `ParameterBuilder` configuration.
 * `class_name`: the name of the class that corresponds to the `ParameterBuilder` defined by this configuration.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations.md
@@ -308,5 +308,5 @@ This is particularly important because ***we*** want to make sure that ***you***
 For more information on our code standards and contribution, see our guide on [Levels of Maturity](/oss/contributing/contributing_maturity.md#expectation-contributions) for Expectations.
 
 To view the full script used in this page, see it on GitHub:
-- [expect_batch_columns_to_be_unique.py](https://github.com/great-expectations/great_expectations/blob/develop/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py)
+- [expect_batch_columns_to_be_unique.py](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py#L4)
 :::

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_map_expectations.md
@@ -27,7 +27,7 @@ Your Expectation will have two versions of the same name: a `CamelCaseName` and 
 
 By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
 
-You can find the template file for a custom [`ColumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/column_map_expectation_template.py). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
+You can find the template file for a custom [`ColumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.17/guides/expectations/creating_custom_expectations/column_map_expectation_template.py#L4). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
 
 ```bash
 cp column_map_expectation_template.py /SOME_DIRECTORY/expect_column_values_to_equal_three.py

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_pair_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_pair_map_expectations.md
@@ -27,7 +27,7 @@ Your Expectation will have two versions of the same name: a `CamelCaseName` and 
 
 By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
 
-You can find the template file for a custom [`ColumnPairMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/column_pair_map_expectation_template.py). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
+You can find the template file for a custom [`ColumnPairMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py#L4). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
 
 ```bash
 cp column_pair_map_expectation_template.py /SOME_DIRECTORY/expect_column_pair_values_to_have_a_difference_of_three.py
@@ -291,5 +291,5 @@ This is particularly important because ***we*** want to make sure that ***you***
 For more information on our code standards and contribution, see our guide on [Levels of Maturity](/oss/contributing/contributing_maturity.md#expectation-contributions) for Expectations.
 
 To view the full script used in this page, see it on GitHub:
-- [expect_column_pair_values_to_have_a_difference_of_three.py](https://github.com/great-expectations/great_expectations/blob/develop/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py)
+- [expect_column_pair_values_to_have_a_difference_of_three.py](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py#L4)
 :::

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_multicolumn_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_multicolumn_map_expectations.md
@@ -27,7 +27,7 @@ Your Expectation will have two versions of the same name: a `CamelCaseName` and 
 
 By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
 
-You can find the template file for a custom [`MulticolumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/multicolumn_map_expectation_template.py). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
+You can find the template file for a custom [`MulticolumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py#L4). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
 
 ```bash
 cp multicolumn_map_expectation_template.py /SOME_DIRECTORY/expect_multicolumn_values_to_be_multiples_of_three.py
@@ -290,5 +290,5 @@ This is particularly important because ***we*** want to make sure that ***you***
 For more information on our code standards and contribution, see our guide on [Levels of Maturity](/oss/contributing/contributing_maturity.md#expectation-contributions) for Expectations.
 
 To view the full script used in this page, see it on GitHub:
-- [expect_multicolumn_values_to_be_multiples_of_three.py](https://github.com/great-expectations/great_expectations/blob/develop/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py)
+- [expect_multicolumn_values_to_be_multiples_of_three.py](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py#L4)
 :::

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations.md
@@ -52,7 +52,7 @@ For more on Expectation naming conventions, see the [Expectations section](../..
 
 By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
 
-You can find the template file for a custom [`QueryExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/query_expectation_template.py).
+You can find the template file for a custom [`QueryExpectation` here](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py#L4).
 Download the file, place it in the appropriate directory, and rename it to the appropriate name.
 
 ```bash
@@ -330,7 +330,7 @@ For more on Expectation naming conventions, see the [Expectations section](../..
 
 By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
 
-You can find the template file for a custom [`QueryExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/query_expectation_template.py).
+You can find the template file for a custom [`QueryExpectation` here](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py#L4).
 Download the file, place it in the appropriate directory, and rename it to the appropriate name.
 
 ```bash

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_regex_based_column_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_regex_based_column_map_expectations.md
@@ -30,7 +30,7 @@ Your Expectation will have two versions of the same name: a `CamelCaseName` and 
 
 By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
 
-You can find the template file for a custom [`RegexBasedColumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/regex_based_column_map_expectation_template.py). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
+You can find the template file for a custom [`RegexBasedColumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py#L4). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
 
 ```bash
 cp regex_based_column_map_expectation_template.py /SOME_DIRECTORY/expect_column_values_to_only_contain_vowels.py
@@ -270,5 +270,5 @@ This is particularly important because ***we*** want to make sure that ***you***
 For more information on our code standards and contribution, see our guide on [Levels of Maturity](/oss/contributing/contributing_maturity.md#expectation-contributions) for Expectations.
 
 To view the full script used in this page, see it on GitHub:
-- [expect_column_values_to_only_contain_vowels.py](https://github.com/great-expectations/great_expectations/blob/develop/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py)
+- [expect_column_values_to_only_contain_vowels.py](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L4)
 :::

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_set_based_column_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_set_based_column_map_expectations.md
@@ -29,7 +29,7 @@ Your Expectation will have two versions of the same name: a `CamelCaseName` and 
 
 By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
 
-You can find the template file for a custom [`SetBasedColumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/set_based_column_map_expectation_template.py). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
+You can find the template file for a custom [`SetBasedColumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py#L4). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
 
 ```bash
 cp set_based_column_map_expectation_template.py /SOME_DIRECTORY/expect_column_values_to_be_in_solfege_scale_set.py
@@ -271,5 +271,5 @@ This is particularly important because ***we*** want to make sure that ***you***
 For more information on our code standards and contribution, see our guide on [Levels of Maturity](/oss/contributing/contributing_maturity.md#expectation-contributions) for Expectations.
 
 To view the full script used in this page, see it on GitHub:
-- [expect_column_values_to_be_in_solfege_scale_set.py](https://github.com/great-expectations/great_expectations/blob/develop/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py)
+- [expect_column_values_to_be_in_solfege_scale_set.py](https://github.com/great-expectations/great_expectations/blob/a502fad53a0ba10acb924a664b5a94f058e30c14/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py#L4)
 :::


### PR DESCRIPTION
## Description
- Updates links to example files in github to referenced versioned example files for contributing Expectations docs that aren't in the GX 1.0 preview docs.


## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [X] Appropriate tests and docs have been updated
