### PR TITLE
[FEATURE] Add missing atomic renderers to Expectations (#10079)

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from great_expectations.core import (
     ExpectationConfiguration,
@@ -15,7 +15,14 @@ from great_expectations.render.components import (
     RenderedStringTemplateContent,
 )
 from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.renderer_configuration import (
+    RendererConfiguration,
+    RendererValueType,
+)
 from great_expectations.render.util import num_to_str, substitute_none_for_missing
+
+if TYPE_CHECKING:
+    from great_expectations.render.renderer_configuration import AddParamArgs
 
 
 class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
@@ -128,6 +135,56 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
 
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
+
+    @classmethod
+    def _prescriptive_template(
+        cls,
+        renderer_configuration: RendererConfiguration,
+    ) -> RendererConfiguration:
+        add_param_args: AddParamArgs = (
+            ("column", RendererValueType.STRING),
+            ("like_pattern_list", RendererValueType.ARRAY),
+            ("match_on", RendererValueType.STRING),
+            ("mostly", RendererValueType.NUMBER),
+        )
+        for name, param_type in add_param_args:
+            renderer_configuration.add_param(name=name, param_type=param_type)
+
+        params = renderer_configuration.params
+
+        if renderer_configuration.include_column_name:
+            template_str = "$column values "
+        else:
+            template_str = "Values "
+
+        if params.match_on:
+            template_str += "must match $match_on of "
+        else:
+            template_str += "must match "
+
+        if params.like_pattern_list:
+            array_param_name = "like_pattern_list"
+            param_prefix = "like_pattern_list_"
+            renderer_configuration = cls._add_array_params(
+                array_param_name=array_param_name,
+                param_prefix=param_prefix,
+                renderer_configuration=renderer_configuration,
+            )
+            template_str += "the following like patterns: " + cls._get_array_string(
+                array_param_name=array_param_name,
+                param_prefix=param_prefix,
+                renderer_configuration=renderer_configuration,
+            )
+
+        if params.mostly and params.mostly.value < 1.0:
+            renderer_configuration = cls._add_mostly_pct_param(
+                renderer_configuration=renderer_configuration
+            )
+            template_str += " , at least $mostly_pct % of the time."
+
+        renderer_configuration.template_str = template_str
+
+        return renderer_configuration
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from great_expectations.core import (
     ExpectationConfiguration,
@@ -13,7 +13,14 @@ from great_expectations.expectations.expectation import (
 from great_expectations.render import RenderedStringTemplateContent
 from great_expectations.render.components import LegacyRendererType
 from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.renderer_configuration import (
+    RendererConfiguration,
+    RendererValueType,
+)
 from great_expectations.render.util import num_to_str, substitute_none_for_missing
+
+if TYPE_CHECKING:
+    from great_expectations.render.renderer_configuration import AddParamArgs
 
 
 class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):
@@ -122,6 +129,38 @@ class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):
                 ), 'Evaluation Parameter dict for like_pattern kwarg must have "$PARAMETER" key.'
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
+
+    @classmethod
+    def _prescriptive_template(
+        cls,
+        renderer_configuration: RendererConfiguration,
+    ) -> RendererConfiguration:
+        add_param_args: AddParamArgs = (
+            ("column", RendererValueType.STRING),
+            ("like_pattern", RendererValueType.STRING),
+            ("mostly", RendererValueType.NUMBER),
+        )
+        for name, param_type in add_param_args:
+            renderer_configuration.add_param(name=name, param_type=param_type)
+
+        params = renderer_configuration.params
+
+        if renderer_configuration.include_column_name:
+            template_str = "$column values "
+        else:
+            template_str = "Values "
+
+        if params.mostly and params.mostly.value < 1.0:
+            renderer_configuration = cls._add_mostly_pct_param(
+                renderer_configuration=renderer_configuration
+            )
+            template_str += "must not match like pattern $like_pattern, at least $mostly_pct % of the time."
+        else:
+            template_str += "must not match like pattern $like_pattern."
+
+        renderer_configuration.template_str = template_str
+
+        return renderer_configuration
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from great_expectations.core import (
     ExpectationConfiguration,
@@ -15,7 +15,14 @@ from great_expectations.render.components import (
     RenderedStringTemplateContent,
 )
 from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.renderer_configuration import (
+    RendererConfiguration,
+    RendererValueType,
+)
 from great_expectations.render.util import num_to_str, substitute_none_for_missing
+
+if TYPE_CHECKING:
+    from great_expectations.render.renderer_configuration import AddParamArgs
 
 
 class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
@@ -132,6 +139,50 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
 
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
+
+    @classmethod
+    def _prescriptive_template(
+        cls,
+        renderer_configuration: RendererConfiguration,
+    ) -> RendererConfiguration:
+        add_param_args: AddParamArgs = (
+            ("column", RendererValueType.STRING),
+            ("like_pattern_list", RendererValueType.ARRAY),
+            ("mostly", RendererValueType.NUMBER),
+        )
+        for name, param_type in add_param_args:
+            renderer_configuration.add_param(name=name, param_type=param_type)
+
+        params = renderer_configuration.params
+
+        if renderer_configuration.include_column_name:
+            template_str = "$column values must not match "
+        else:
+            template_str = "Values must not match "
+
+        if params.like_pattern_list:
+            array_param_name = "like_pattern_list"
+            param_prefix = "like_pattern_list_"
+            renderer_configuration = cls._add_array_params(
+                array_param_name=array_param_name,
+                param_prefix=param_prefix,
+                renderer_configuration=renderer_configuration,
+            )
+            template_str += "the following like patterns: " + cls._get_array_string(
+                array_param_name=array_param_name,
+                param_prefix=param_prefix,
+                renderer_configuration=renderer_configuration,
+            )
+
+        if params.mostly and params.mostly.value < 1.0:
+            renderer_configuration = cls._add_mostly_pct_param(
+                renderer_configuration=renderer_configuration
+            )
+            template_str += " , at least $mostly_pct % of the time."
+
+        renderer_configuration.template_str = template_str
+
+        return renderer_configuration
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -162,7 +162,7 @@ def test_renderer_configuration_add_param_validation(
 @pytest.mark.unit
 def test_add_param_args():
     expectation_configuration = ExpectationConfiguration(
-        type="expect_column_value_z_scores_to_be_less_than",
+        expectation_type="expect_column_value_z_scores_to_be_less_than",
         kwargs={"column": "foo", "threshold": 2, "double_sided": False, "mostly": 1.0},
     )
     renderer_configuration = RendererConfiguration(
@@ -189,7 +189,7 @@ def test_add_param_args():
 @pytest.mark.unit
 def test_template_str_setter():
     expectation_configuration = ExpectationConfiguration(
-        type="expect_column_value_z_scores_to_be_less_than",
+        expectation_type="expect_column_value_z_scores_to_be_less_than",
         kwargs={"column": "foo", "threshold": 2, "double_sided": False, "mostly": 1.0},
     )
     renderer_configuration = RendererConfiguration(
@@ -205,7 +205,7 @@ def test_template_str_setter():
 @pytest.mark.unit
 def test_add_array_params():
     expectation_configuration = ExpectationConfiguration(
-        type="expect_column_values_to_match_like_pattern_list",
+        expectation_type="expect_column_values_to_match_like_pattern_list",
         kwargs={
             "column": "foo",
             "like_pattern_list": ["%", "_"],

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import pytest
 
@@ -9,10 +9,14 @@ from great_expectations.core import (
     ExpectationConfiguration,
     ExpectationValidationResult,
 )
+from great_expectations.expectations.expectation import Expectation
 from great_expectations.render.renderer_configuration import (
     RendererConfiguration,
     RendererValueType,
 )
+
+if TYPE_CHECKING:
+    from great_expectations.render.renderer_configuration import AddParamArgs
 
 
 def mock_expectation_validation_result_from_expectation_configuration(
@@ -153,3 +157,86 @@ def test_renderer_configuration_add_param_validation(
             error_wrapper.exc for error_wrapper in e.value.raw_errors
         ]
     )
+
+
+@pytest.mark.unit
+def test_add_param_args():
+    expectation_configuration = ExpectationConfiguration(
+        type="expect_column_value_z_scores_to_be_less_than",
+        kwargs={"column": "foo", "threshold": 2, "double_sided": False, "mostly": 1.0},
+    )
+    renderer_configuration = RendererConfiguration(
+        configuration=expectation_configuration
+    )
+
+    add_param_args: AddParamArgs = (
+        ("column", RendererValueType.STRING),
+        ("threshold", RendererValueType.NUMBER),
+        ("double_sided", RendererValueType.BOOLEAN),
+        ("mostly", RendererValueType.NUMBER),
+    )
+    for name, param_type in add_param_args:
+        renderer_configuration.add_param(name=name, param_type=param_type)
+
+    params = renderer_configuration.params
+
+    assert params.column
+    assert params.threshold
+    assert params.double_sided
+    assert params.mostly
+
+
+@pytest.mark.unit
+def test_template_str_setter():
+    expectation_configuration = ExpectationConfiguration(
+        type="expect_column_value_z_scores_to_be_less_than",
+        kwargs={"column": "foo", "threshold": 2, "double_sided": False, "mostly": 1.0},
+    )
+    renderer_configuration = RendererConfiguration(
+        configuration=expectation_configuration
+    )
+
+    template_str = "My rendered string"
+    renderer_configuration.template_str = template_str
+
+    assert renderer_configuration.template_str == template_str
+
+
+@pytest.mark.unit
+def test_add_array_params():
+    expectation_configuration = ExpectationConfiguration(
+        type="expect_column_values_to_match_like_pattern_list",
+        kwargs={
+            "column": "foo",
+            "like_pattern_list": ["%", "_"],
+            "match_on": "any",
+            "mostly": 1.0,
+        },
+    )
+    renderer_configuration = RendererConfiguration(
+        configuration=expectation_configuration
+    )
+    renderer_configuration.add_param(
+        name="like_pattern_list", param_type=RendererValueType.ARRAY
+    )
+
+    array_param_name = "like_pattern_list"
+    param_prefix = array_param_name + "_"
+
+    renderer_configuration = Expectation._add_array_params(
+        array_param_name=array_param_name,
+        param_prefix=param_prefix,
+        renderer_configuration=renderer_configuration,
+    )
+    params = renderer_configuration.params
+
+    assert params.like_pattern_list_0
+    assert params.like_pattern_list_1
+
+    array_string = Expectation._get_array_string(
+        array_param_name=array_param_name,
+        param_prefix=param_prefix,
+        renderer_configuration=renderer_configuration,
+    )
+
+    assert array_string == "$like_pattern_list_0 $like_pattern_list_1"


### PR DESCRIPTION
Cherry-pick of https://github.com/great-expectations/great_expectations/pull/10079

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated