### PR TITLE
[MAINTENANCE] Parametrize `TestConnectionError`

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -171,7 +171,28 @@ class PartitionerProtocol(PartitionerSortingProtocol, Protocol):
 
 
 class TestConnectionError(Exception):
-    pass
+    """
+    Raised if `.test_connection()` fails to connect to the datasource.
+    """
+
+    def __init__(
+        self,
+        message: str = "Attempt to connect to datasource failed",
+        cause: Exception | None = None,
+        addendum: str | None = None,
+    ):
+        """
+        Args:
+            `message` base of the error message to be provided to the user.
+            `addendum` is optional additional information that can be added to the error message.
+            `cause` is the original exception that caused the error, the repr of which will be added
+                to the error message.
+        """
+        if cause:
+            message += f": due to {cause!r}"
+        if addendum:
+            message += f": {addendum}"
+        super().__init__(message)
 
 
 class GxDatasourceWarning(UserWarning):

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -178,15 +178,16 @@ class TestConnectionError(ConnectionError):
     def __init__(
         self,
         message: str = "Attempt to connect to datasource failed",
+        *,
         cause: Exception | None = None,
         addendum: str | None = None,
     ):
         """
         Args:
             `message` base of the error message to be provided to the user.
-            `addendum` is optional additional information that can be added to the error message.
             `cause` is the original exception that caused the error, the repr of which will be added
                 to the error message.
+            `addendum` is optional additional information that can be added to the error message.
         """
         self.cause = cause  # not guaranteed to be the same as `self.__cause__`
         self.addendum = addendum

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -170,7 +170,7 @@ class PartitionerProtocol(PartitionerSortingProtocol, Protocol):
         ...
 
 
-class TestConnectionError(Exception):
+class TestConnectionError(ConnectionError):
     """
     Raised if `.test_connection()` fails to connect to the datasource.
     """

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -188,6 +188,8 @@ class TestConnectionError(Exception):
             `cause` is the original exception that caused the error, the repr of which will be added
                 to the error message.
         """
+        self.cause = cause  # not guaranteed to be the same as `self.__cause__`
+        self.addendum = addendum
         if cause:
             message += f": due to {cause!r}"
         if addendum:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -513,10 +513,11 @@ class SnowflakeDatasource(SQLDatasource):
         except TestConnectionError as e:
             if self.account and not self.account.match:
                 raise TestConnectionError(
-                    AccountIdentifier.MSG_TEMPLATE.format(
+                    message=e.__class__.__name__,
+                    addendum=AccountIdentifier.MSG_TEMPLATE.format(
                         value=self.account,
                         formats=AccountIdentifier.FORMATS,
-                    )
+                    ),
                 ) from e
             raise
 

--- a/great_expectations/datasource/fluent/spark_datasource.py
+++ b/great_expectations/datasource/fluent/spark_datasource.py
@@ -161,7 +161,7 @@ class _SparkDatasource(Datasource):
         try:
             self.get_spark()
         except Exception as e:
-            raise TestConnectionError(e) from e
+            raise TestConnectionError(cause=e) from e
 
     # End Abstract Methods
 

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1045,10 +1045,7 @@ class SQLDatasource(Datasource):
             engine: sqlalchemy.Engine = self.get_engine()
             engine.connect()
         except Exception as e:
-            raise TestConnectionError(  # noqa: TRY003
-                "Attempt to connect to datasource failed with the following error message: "
-                f"{e!s}"
-            ) from e
+            raise TestConnectionError(cause=e) from e
         if self.assets and test_assets:
             for asset in self.assets:
                 asset._datasource = self


### PR DESCRIPTION
Update `TestConnectionError` exception to make usage more consistent and bring it in-line with suggestions from `TRYceratops`.

In particular, `TRY003`
https://docs.astral.sh/ruff/rules/raise-vanilla-args/

Also updates `TestConnectionError` to inherit from `ConnectionError` instead the base `Exception`.

---

# raise-vanilla-args (TRY003)

Derived from the **tryceratops** linter.

## What it does
Checks for long exception messages that are not defined in the exception
class itself.

## Why is this bad?
By formatting an exception message at the `raise` site, the exception class
becomes less reusable, and may now raise inconsistent messages depending on
where it is raised.

If the exception message is instead defined within the exception class, it
will be consistent across all `raise` invocations.

This rule is not enforced for some built-in exceptions that are commonly
raised with a message and would be unusual to subclass, such as
`NotImplementedError`.

## Example
```python
class CantBeNegative(Exception):
    pass


def foo(x):
    if x < 0:
        raise CantBeNegative(f"{x} is negative")
```

Use instead:
```python
class CantBeNegative(Exception):
    def __init__(self, number):
        super().__init__(f"{number} is negative")


def foo(x):
    if x < 0:
        raise CantBeNegative(x)
```

---


## Related

- https://guicommits.com/handling-exceptions-in-python-like-a-pro/
- https://github.com/guilatrova/tryceratops

