### PR TITLE
[BUGFIX] SQLDatasource - lowercase unquoted `schema_names` for SQLAlchemy case-sensitivity compatibility

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1007,7 +1007,7 @@ class TableAsset(_SQLAsset):
             The target string in lowercase if it is not bracketed by quotes.
         """
         if cls._is_bracketed_by_quotes(target):
-            LOGGER.info(
+            LOGGER.warning(
                 f"The {target}  string is bracketed by quotes, so it will not be converted to lowercase."
                 " May cause sqlalchemy case-sensitivity issues."
             )

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -62,7 +62,7 @@ FLUENT_DATASOURCE_TEST_DIR: Final = pathlib.Path(__file__).parent
 PG_CONFIG_YAML_FILE: Final = FLUENT_DATASOURCE_TEST_DIR / FileDataContext.GX_YML
 
 
-logger = logging.getLogger(__name__)
+CNF_TEST_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 def sqlachemy_execution_engine_mock_cls(
@@ -172,7 +172,7 @@ def seed_ds_env_vars(
 
     for name, value in config_sub_dict.items():
         monkeypatch.setenv(name, value)
-        logger.info(f"Setting ENV - {name} = '{value}'")
+        CNF_TEST_LOGGER.info(f"Setting ENV - {name} = '{value}'")
 
     # return as tuple of tuples so that the return value is immutable and therefore cacheable
     return tuple((k, v) for k, v in config_sub_dict.items())
@@ -197,7 +197,7 @@ def file_dc_config_dir_init(tmp_path: pathlib.Path) -> pathlib.Path:
     assert gx_yml.exists()
 
     tmp_gx_dir = gx_yml.parent.absolute()
-    logger.info(f"tmp_gx_dir -> {tmp_gx_dir}")
+    CNF_TEST_LOGGER.info(f"tmp_gx_dir -> {tmp_gx_dir}")
     return tmp_gx_dir
 
 
@@ -243,7 +243,7 @@ _CLIENT_DUMMY = _TestClientDummy()
 
 
 def _get_test_client_dummy(*args, **kwargs) -> _TestClientDummy:
-    logger.debug(
+    CNF_TEST_LOGGER.debug(
         f"_get_test_client_dummy() called with \nargs: {pf(args)}\nkwargs: {pf(kwargs)}"
     )
     return _CLIENT_DUMMY
@@ -292,7 +292,7 @@ def cloud_storage_get_client_doubles(
     gcs
     azure
     """
-    logger.warning(
+    CNF_TEST_LOGGER.warning(
         "Patching cloud storage _get_*_client() methods to return client test doubles"
     )
 
@@ -332,7 +332,9 @@ def fluent_yaml_config_file(
         yaml_string = "\n# Fluent\n" + fluent_gx_config_yml_str
         f_append.write(yaml_string)
 
-    logger.debug(f"  Config File Text\n-----------\n{config_file_path.read_text()}")
+    CNF_TEST_LOGGER.debug(
+        f"  Config File Text\n-----------\n{config_file_path.read_text()}"
+    )
     return config_file_path
 
 
@@ -366,7 +368,7 @@ def seed_cloud(
     _CLOUD_API_FAKE_DB.update(fake_db_data)
 
     seeded_datasources = _CLOUD_API_FAKE_DB["data-context-configuration"]["datasources"]
-    logger.info(f"Seeded Datasources ->\n{pf(seeded_datasources, depth=2)}")
+    CNF_TEST_LOGGER.info(f"Seeded Datasources ->\n{pf(seeded_datasources, depth=2)}")
     assert seeded_datasources
 
     yield cloud_api_fake

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -38,7 +38,6 @@ from great_expectations.datasource.fluent import (
 from great_expectations.datasource.fluent.config import GxConfig
 from great_expectations.datasource.fluent.interfaces import Datasource
 from great_expectations.datasource.fluent.sources import _SourceFactories
-from great_expectations.datasource.fluent.sql_datasource import SQLDatasource
 from great_expectations.execution_engine import (
     ExecutionEngine,
     SqlAlchemyExecutionEngine,
@@ -55,7 +54,6 @@ from tests.sqlalchemy_test_doubles import Dialect, MockSaEngine
 if TYPE_CHECKING:
     import responses
     from pytest import FixtureRequest
-    from pytest_mock import MockFixture, MockType
 
     from great_expectations.data_context import CloudDataContext
 
@@ -401,16 +399,3 @@ def seeded_contexts(
         request.param
     )
     return context_fixture
-
-
-@pytest.fixture
-def sql_datasource_test_connection_noop(mocker: MockFixture) -> MockType:
-    """Patch the SQLDatasource.test_connection() method to be a noop and always pass."""
-    CNF_TEST_LOGGER.warning(
-        f"Patching {SQLDatasource.__name__}.test_connection() to a noop"
-    )
-
-    def noop(self):
-        CNF_TEST_LOGGER.warning(".test_connection noop")
-
-    return mocker.patch.object(SQLDatasource, "test_connection", noop)

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -38,6 +38,7 @@ from great_expectations.datasource.fluent import (
 from great_expectations.datasource.fluent.config import GxConfig
 from great_expectations.datasource.fluent.interfaces import Datasource
 from great_expectations.datasource.fluent.sources import _SourceFactories
+from great_expectations.datasource.fluent.sql_datasource import SQLDatasource
 from great_expectations.execution_engine import (
     ExecutionEngine,
     SqlAlchemyExecutionEngine,
@@ -54,6 +55,7 @@ from tests.sqlalchemy_test_doubles import Dialect, MockSaEngine
 if TYPE_CHECKING:
     import responses
     from pytest import FixtureRequest
+    from pytest_mock import MockFixture, MockType
 
     from great_expectations.data_context import CloudDataContext
 
@@ -399,3 +401,16 @@ def seeded_contexts(
         request.param
     )
     return context_fixture
+
+
+@pytest.fixture
+def sql_datasource_test_connection_noop(mocker: MockFixture) -> MockType:
+    """Patch the SQLDatasource.test_connection() method to be a noop and always pass."""
+    CNF_TEST_LOGGER.warning(
+        f"Patching {SQLDatasource.__name__}.test_connection() to a noop"
+    )
+
+    def noop(self):
+        CNF_TEST_LOGGER.warning(".test_connection noop")
+
+    return mocker.patch.object(SQLDatasource, "test_connection", noop)

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -74,20 +74,19 @@ def sql_datasource(
 
 
 @pytest.fixture
-def sql_datasource_test_connection_noop(
+def sql_datasource_table_asset_test_connection_noop(
     monkeypatch: pytest.MonkeyPatch, sql_datasource: SQLDatasource
 ) -> SQLDatasource:
     """
-    Patch and return the sql_datasource fixture `SQLDatasource.test_connection()` and `TableAsset.test_connection()`
-    to be noops and always pass.
+    Patch and return the sql_datasource fixture `TableAsset.test_connection()`
+    to be a noop and always pass.
     """
 
     LOGGER.warning(f"Patching {sql_datasource.name} `.test_connection()` to a noop")
 
     def noop(self: SQLDatasource | TableAsset):
-        LOGGER.warning(f"{self.__class__.__name__}.test_connection noop")
+        LOGGER.warning(f"{self.__class__.__name__}.test_connection noop called")
 
-    # monkeypatch.setattr(SQLDatasource, "test_connection", noop, raising=True)
     monkeypatch.setattr(TableAsset, "test_connection", noop, raising=True)
     return sql_datasource
 
@@ -421,10 +420,12 @@ class TestTableAsset:
     @pytest.mark.parametrize("schema_name", ["my_schema", "MY_SCHEMA", "My_Schema"])
     def test_unquoted_schema_names_are_added_as_lowercase(
         self,
-        sql_datasource_noop_test_connection: SQLDatasource,
+        sql_datasource_table_asset_test_connection_noop: SQLDatasource,
         schema_name: str,
     ):
-        table_asset = sql_datasource_noop_test_connection.add_table_asset(
+        my_datasource: SQLDatasource = sql_datasource_table_asset_test_connection_noop
+
+        table_asset = my_datasource.add_table_asset(
             name="my_table_asset",
             table_name="my_table",
             schema_name=schema_name,
@@ -444,10 +445,12 @@ class TestTableAsset:
     )
     def test_quoted_schema_names_are_not_modified(
         self,
-        sql_datasource_noop_test_connection: SQLDatasource,
+        sql_datasource_table_asset_test_connection_noop: SQLDatasource,
         schema_name: str,
     ):
-        table_asset = sql_datasource_noop_test_connection.add_table_asset(
+        my_datasource: SQLDatasource = sql_datasource_table_asset_test_connection_noop
+
+        table_asset = my_datasource.add_table_asset(
             name="my_table_asset",
             table_name="my_table",
             schema_name=schema_name,

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -73,6 +73,33 @@ def sql_datasource(
     )
 
 
+@pytest.fixture
+def sql_datasource_test_connection_noop(
+    monkeypatch: pytest.MonkeyPatch, sql_datasource: SQLDatasource
+) -> SQLDatasource:
+    """
+    Patch and return the sql_datasource fixture `SQLDatasource.test_connection()` and `TableAsset.test_connection()`
+    to be noops and always pass.
+    """
+
+    LOGGER.warning(f"Patching {sql_datasource.name} `.test_connection()` to a noop")
+
+    def noop(self: SQLDatasource | TableAsset):
+        LOGGER.warning(f"{self.__class__.__name__}.test_connection noop")
+
+    # monkeypatch.setattr(SQLDatasource, "test_connection", noop, raising=True)
+    monkeypatch.setattr(TableAsset, "test_connection", noop, raising=True)
+    return sql_datasource
+
+
+@pytest.fixture
+def sql_datasource_noop_test_connection(
+    sql_datasource: SQLDatasource,
+    sql_datasource_test_connection_noop: MockType,
+) -> SQLDatasource:
+    return sql_datasource
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "ds_kwargs",
@@ -394,11 +421,10 @@ class TestTableAsset:
     @pytest.mark.parametrize("schema_name", ["my_schema", "MY_SCHEMA", "My_Schema"])
     def test_unquoted_schema_names_are_added_as_lowercase(
         self,
-        sql_datasource: SQLDatasource,
-        sql_datasource_test_connection_noop: MockType,
+        sql_datasource_noop_test_connection: SQLDatasource,
         schema_name: str,
     ):
-        table_asset = sql_datasource.add_table_asset(
+        table_asset = sql_datasource_noop_test_connection.add_table_asset(
             name="my_table_asset",
             table_name="my_table",
             schema_name=schema_name,
@@ -418,11 +444,10 @@ class TestTableAsset:
     )
     def test_quoted_schema_names_are_not_modified(
         self,
-        sql_datasource: SQLDatasource,
-        sql_datasource_test_connection_noop: MockType,
+        sql_datasource_noop_test_connection: SQLDatasource,
         schema_name: str,
     ):
-        table_asset = sql_datasource.add_table_asset(
+        table_asset = sql_datasource_noop_test_connection.add_table_asset(
             name="my_table_asset",
             table_name="my_table",
             schema_name=schema_name,

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -61,6 +61,16 @@ def create_engine_fake(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sa, "create_engine", _fake_create_engine, raising=True)
 
 
+@pytest.fixture
+def sql_datasource(
+    ephemeral_context_with_defaults: EphemeralDataContext,
+    filter_gx_datasource_warnings: None,
+) -> SQLDatasource:
+    return ephemeral_context_with_defaults.sources.add_sql(
+        name="my_sql_datasource", connection_string="sqlite:///"
+    )
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "ds_kwargs",


### PR DESCRIPTION
`.lower()` the `schema_name` as passed to `my_datasource.add_table_asset(..., schema_name=...)`.

This is to ensure that sqlalchemy operations and comparisons are performed case-insensitively. 

Note: if the schema name is enclosed in quotes, it remains unmodified.
