### PR TITLE
[MAINTENANCE] add json schema field description

### DIFF
--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
+from great_expectations.compatibility.pydantic import Field, StrictStr
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TCH001
@@ -10,7 +11,6 @@ from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
 )
-from great_expectations.compatibility.pydantic import Field, StrictStr
 from great_expectations.expectations.model_field_descriptions import COLUMN_DESCRIPTION
 from great_expectations.render import LegacyRendererType, RenderedStringTemplateContent
 from great_expectations.render.renderer.renderer import renderer

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -10,6 +10,7 @@ from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
 )
+from great_expectations.compatibility.pydantic import Field, StrictStr
 from great_expectations.expectations.model_field_descriptions import COLUMN_DESCRIPTION
 from great_expectations.render import LegacyRendererType, RenderedStringTemplateContent
 from great_expectations.render.renderer.renderer import renderer
@@ -134,7 +135,7 @@ class ExpectColumnToExist(BatchExpectation):
             }}
     """  # noqa: E501
 
-    column: str
+    column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
     column_index: Union[int, SuiteParameterDict, None] = None
 
     # This dictionary contains metadata for display in the public gallery

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -136,7 +136,7 @@ class ExpectColumnToExist(BatchExpectation):
     """  # noqa: E501
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
-    column_index: Union[int, SuiteParameterDict, None] = None
+    column_index: Union[int, SuiteParameterDict, None] = Field(default=None, description=COLUMN_INDEX_DESCRIPTION)
 
     # This dictionary contains metadata for display in the public gallery
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -136,7 +136,9 @@ class ExpectColumnToExist(BatchExpectation):
     """  # noqa: E501
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
-    column_index: Union[int, SuiteParameterDict, None] = Field(default=None, description=COLUMN_INDEX_DESCRIPTION)
+    column_index: Union[int, SuiteParameterDict, None] = Field(
+        default=None, description=COLUMN_INDEX_DESCRIPTION
+    )
 
     # This dictionary contains metadata for display in the public gallery
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -69,6 +69,7 @@
         },
         "column_index": {
             "title": "Column Index",
+            "description": "If not None, checks the order of the columns. The expectation will fail if the column is not in location column_index (zero-indexed).",
             "anyOf": [
                 {
                     "type": "integer"

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -63,6 +63,8 @@
         },
         "column": {
             "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
             "type": "string"
         },
         "column_index": {


### PR DESCRIPTION
- Adds field description to the `column` kwarg of the "expect column to exist" expectation.