### PR TITLE
[BUGFIX] Fix `get_user_friendly_error_message` with non-standard formats

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -193,6 +193,7 @@ yaml = YAMLHandler()
 
 
 T = TypeVar("T", dict, list, str)
+DST = TypeVar("DST", FluentDatasource, BaseDatasource, LegacyDatasource)
 
 
 @public_api
@@ -867,9 +868,9 @@ class AbstractDataContext(ConfigPeer, ABC):
         self,
         name: None = ...,
         initialize: bool = ...,
-        datasource: BaseDatasource | FluentDatasource | LegacyDatasource = ...,
+        datasource: DST = ...,
         **kwargs,
-    ) -> BaseDatasource | FluentDatasource | LegacyDatasource | None:
+    ) -> DST:
         """
         A `datasource` is provided.
         `name` should not be provided.
@@ -890,9 +891,9 @@ class AbstractDataContext(ConfigPeer, ABC):
         self,
         name: str | None = None,
         initialize: bool = True,
-        datasource: BaseDatasource | FluentDatasource | LegacyDatasource | None = None,
+        datasource: DST | None = None,
         **kwargs,
-    ) -> BaseDatasource | FluentDatasource | LegacyDatasource | None:
+    ) -> DST | BaseDatasource | FluentDatasource | LegacyDatasource | None:
         """Add a new Datasource to the data context, with configuration provided as kwargs.
 
         --Documentation--
@@ -1056,9 +1057,9 @@ class AbstractDataContext(ConfigPeer, ABC):
     def add_or_update_datasource(
         self,
         name: None = ...,
-        datasource: BaseDatasource | FluentDatasource | LegacyDatasource = ...,
+        datasource: DST = ...,
         **kwargs,
-    ) -> BaseDatasource | FluentDatasource | LegacyDatasource:
+    ) -> DST:
         """
         A `datasource` is provided.
         `name` should not be provided.
@@ -1070,9 +1071,9 @@ class AbstractDataContext(ConfigPeer, ABC):
     def add_or_update_datasource(
         self,
         name: str | None = None,
-        datasource: BaseDatasource | FluentDatasource | LegacyDatasource | None = None,
+        datasource: DST | None = None,
         **kwargs,
-    ) -> BaseDatasource | FluentDatasource | LegacyDatasource:
+    ) -> DST | BaseDatasource | FluentDatasource | LegacyDatasource:
         """Add a new Datasource or update an existing one on the context depending on whether
         it already exists or not. The configuration is provided as kwargs.
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -193,7 +193,6 @@ yaml = YAMLHandler()
 
 
 T = TypeVar("T", dict, list, str)
-DST = TypeVar("DST", FluentDatasource, BaseDatasource, LegacyDatasource)
 
 
 @public_api
@@ -868,9 +867,9 @@ class AbstractDataContext(ConfigPeer, ABC):
         self,
         name: None = ...,
         initialize: bool = ...,
-        datasource: DST = ...,
+        datasource: BaseDatasource | FluentDatasource | LegacyDatasource = ...,
         **kwargs,
-    ) -> DST:
+    ) -> BaseDatasource | FluentDatasource | LegacyDatasource | None:
         """
         A `datasource` is provided.
         `name` should not be provided.
@@ -891,9 +890,9 @@ class AbstractDataContext(ConfigPeer, ABC):
         self,
         name: str | None = None,
         initialize: bool = True,
-        datasource: DST | None = None,
+        datasource: BaseDatasource | FluentDatasource | LegacyDatasource | None = None,
         **kwargs,
-    ) -> DST | BaseDatasource | FluentDatasource | LegacyDatasource | None:
+    ) -> BaseDatasource | FluentDatasource | LegacyDatasource | None:
         """Add a new Datasource to the data context, with configuration provided as kwargs.
 
         --Documentation--
@@ -1057,9 +1056,9 @@ class AbstractDataContext(ConfigPeer, ABC):
     def add_or_update_datasource(
         self,
         name: None = ...,
-        datasource: DST = ...,
+        datasource: BaseDatasource | FluentDatasource | LegacyDatasource = ...,
         **kwargs,
-    ) -> DST:
+    ) -> BaseDatasource | FluentDatasource | LegacyDatasource:
         """
         A `datasource` is provided.
         `name` should not be provided.
@@ -1071,9 +1070,9 @@ class AbstractDataContext(ConfigPeer, ABC):
     def add_or_update_datasource(
         self,
         name: str | None = None,
-        datasource: DST | None = None,
+        datasource: BaseDatasource | FluentDatasource | LegacyDatasource | None = None,
         **kwargs,
-    ) -> DST | BaseDatasource | FluentDatasource | LegacyDatasource:
+    ) -> BaseDatasource | FluentDatasource | LegacyDatasource:
         """Add a new Datasource or update an existing one on the context depending on whether
         it already exists or not. The configuration is provided as kwargs.
 

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -114,6 +114,12 @@ def get_user_friendly_error_message(
         errors = error_json.get("errors")
         if errors:
             support_message.append(json.dumps(errors))
+        elif (  # error doesn't conform to the standard format but we still want to expose it
+            # TODO: remove this once our error format has stabilized
+            response.status_code
+            in (400, 409, 422)
+        ):
+            support_message.append(json.dumps(error_json))
 
     except json.JSONDecodeError:
         support_message.append(
@@ -224,7 +230,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         filter_properties_dict(properties=self._config, inplace=True)
 
     @override
-    def _get(self, key: Tuple[GXCloudRESTResource, str | None, str | None]) -> ResponsePayload:  # type: ignore[override]
+    def _get(
+        self, key: Tuple[GXCloudRESTResource, str | None, str | None]
+    ) -> ResponsePayload:  # type: ignore[override]
         url = self.get_url_for_key(key=key)
 
         # if name is included in the key, add as a param

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -230,9 +230,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         filter_properties_dict(properties=self._config, inplace=True)
 
     @override
-    def _get(
-        self, key: Tuple[GXCloudRESTResource, str | None, str | None]
-    ) -> ResponsePayload:  # type: ignore[override]
+    def _get(self, key: Tuple[GXCloudRESTResource, str | None, str | None]) -> ResponsePayload:  # type: ignore[override]
         url = self.get_url_for_key(key=key)
 
         # if name is included in the key, add as a param

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -115,7 +115,7 @@ def get_user_friendly_error_message(
         if errors:
             support_message.append(json.dumps(errors))
         elif (  # error doesn't conform to the standard format but we still want to expose it
-            # TODO: remove this once our error format has stabilized
+            # TODO: consider removing this once our error format has stabilized
             response.status_code
             in (400, 409, 422)
         ):

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1075,6 +1075,13 @@ class SQLDatasource(Datasource):
         """Returns the default execution engine type."""
         return SqlAlchemyExecutionEngine
 
+    @pydantic.validator("connection_string", pre=True)
+    def _config_str_instance_compatibility(cls, v: Union[ConfigStr, str]) -> str:
+        """If a ConfigStr is passed, we need to convert it back to string for pydantic to validate it."""
+        if isinstance(v, ConfigStr):
+            return str(v)
+        return v
+
     def get_engine(self) -> sqlalchemy.Engine:
         if self.connection_string != self._cached_connection_string or not self._engine:
             try:

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -358,7 +358,7 @@ def test_specific_datasource_warnings(
     ],
     ids=lambda x: x["name"],
 )
-def test_datasource_autophagy(
+def test_recreate_from_dict(
     monkeypatch: pytest.MonkeyPatch,
     create_engine_fake: None,
     ephemeral_context_with_defaults: EphemeralDataContext,

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -101,7 +101,7 @@ def create_engine_fake(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     ],
 )
-class TestConfigPasstrough:
+class TestConfigPassthrough:
     def test_kwargs_passed_to_create_engine(
         self,
         create_engine_spy: mock.MagicMock,

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -337,5 +337,45 @@ def test_specific_datasource_warnings(
             ).test_connection()
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "name": "connection_string only",
+            "connection_string": "sqlite:///",
+        },
+        {
+            "name": "no subs + kwargs",
+            "connection_string": "sqlite:///",
+            "kwargs": {"isolation_level": "SERIALIZABLE"},
+        },
+        {
+            "name": "subs + kwargs",
+            "connection_string": "sqlite:///${MY_VAR}",
+            "kwargs": {"isolation_level": "SERIALIZABLE"},
+        },
+    ],
+    ids=lambda x: x["name"],
+)
+def test_datasource_autophagy(
+    monkeypatch: pytest.MonkeyPatch,
+    create_engine_fake: None,
+    ephemeral_context_with_defaults: EphemeralDataContext,
+    config: dict,
+):
+    """
+    Test that .dict() method of a datasource can be fed back into the constructor to recreate the datasource.
+    """
+    monkeypatch.setenv("MY_VAR", "my_var_value")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        d1 = ephemeral_context_with_defaults.sources.add_sql(**config)
+        ephemeral_context_with_defaults.delete_datasource(d1.name)
+        d2 = ephemeral_context_with_defaults.sources.add_sql(**d1.dict())
+    assert d1 == d2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vv"])

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -106,7 +106,7 @@ def test_create_datasource(
         ),
     ],
 )
-def test_create_failure_error_message(
+def test_create_4xx_error_message_handling(
     context: CloudDataContext,
     connection_details: dict[str, str],
     details_override: dict[str, str | None],

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -87,7 +87,7 @@ def test_create_datasource(
             id="schema missing",
         ),
         pytest.param(
-            {"database": None},
+            {"database": None, "schema": None},
             r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"database"\],'
             r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
             id="database missing",

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -112,8 +112,6 @@ def test_create_4xx_error_message_handling(
     details_override: dict[str, str | None],
     expected_err_pattern: str,
 ):
-    datasource_name = f"i{uuid.uuid4().hex}"
-
     connection = {**connection_details, **details_override}
     with pytest.raises(
         StoreBackendError,
@@ -121,7 +119,7 @@ def test_create_4xx_error_message_handling(
         + expected_err_pattern,
     ):
         _: SnowflakeDatasource = context.sources.add_snowflake(
-            name=datasource_name,
+            name=f"i{uuid.uuid4().hex}",
             connection_string={  # filter out falsey values
                 k: v for k, v in connection.items() if v
             },

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -80,28 +80,31 @@ def test_create_datasource(
 @pytest.mark.parametrize(
     ["details_override", "expected_err_pattern"],
     [
-        (
+        pytest.param(
             {"schema": None},
             r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"schema"\],'
             r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
+            id="schema missing",
         ),
-        (
+        pytest.param(
             {"database": None},
             r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"database"\],'
             r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
+            id="database missing",
         ),
-        (
+        pytest.param(
             {"warehouse": None},
             r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"warehouse"\],'
             r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
+            id="warehouse missing",
         ),
-        (
+        pytest.param(
             {"role": None},
             r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"role"\],'
             r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
+            id="role missing",
         ),
     ],
-    ids=lambda x: str(x[0]),
 )
 def test_create_failure_error_message(
     context: CloudDataContext,

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -78,7 +78,14 @@ def test_create_datasource(
 
 
 @pytest.mark.parametrize(
-    ["details_override", "expected_err_pattern"], [({"schema": None}, "schema missing")]
+    ["details_override", "expected_err_pattern"],
+    [
+        (
+            {"schema": None},
+            r'.*"loc": ["snowflake", "connection_string", "SnowflakeConnectionDetails", "schema"],'
+            r' "msg": "Field required", "type": "missing"',
+        )
+    ],
 )
 def test_create_failure_error_message(
     context: CloudDataContext,
@@ -89,7 +96,10 @@ def test_create_failure_error_message(
     datasource_name = f"i{uuid.uuid4().hex}"
 
     connection = {**connection_details, **details_override}
-    with pytest.raises(StoreBackendError, match=expected_err_pattern):
+    with pytest.raises(
+        StoreBackendError,
+        match=r"Unable to set object in GX Cloud Store Backend:" + expected_err_pattern,
+    ):
         _: SnowflakeDatasource = context.sources.add_snowflake(
             name=datasource_name,
             connection_string={  # filter out falsey values

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -83,7 +83,7 @@ def test_create_datasource(
         (
             {"schema": None},
             r'.*"loc": ["snowflake", "connection_string", "SnowflakeConnectionDetails", "schema"],'
-            r' "msg": "Field required", "type": "missing"',
+            r' "msg": "Field required", "type": "missing".*',
         )
     ],
 )
@@ -98,7 +98,8 @@ def test_create_failure_error_message(
     connection = {**connection_details, **details_override}
     with pytest.raises(
         StoreBackendError,
-        match=r"Unable to set object in GX Cloud Store Backend:" + expected_err_pattern,
+        match=r"Unable to set object in GX Cloud Store Backend: "
+        + expected_err_pattern,
     ):
         _: SnowflakeDatasource = context.sources.add_snowflake(
             name=datasource_name,

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -57,7 +57,7 @@ def datasource(
         "echo": True
     }, "The datasource was not updated in the previous method call."
     datasource.kwargs["echo"] = False
-    datasource = context.add_or_update_datasource(datasource=datasource)
+    datasource = context.add_or_update_datasource(datasource=datasource)  # type: ignore[assignment] # more specific type
     assert datasource.kwargs == {
         "echo": False
     }, "The datasource was not updated in the previous method call."
@@ -70,7 +70,7 @@ def datasource(
     datasource.kwargs["echo"] = False
 
     _ = context.add_or_update_datasource(**datasource.dict())
-    datasource = context.get_datasource(datasource_name=datasource_name)
+    datasource = context.get_datasource(datasource_name=datasource_name)  # type: ignore[assignment] # more specific type
     assert datasource.kwargs == {
         "echo": False
     }, "The datasource was not updated in the previous method call."

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -84,8 +84,24 @@ def test_create_datasource(
             {"schema": None},
             r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"schema"\],'
             r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
-        )
+        ),
+        (
+            {"database": None},
+            r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"database"\],'
+            r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
+        ),
+        (
+            {"warehouse": None},
+            r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"warehouse"\],'
+            r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
+        ),
+        (
+            {"role": None},
+            r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"role"\],'
+            r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
+        ),
     ],
+    ids=lambda x: str(x[0]),
 )
 def test_create_failure_error_message(
     context: CloudDataContext,

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -82,8 +82,8 @@ def test_create_datasource(
     [
         (
             {"schema": None},
-            r'.*"loc": ["snowflake", "connection_string", "SnowflakeConnectionDetails", "schema"],'
-            r' "msg": "Field required", "type": "missing".*',
+            r'.*"loc":\s*\["snowflake",\s*"connection_string",\s*"SnowflakeConnectionDetails",\s*"schema"\],'
+            r'\s*"msg":\s*"Field required",\s*"type":\s*"missing".*',
         )
     ],
 )

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -57,28 +57,26 @@ def datasource(
         "echo": True
     }, "The datasource was not updated in the previous method call."
     datasource.kwargs["echo"] = False
-    datasource = context.add_or_update_datasource(datasource=datasource)
+    datasource: SnowflakeDatasource = context.add_or_update_datasource(
+        datasource=datasource
+    )
     assert datasource.kwargs == {
         "echo": False
     }, "The datasource was not updated in the previous method call."
     datasource.kwargs["echo"] = True
-    datasource_dict = datasource.dict()
-    # this is a bug - LATIKU-448
-    # call to datasource.dict() results in a ConfigStr that fails pydantic
-    # validation on SnowflakeDatasource
-    datasource_dict["connection_string"] = str(datasource_dict["connection_string"])
-    datasource = context.sources.add_or_update_snowflake(**datasource_dict)
+
+    datasource: SnowflakeDatasource = context.sources.add_or_update_snowflake(
+        **datasource.dict()
+    )
     assert datasource.kwargs == {
         "echo": True
     }, "The datasource was not updated in the previous method call."
     datasource.kwargs["echo"] = False
-    datasource_dict = datasource.dict()
-    # this is a bug - LATIKU-448
-    # call to datasource.dict() results in a ConfigStr that fails pydantic
-    # validation on SnowflakeDatasource
-    datasource_dict["connection_string"] = str(datasource_dict["connection_string"])
-    _ = context.add_or_update_datasource(**datasource_dict)
-    datasource = context.get_datasource(datasource_name=datasource_name)
+
+    _ = context.add_or_update_datasource(**datasource.dict())
+    datasource: SnowflakeDatasource = context.get_datasource(
+        datasource_name=datasource_name
+    )
     assert datasource.kwargs == {
         "echo": False
     }, "The datasource was not updated in the previous method call."

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent.sql_datasource import TableAsset
     from tests.integration.cloud.end_to_end.conftest import TableFactory
 
+pytestmark: Final = pytest.mark.cloud
+
 RANDOM_SCHEMA: Final[str] = f"i{uuid.uuid4().hex}"
 
 ConnectionDetailKeys = Literal[
@@ -244,7 +246,6 @@ def checkpoint(
         context.get_checkpoint(name=checkpoint_name)
 
 
-@pytest.mark.cloud
 def test_interactive_validator(
     context: CloudDataContext,
     batch_request: BatchRequest,
@@ -268,7 +269,6 @@ def test_interactive_validator(
     assert len(expectation_suite.expectations) == expectation_count + 1
 
 
-@pytest.mark.cloud
 def test_checkpoint_run(checkpoint: Checkpoint):
     checkpoint_result = checkpoint.run()
     assert checkpoint_result.success is True

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -43,7 +43,7 @@ def datasource(
     get_missing_datasource_error_type: type[Exception],
 ) -> Iterator[SnowflakeDatasource]:
     datasource_name = f"i{uuid.uuid4().hex}"
-    datasource = context.sources.add_snowflake(
+    datasource: SnowflakeDatasource = context.sources.add_snowflake(
         name=datasource_name,
         connection_string=connection_string,
         create_temp_table=False,
@@ -57,26 +57,20 @@ def datasource(
         "echo": True
     }, "The datasource was not updated in the previous method call."
     datasource.kwargs["echo"] = False
-    datasource: SnowflakeDatasource = context.add_or_update_datasource(
-        datasource=datasource
-    )
+    datasource = context.add_or_update_datasource(datasource=datasource)
     assert datasource.kwargs == {
         "echo": False
     }, "The datasource was not updated in the previous method call."
     datasource.kwargs["echo"] = True
 
-    datasource: SnowflakeDatasource = context.sources.add_or_update_snowflake(
-        **datasource.dict()
-    )
+    datasource = context.sources.add_or_update_snowflake(**datasource.dict())
     assert datasource.kwargs == {
         "echo": True
     }, "The datasource was not updated in the previous method call."
     datasource.kwargs["echo"] = False
 
     _ = context.add_or_update_datasource(**datasource.dict())
-    datasource: SnowflakeDatasource = context.get_datasource(
-        datasource_name=datasource_name
-    )
+    datasource = context.get_datasource(datasource_name=datasource_name)
     assert datasource.kwargs == {
         "echo": False
     }, "The datasource was not updated in the previous method call."


### PR DESCRIPTION
Recent changes to our Cloud API resulted in some error messages that don't conform to our standard format.

Without this fix, users will see this opaque error for `400` GX Cloud API responses.
```python
StoreBackendError: 'Unable to set object in GX Cloud Store Backend:'
```


In order for users to understand what went wrong in these cases they would have enable debug level logging.

```python
import logging

logging.basicConfig()
logging.getLogger("great_expectations.core.http").setLevel(level=logging.DEBUG)

```

The Error now looks something like this... Assuming the status code was a `400`, `422` or `409`.

```python
StoreBackendError: Unable to set object in GX Cloud Store Backend:
{"datasource": ... {"input": {"account": "***", "database": "ci", "password": "${SNOWFLAKE_CI_USER_PASSWORD}", "role": "ci", "user": "ci", "warehouse": "ci"}, "loc": ["snowflake", "connection_string", "SnowflakeConnectionDetails", "schema"], "msg": "Field required", "type": "missing", "url": "https://errors.pydantic.dev/2.7/v/missing"}]}' ...
```

Also, critically, we now don't have to keep tweaking the OSS error message handling whenever our cloud error message format changes slightly.


## Other changes

Fix to `SQLDatasource` (and children), that errored if a `ConfigStr` object was passed directly.