### PR TITLE
[BUGFIX] Z-score renderer when `double_sided`

### DIFF
--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -252,7 +252,7 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
         else:
             template_str = "Value z-scores must be "
 
-        if params.double_sided is True:
+        if params.double_sided.value is True:
             template_str += "greater than -$threshold and less than $threshold"
         else:
             template_str += "less than $threshold"

--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -253,7 +253,14 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
             template_str = "Value z-scores must be "
 
         if params.double_sided.value is True:
-            template_str += "greater than -$threshold and less than $threshold"
+            inverse_threshold = params.threshold.value * -1
+            renderer_configuration.add_param(
+                name="inverse_threshold", param_type=RendererValueType.NUMBER
+            )
+            if inverse_threshold < params.threshold.value:
+                template_str += "greater than $inverse_threshold and less than $threshold"
+            else:
+                template_str += "greater than $threshold and less than $inverse_threshold"
         else:
             template_str += "less than $threshold"
 


### PR DESCRIPTION
This Expectation renders the incorrect text when `double_sided` is True

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated