### PR TITLE
[FEATURE] Snowflake - narrow Account Identifier regex

### DIFF
--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -475,11 +475,10 @@
                     "title": "AccountIdentifier",
                     "type": "string",
                     "description": "Snowflake Account identifiers can be in one of two formats: <orgname>-<account_name> or <account_locator>.<region>.<cloud>",
-                    "pattern": "^(?P<orgname>[a-zA-Z0-9]+)[.-](?P<account_name>[a-zA-Z0-9-_]+)$|^(?P<account_locator>[a-zA-Z0-9]+)\\.(?P<region>[a-zA-Z0-9-]+)\\.(?P<cloud>aws|gcp|azure)$",
+                    "pattern": "^(?P<orgname>[a-zA-Z0-9]+)[-](?P<account_name>[a-zA-Z0-9-_]+)$|^(?P<account_locator>[a-zA-Z0-9]+)\\.(?P<region>[a-zA-Z0-9-]+)\\.(?P<cloud>aws|gcp|azure)$",
                     "examples": [
                         "myOrg-my_account",
                         "myOrg-my_account",
-                        "myOrg.my_account",
                         "abc12345.us-east-1.aws"
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -478,7 +478,7 @@
                     "pattern": "^(?P<orgname>[a-zA-Z0-9]+)[-](?P<account_name>[a-zA-Z0-9-_]+)$|^(?P<account_locator>[a-zA-Z0-9]+)\\.(?P<region>[a-zA-Z0-9-]+)\\.(?P<cloud>aws|gcp|azure)$",
                     "examples": [
                         "myOrg-my_account",
-                        "myOrg-my_account",
+                        "myOrg-my-account",
                         "abc12345.us-east-1.aws"
                     ]
                 },

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -122,6 +122,8 @@ class AccountIdentifier(str):
 
     The cloud group is optional if on aws but expecting it to be there makes it easier to distinguish formats.
     GX does not throw errors based on the regex parsing result.
+
+    The `.` separated version of the Account name format is not supported with SQLAlchemy.
     """
 
     FORMATS: ClassVar[
@@ -188,7 +190,6 @@ class AccountIdentifier(str):
         Part of format 1:
         * `<orgname>-<account_name>`
         * `<orgname>-<account-name>`
-        * `<orgname>.<account_name>`
         """
         if self._match:
             return self._match.group("orgname")
@@ -200,7 +201,6 @@ class AccountIdentifier(str):
         Part of format 1:
         * `<orgname>-<account_name>`
         * `<orgname>-<account-name>`
-        * `<orgname>.<account_name>`
         """
         if self._match:
             return self._match.group("account_name")

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -164,7 +164,7 @@ class AccountIdentifier(str):
             "pattern": cls.PATTERN.pattern,
             "examples": [
                 "myOrg-my_account",
-                "myOrg-my_account",
+                "myOrg-my-account",
                 "abc12345.us-east-1.aws",
             ],
         }

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -111,12 +111,12 @@ class AccountIdentifier(str):
     a `SnowflakeDsn` or `ConnectionDetails`.
 
     https://docs.snowflake.com/en/user-guide/admin-account-identifier
+    https://docs.snowflake.com/user-guide/organizations-connect
 
     Expected formats:
     1. Account name in your organization
         a. `<orgname>-<account_name>` - e.g. `"myOrg-my_account"`
         b. `<orgname>-<account-name>` - e.g. `"myOrg-my-account"`
-        c. `<orgname>.<account_name>` - e.g. `"myOrg.my_account"`
     2. Account locator in a region
         a. `<account_locator>.<region>.<cloud>` - e.g. `"abc12345.us-east-1.aws"`
 
@@ -130,7 +130,7 @@ class AccountIdentifier(str):
 
     FMT_1: ClassVar[
         str
-    ] = r"^(?P<orgname>[a-zA-Z0-9]+)[.-](?P<account_name>[a-zA-Z0-9-_]+)$"
+    ] = r"^(?P<orgname>[a-zA-Z0-9]+)[-](?P<account_name>[a-zA-Z0-9-_]+)$"
     FMT_2: ClassVar[
         str
     ] = r"^(?P<account_locator>[a-zA-Z0-9]+)\.(?P<region>[a-zA-Z0-9-]+)\.(?P<cloud>aws|gcp|azure)$"
@@ -163,7 +163,6 @@ class AccountIdentifier(str):
             "examples": [
                 "myOrg-my_account",
                 "myOrg-my_account",
-                "myOrg.my_account",
                 "abc12345.us-east-1.aws",
             ],
         }

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -4,7 +4,7 @@ import base64
 import logging
 from pprint import pformat as pf
 from sys import version_info as python_version
-from typing import TYPE_CHECKING, Final, Literal, Sequence
+from typing import TYPE_CHECKING, Final, Sequence
 from unittest.mock import ANY
 
 import pytest
@@ -245,25 +245,10 @@ class TestAccountIdentifier:
         assert str(account_identifier) == value
         assert repr(account_identifier) == f"AccountIdentifier({value!r})"
 
-    @pytest.mark.parametrize("separator", [".", "-"])
-    def test_fmt1_hyphen_parse(self, separator: Literal[".", "-"]):
+    @pytest.mark.parametrize("account_name", ["account_name", "account-name"])
+    def test_fmt1_parse(self, account_name: str):
         orgname = "orgname"
-        account_name = "account-name"
-        value = f"{orgname}{separator}{account_name}"
-        print(f"{value=}")
-
-        account_identifier = pydantic.parse_obj_as(AccountIdentifier, value)
-        assert account_identifier.match
-
-        assert account_identifier.account_name == account_name
-        assert account_identifier.orgname == orgname
-        assert account_identifier.as_tuple() == (orgname, account_name)
-
-    @pytest.mark.parametrize("separator", [".", "-"])
-    def test_fmt1_underscore_parse(self, separator: Literal[".", "-"]):
-        orgname = "orgname"
-        account_name = "account_name"
-        value = f"{orgname}{separator}{account_name}"
+        value = f"{orgname}-{account_name}"
         print(f"{value=}")
 
         account_identifier = pydantic.parse_obj_as(AccountIdentifier, value)
@@ -305,6 +290,8 @@ class TestAccountIdentifier:
         "value",
         [
             "foobar",
+            "orgname.account-name",
+            "orgname.account_name",
             "my_account.us-east-1",
             "xy12345.us-gov-west-1.aws.",
             "xy12345.europe-west4.gcp.bar",


### PR DESCRIPTION
An initial reading of the Snowflake Docs on Account Identifiers indicates that `.` and `-` separators are allowed in the Account name format.

https://docs.snowflake.com/en/user-guide/admin-account-identifier

![image](https://github.com/great-expectations/great_expectations/assets/13108583/175bca53-cadf-4111-8e18-5bfaf0e1105f)


However, this is not allowed when using Python or SQLAlchemy.

https://docs.snowflake.com/user-guide/organizations-connect

![image](https://github.com/great-expectations/great_expectations/assets/13108583/7a6114c0-a60b-49c4-a262-573e734aefbe)

![image](https://github.com/great-expectations/great_expectations/assets/13108583/3ba0895f-d668-4e44-b89c-c25e59d2ac44)


## Changes

- The `AccountIdentifier.PATTERN` regex from https://github.com/great-expectations/great_expectations/pull/10043 has been adjusted to only allow `-` separators when specifying the account name.
