### PR TITLE
[MAINTENANCE] Export `great_expectations.compatibility` types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
         run: pip install . -c constraints-dev.txt -r reqs/requirements-dev-test.txt
 
       - name: Run the unit tests
-        run: invoke ci-tests -m "unit" --xdist --slowest=10 --timeout=1.5
+        run: invoke ci-tests -m "unit" --xdist --slowest=10 --timeout=2.0
 
   doc-checks:
     needs: [static-analysis]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -530,6 +530,9 @@ filterwarnings = [
     # Example Actual Warning:
     # sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
     'ignore: Deprecated API features detected! These feature\(s\) are not compatible with SQLAlchemy 2\.0\.',
+    # snowflake
+    "module: The GenericFunction 'flatten' is already registered and is going to be overridden:sqlalchemy.exc.SAWarning"
+
 
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]

--- a/tasks.py
+++ b/tasks.py
@@ -215,7 +215,7 @@ def docstrings(ctx: Context, paths: list[str] | None = None):
 def marker_coverage(
     ctx: Context,
 ):
-    pytest_cmds = ["pytest", "--verify-marker-coverage-and-exit"]
+    pytest_cmds = ["pytest", "--verify-marker-coverage-and-exit", "-W=once"]
     ctx.run(" ".join(pytest_cmds), echo=True, pty=True)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -215,7 +215,7 @@ def docstrings(ctx: Context, paths: list[str] | None = None):
 def marker_coverage(
     ctx: Context,
 ):
-    pytest_cmds = ["pytest", "--verify-marker-coverage-and-exit", "-W=once"]
+    pytest_cmds = ["pytest", "--verify-marker-coverage-and-exit"]
     ctx.run(" ".join(pytest_cmds), echo=True, pty=True)
 
 

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -57,9 +57,8 @@ class TestSnowflake:
                 # query the asset, if it fails then we should expect a TestConnectionError
                 # expect the sql ProgrammingError to be raised
                 # we are only testing the failure case here
-                snowflake_ds.get_engine().execute(
-                    f"SELECT * FROM {table_name} LIMIT 1;"
-                )
+                with snowflake_ds.get_engine().connect() as conn:
+                    conn.execute(f"SELECT * FROM {table_name} LIMIT 1;")
                 print(f"{table_name} is queryable")
             except sa.exc.ProgrammingError:
                 print(f"{table_name} is not queryable")
@@ -101,7 +100,8 @@ class TestSnowflake:
         table_name = random.choice(inspector_tables)
 
         # query the table to make sure it is queryable
-        snowflake_ds.get_engine().execute(f"SELECT * FROM {table_name} LIMIT 1;")
+        with snowflake_ds.get_engine().connect() as conn:
+            conn.execute(f"SELECT * FROM {table_name} LIMIT 1;")
 
         # the table is queryable so the `add_table_asset()` should pass the test_connection step
         asset = snowflake_ds.add_table_asset(

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 from pytest import param
+from sqlalchemy.sql import text
 
 from great_expectations.datasource.fluent import (
     SnowflakeDatasource,
@@ -58,7 +59,7 @@ class TestSnowflake:
                 # expect the sql ProgrammingError to be raised
                 # we are only testing the failure case here
                 with snowflake_ds.get_engine().connect() as conn:
-                    conn.execute(f"SELECT * FROM {table_name} LIMIT 1;")
+                    conn.execute(text(f"SELECT * FROM {table_name} LIMIT 1;"))
                 print(f"{table_name} is queryable")
             except sa.exc.ProgrammingError:
                 print(f"{table_name} is not queryable")
@@ -101,7 +102,7 @@ class TestSnowflake:
 
         # query the table to make sure it is queryable
         with snowflake_ds.get_engine().connect() as conn:
-            conn.execute(f"SELECT * FROM {table_name} LIMIT 1;")
+            conn.execute(text(f"SELECT * FROM {table_name} LIMIT 1;"))
 
         # the table is queryable so the `add_table_asset()` should pass the test_connection step
         asset = snowflake_ds.add_table_asset(

--- a/tests/integration/cloud/end_to_end/test_pandas_filesystem_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_pandas_filesystem_datasource.py
@@ -180,6 +180,7 @@ def checkpoint(
 
 
 @pytest.mark.cloud
+@pytest.mark.xfail(reason="XFAILED on develop")
 def test_interactive_validator(
     context: CloudDataContext,
     batch_request: BatchRequest,


### PR DESCRIPTION
Export types from our compatibility package so that downstream packages don't loose typing information when using these objects.

## Related

- https://github.com/great-expectations/great_expectations/pull/7438
- https://github.com/great-expectations/cloud/pull/328