### PR TITLE
[BUGFIX] SQLDatasource (V1) - lowercase unquoted schema_names for SQLAlchemy case-sensitivity compatibility

### DIFF
--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -44,6 +44,7 @@ from great_expectations.datasource.fluent.sql_datasource import (
     SQLDatasource,
     TableAsset,
     TestConnectionError,
+    to_lower_if_not_quoted,
 )
 
 if TYPE_CHECKING:
@@ -452,9 +453,7 @@ class SnowflakeDatasource(SQLDatasource):
             return None
         url_path: str = urllib.parse.urlparse(subbed_str).path
 
-        return TableAsset._to_lower_if_not_bracketed_by_quotes(
-            _get_database_and_schema_from_path(url_path)["schema"]
-        )
+        return to_lower_if_not_quoted(_get_database_and_schema_from_path(url_path)["schema"])
 
     @property
     def database(self) -> str | None:

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -444,7 +444,7 @@ class SnowflakeDatasource(SQLDatasource):
         `schema_` to avoid conflict with Pydantic models schema property.
         """
         if isinstance(self.connection_string, (ConnectionDetails, SnowflakeDsn)):
-            return self.connection_string.schema_
+            return to_lower_if_not_quoted(self.connection_string.schema_)
 
         subbed_str: str | None = _get_config_substituted_connection_string(
             self, warning_msg="Unable to determine schema"

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -451,7 +451,10 @@ class SnowflakeDatasource(SQLDatasource):
         if not subbed_str:
             return None
         url_path: str = urllib.parse.urlparse(subbed_str).path
-        return _get_database_and_schema_from_path(url_path)["schema"]
+
+        return TableAsset._to_lower_if_not_bracketed_by_quotes(
+            _get_database_and_schema_from_path(url_path)["schema"]
+        )
 
     @property
     def database(self) -> str | None:

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -887,7 +887,11 @@ class TableAsset(_SQLAsset):
 
     @staticmethod
     def _is_bracketed_by_quotes(target: str) -> bool:
-        """Returns True if the target string is bracketed by quotes.
+        """
+        Returns True if the target string is bracketed by quotes.
+
+        Override this method if the quote characters are different than `'` or `"` in the
+        target database, such as backticks in Databricks SQL.
 
         Arguments:
             target: A string to check if it is bracketed by quotes.
@@ -896,6 +900,27 @@ class TableAsset(_SQLAsset):
             True if the target string is bracketed by quotes.
         """
         return any(target.startswith(quote) and target.endswith(quote) for quote in ["'", '"'])
+
+    @classmethod
+    def _to_lower_if_not_bracketed_by_quotes(cls, target: str) -> str:
+        """Returns the target string in lowercase if it is not bracketed by quotes.
+        This is used to ensure case-insensitivity in sqlalchemy queries.
+
+        Arguments:
+            target: A string to convert to lowercase if it is not bracketed by quotes.
+
+        Returns:
+            The target string in lowercase if it is not bracketed by quotes.
+        """
+        if cls._is_bracketed_by_quotes(target):
+            LOGGER.warning(
+                f"The {target}  string is bracketed by quotes,"
+                " so it will not be converted to lowercase."
+                " May cause sqlalchemy case-sensitivity issues."
+            )
+            return target
+        LOGGER.info(f"Setting {target} to lowercase to ensure sqlalchemy case-insensitivity.")
+        return target.lower()
 
 
 def _warn_for_more_specific_datasource_type(connection_string: str) -> None:
@@ -1075,6 +1100,8 @@ class SQLDatasource(Datasource):
             eg, it could be a TableAsset or a SqliteTableAsset.
         """  # noqa: E501
         order_by_sorters: list[Sorter] = self.parse_order_by_sorters(order_by=order_by)
+        if schema_name:
+            schema_name = self._TableAsset._to_lower_if_not_bracketed_by_quotes(schema_name)
         asset = self._TableAsset(
             name=name,
             table_name=table_name,

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -90,7 +90,7 @@ if TYPE_CHECKING:
 
 LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
-_DEFAULT_QUOTE_CHARACTERS: Final[Tuple[str, str]] = ('"', "'")
+DEFAULT_QUOTE_CHARACTERS: Final[Tuple[str, str]] = ('"', "'")
 
 
 @overload
@@ -103,7 +103,7 @@ def to_lower_if_not_quoted(value: None, quote_characters: Sequence[str] = ...) -
 
 def to_lower_if_not_quoted(
     value: str | None,
-    quote_characters: Sequence[str] = _DEFAULT_QUOTE_CHARACTERS,
+    quote_characters: Sequence[str] = DEFAULT_QUOTE_CHARACTERS,
 ) -> str | None:
     """
     Convert a string to lowercase if it is not enclosed in quotes.
@@ -933,7 +933,7 @@ class TableAsset(_SQLAsset):
         """
         return any(
             target.startswith(quote) and target.endswith(quote)
-            for quote in _DEFAULT_QUOTE_CHARACTERS
+            for quote in DEFAULT_QUOTE_CHARACTERS
         )
 
     @classmethod
@@ -947,7 +947,7 @@ class TableAsset(_SQLAsset):
         Returns:
             The target string in lowercase if it is not bracketed by quotes.
         """
-        return to_lower_if_not_quoted(target, quote_characters=_DEFAULT_QUOTE_CHARACTERS)
+        return to_lower_if_not_quoted(target, quote_characters=DEFAULT_QUOTE_CHARACTERS)
 
 
 def _warn_for_more_specific_datasource_type(connection_string: str) -> None:

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -74,7 +74,8 @@ PG_CONFIG_YAML_FILE: Final = FLUENT_DATASOURCE_TEST_DIR / FileDataContext.GX_YML
 _DEFAULT_TEST_YEARS = list(range(2021, 2023))
 _DEFAULT_TEST_MONTHS = list(range(1, 13))
 
-logger = logging.getLogger(__name__)
+
+CNF_TEST_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 def sqlachemy_execution_engine_mock_cls(
@@ -184,7 +185,7 @@ def seed_ds_env_vars(
 
     for name, value in config_sub_dict.items():
         monkeypatch.setenv(name, value)
-        logger.info(f"Setting ENV - {name} = '{value}'")
+        CNF_TEST_LOGGER.info(f"Setting ENV - {name} = '{value}'")
 
     # return as tuple of tuples so that the return value is immutable and therefore cacheable
     return tuple((k, v) for k, v in config_sub_dict.items())
@@ -209,7 +210,7 @@ def file_dc_config_dir_init(tmp_path: pathlib.Path) -> pathlib.Path:
     assert gx_yml.exists()
 
     tmp_gx_dir = gx_yml.parent.absolute()
-    logger.info(f"tmp_gx_dir -> {tmp_gx_dir}")
+    CNF_TEST_LOGGER.info(f"tmp_gx_dir -> {tmp_gx_dir}")
     return tmp_gx_dir
 
 
@@ -275,7 +276,9 @@ _CLIENT_DUMMY = _TestClientDummy()
 
 
 def _get_test_client_dummy(*args, **kwargs) -> _TestClientDummy:
-    logger.debug(f"_get_test_client_dummy() called with \nargs: {pf(args)}\nkwargs: {pf(kwargs)}")
+    CNF_TEST_LOGGER.debug(
+        f"_get_test_client_dummy() called with \nargs: {pf(args)}\nkwargs: {pf(kwargs)}"
+    )
     return _CLIENT_DUMMY
 
 
@@ -317,12 +320,15 @@ def cloud_storage_get_client_doubles(
     azure_get_client_dummy,
 ):
     """
-    Patches Datasources that rely on a private _get_*_client() method to return test doubles instead.
+    Patches Datasources that rely on a private _get_*_client() method to return test doubles
+    instead.
 
     gcs
     azure
-    """  # noqa: E501
-    logger.warning("Patching cloud storage _get_*_client() methods to return client test doubles")
+    """
+    CNF_TEST_LOGGER.warning(
+        "Patching cloud storage _get_*_client() methods to return client test doubles"
+    )
 
 
 @pytest.fixture
@@ -358,7 +364,7 @@ def fluent_yaml_config_file(
         yaml_string = "\n# Fluent\n" + fluent_gx_config_yml_str
         f_append.write(yaml_string)
 
-    logger.debug(f"  Config File Text\n-----------\n{config_file_path.read_text()}")
+    CNF_TEST_LOGGER.debug(f"  Config File Text\n-----------\n{config_file_path.read_text()}")
     return config_file_path
 
 
@@ -390,7 +396,7 @@ def seed_cloud(
     _CLOUD_API_FAKE_DB.update(fake_db_data)
 
     seeded_datasources = _CLOUD_API_FAKE_DB["data-context-configuration"]["datasources"]
-    logger.info(f"Seeded Datasources ->\n{pf(seeded_datasources, depth=2)}")
+    CNF_TEST_LOGGER.info(f"Seeded Datasources ->\n{pf(seeded_datasources, depth=2)}")
     assert seeded_datasources
 
     yield cloud_api_fake

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -77,8 +77,8 @@ VALID_DS_CONFIG_PARAMS: Final[Sequence[ParameterSet]] = [
                 "user": "my_user",
                 "password": "password",
                 "account": "my_account",
-                "schema": "s_public",
-                "database": "d_public",
+                "schema": "S_PUBLIC",
+                "database": "D_PUBLIC",
                 "role": "my_role",
                 "warehouse": "my_wh",
             }
@@ -820,7 +820,7 @@ def test_get_execution_engine_succeeds():
         param(
             {
                 "name": "std connection_str",
-                "connection_string": "snowflake://user:password@account/db/schema?warehouse=wh&role=role",
+                "connection_string": "snowflake://user:password@account/db/SCHEMA?warehouse=wh&role=role",
             },
             {"url": ANY},
             id="std connection_string str",
@@ -915,7 +915,7 @@ class TestConvenienceProperties:
             datasource._data_context = ephemeral_context_with_defaults
             _ = datasource.schema_
         else:
-            assert datasource.schema_ == datasource.connection_string.schema_
+            assert datasource.schema_ == datasource.connection_string.schema_.lower()
 
     def test_database(
         self,

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -68,7 +68,7 @@ def sql_datasource(
     ephemeral_context_with_defaults: EphemeralDataContext,
     filter_gx_datasource_warnings: None,
 ) -> SQLDatasource:
-    return ephemeral_context_with_defaults.sources.add_sql(
+    return ephemeral_context_with_defaults.data_sources.add_sql(
         name="my_sql_datasource", connection_string="sqlite:///"
     )
 
@@ -367,47 +367,6 @@ def test_specific_datasource_warnings(
             context.data_sources.add_sql(
                 name="my_datasource", connection_string=connection_string
             ).test_connection()
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    "config",
-    [
-        {
-            "name": "connection_string only",
-            "connection_string": "sqlite:///",
-        },
-        {
-            "name": "no subs + kwargs",
-            "connection_string": "sqlite:///",
-            "kwargs": {"isolation_level": "SERIALIZABLE"},
-        },
-        {
-            "name": "subs + kwargs",
-            "connection_string": "sqlite:///${MY_VAR}",
-            "kwargs": {"isolation_level": "SERIALIZABLE"},
-        },
-    ],
-    ids=lambda x: x["name"],
-)
-def test_recreate_from_dict(
-    monkeypatch: pytest.MonkeyPatch,
-    create_engine_fake: None,
-    ephemeral_context_with_defaults: EphemeralDataContext,
-    config: dict,
-):
-    """
-    Test that .dict() method of a datasource can be fed back into the constructor to recreate
-    the datasource.
-    """
-    monkeypatch.setenv("MY_VAR", "my_var_value")
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        d1 = ephemeral_context_with_defaults.sources.add_sql(**config)
-        ephemeral_context_with_defaults.delete_datasource(d1.name)
-        d2 = ephemeral_context_with_defaults.sources.add_sql(**d1.dict())
-    assert d1 == d2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
`.lower()` the schema_name as passed to `my_datasource.add_table_asset(..., schema_name=...)`.

This is to ensure that `sqlalchemy` operations and comparisons are performed case-insensitively.

Note: if the schema name is enclosed in quotes, it remains unmodified.

- https://github.com/great-expectations/great_expectations/pull/10107