### PR TITLE
[MAINTENANCE] Remove public api decorator from non-public V1 code.

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -316,7 +316,6 @@ class ExpectationSuite(SerializableDictDot):
         myself["meta"] = convert_to_json_serializable(myself["meta"])
         return myself
 
-    @public_api
     def remove_expectation(
         self,
         expectation_configuration: Optional[ExpectationConfiguration] = None,
@@ -524,7 +523,6 @@ class ExpectationSuite(SerializableDictDot):
         ]
         return expectation_configurations_attempted_to_be_added
 
-    @public_api
     def add_expectation_configuration(
         self,
         expectation_configuration: ExpectationConfiguration,

--- a/great_expectations/core/metric_domain_types.py
+++ b/great_expectations/core/metric_domain_types.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import enum
 import logging
 
-from great_expectations._docs_decorators import public_api
-
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class MetricDomainTypes(enum.Enum):
     """Enum type, whose members signify the data "Domain", on which a metric can be computed.
 

--- a/great_expectations/core/metric_function_types.py
+++ b/great_expectations/core/metric_function_types.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import enum
 import logging
 
-from great_expectations._docs_decorators import public_api
-
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class MetricFunctionTypes(enum.Enum):
-    """Enum type, whose members depict the nature of return value of a metric implementation function (defined for a specified "ExecutionEngine" subclass) that is the final result (rather than a Callable for deferred execution).
+    """Enum type, whose members depict the nature of return value of a metric implementation function
+    (defined for a specified "ExecutionEngine" subclass) that is the final result
+    (rather than a Callable for deferred execution).
 
     The available types are:
 
@@ -28,9 +27,10 @@ class MetricFunctionTypes(enum.Enum):
     VALUE = "value"
 
 
-@public_api
 class MetricPartialFunctionTypes(enum.Enum):
-    """Enum type, whose members depict the nature of return value of a metric implementation function (defined for a specified "ExecutionEngine" subclass) that is a (partial) Callable to be executed once execution plan is complete.
+    """Enum type, whose members depict the nature of return value of a metric implementation function
+    (defined for a specified "ExecutionEngine" subclass) that is a (partial)
+    Callable to be executed once execution plan is complete.
 
     The available types are:
 
@@ -69,7 +69,6 @@ class MetricPartialFunctionTypes(enum.Enum):
     )
 
     @property
-    @public_api
     def metric_suffix(self) -> str:
         """Examines the "name" property of this "Enum" and returns corresponding suffix for metric registration/usage.
 
@@ -96,7 +95,6 @@ class MetricPartialFunctionTypes(enum.Enum):
         return ""
 
 
-@public_api
 class MetricPartialFunctionTypeSuffixes(enum.Enum):
     """Enum type, whose members specify available suffixes for metrics representing partial functions."""  # noqa: E501
 
@@ -105,7 +103,6 @@ class MetricPartialFunctionTypeSuffixes(enum.Enum):
     AGGREGATE_FUNCTION = "aggregate_fn"
 
 
-@public_api
 class SummarizationMetricNameSuffixes(enum.Enum):
     """Enum type, whose members specify suffixes for metrics used for summarizing Expectation validation results."""  # noqa: E501
 

--- a/great_expectations/core/partitioners.py
+++ b/great_expectations/core/partitioners.py
@@ -3,25 +3,21 @@ from __future__ import annotations
 import re
 from typing import Final, List, Literal, Union
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import pydantic
 
 
-@public_api
 class ColumnPartitionerYearly(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True
     method_name: Literal["partition_on_year"] = "partition_on_year"
 
 
-@public_api
 class ColumnPartitionerMonthly(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True
     method_name: Literal["partition_on_year_and_month"] = "partition_on_year_and_month"
 
 
-@public_api
 class ColumnPartitionerDaily(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True
@@ -30,7 +26,6 @@ class ColumnPartitionerDaily(pydantic.BaseModel):
     )
 
 
-@public_api
 class PartitionerDatetimePart(pydantic.BaseModel):
     datetime_parts: List[str]
     column_name: str
@@ -38,7 +33,6 @@ class PartitionerDatetimePart(pydantic.BaseModel):
     method_name: Literal["partition_on_date_parts"] = "partition_on_date_parts"
 
 
-@public_api
 class PartitionerDividedInteger(pydantic.BaseModel):
     divisor: int
     column_name: str
@@ -46,7 +40,6 @@ class PartitionerDividedInteger(pydantic.BaseModel):
     method_name: Literal["partition_on_divided_integer"] = "partition_on_divided_integer"
 
 
-@public_api
 class PartitionerModInteger(pydantic.BaseModel):
     mod: int
     column_name: str
@@ -54,21 +47,18 @@ class PartitionerModInteger(pydantic.BaseModel):
     method_name: Literal["partition_on_mod_integer"] = "partition_on_mod_integer"
 
 
-@public_api
 class PartitionerColumnValue(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True
     method_name: Literal["partition_on_column_value"] = "partition_on_column_value"
 
 
-@public_api
 class PartitionerMultiColumnValue(pydantic.BaseModel):
     column_names: List[str]
     sort_ascending: bool = True
     method_name: Literal["partition_on_multi_column_values"] = "partition_on_multi_column_values"
 
 
-@public_api
 class PartitionerConvertedDatetime(pydantic.BaseModel):
     column_name: str
     sort_ascending: bool = True

--- a/great_expectations/core/yaml_handler.py
+++ b/great_expectations/core/yaml_handler.py
@@ -5,11 +5,9 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.alias_types import JSONValues  # noqa: TCH001
 
 
-@public_api
 class YAMLHandler:
     """Facade class designed to be a lightweight wrapper around YAML serialization.
 
@@ -43,7 +41,6 @@ class YAMLHandler:
         self._handler.indent(mapping=2, sequence=4, offset=2)
         self._handler.default_flow_style = False
 
-    @public_api
     def load(self, stream: io.TextIOWrapper | str) -> dict[str, JSONValues]:
         """Converts a YAML input stream into a Python dictionary.
 
@@ -66,7 +63,6 @@ class YAMLHandler:
         """  # noqa: E501
         return self._handler.load(stream=stream)
 
-    @public_api
     def dump(
         self,
         data: dict,

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -140,7 +140,6 @@ yaml = YAMLHandler()
 T = TypeVar("T", dict, list, str)
 
 
-@public_api
 class AbstractDataContext(ConfigPeer, ABC):
     """Base class for all Data Contexts that contains shared functionality.
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -450,7 +450,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         return self.variables.expectations_store_name
 
     @expectations_store_name.setter
-    @public_api
     @new_method_or_class(version="0.17.2")
     def expectations_store_name(self, value: str) -> None:
         """Set the name of the expectations store.
@@ -479,7 +478,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         return self.variables.validation_results_store_name
 
     @validation_results_store_name.setter
-    @public_api
     @new_method_or_class(version="0.17.2")
     def validation_results_store_name(self, value: str) -> None:
         """Set the name of the validations store.
@@ -516,7 +514,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         return None
 
     @checkpoint_store_name.setter
-    @public_api
     @new_method_or_class(version="0.17.2")
     def checkpoint_store_name(self, value: str) -> None:
         """Set the name of the checkpoint store.
@@ -649,7 +646,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         """
         ...
 
-    @public_api
     @new_argument(
         argument_name="datasource",
         version="0.15.49",
@@ -720,7 +716,6 @@ class AbstractDataContext(ConfigPeer, ABC):
             raise DataContextError("Datasource is not a FluentDatasource")  # noqa: TRY003
         return datasource
 
-    @public_api
     def update_datasource(
         self,
         datasource: FluentDatasource,
@@ -765,7 +760,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         """
         ...
 
-    @public_api
     @new_method_or_class(version="0.15.48")
     def add_or_update_datasource(
         self,
@@ -861,7 +855,6 @@ class AbstractDataContext(ConfigPeer, ABC):
             if store.get("name") in active_store_names  # type: ignore[arg-type,operator]
         ]
 
-    @public_api
     def get_datasource(self, datasource_name: str = "default") -> FluentDatasource:
         """Retrieve a given Datasource by name from the context's underlying DatasourceStore.
 
@@ -885,7 +878,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         datasource._data_context = self
         return datasource
 
-    @public_api
     def add_store(self, store_name: str, store_config: StoreConfigTypedDict) -> Store:
         """Add a new Store to the DataContext.
 
@@ -982,7 +974,6 @@ class AbstractDataContext(ConfigPeer, ABC):
             self.variables.data_docs_sites = sites
             self._save_project_config()
 
-    @public_api
     @new_method_or_class(version="0.15.48")
     def delete_store(self, store_name: str) -> None:
         """Delete an existing Store from the DataContext.
@@ -1004,7 +995,6 @@ class AbstractDataContext(ConfigPeer, ABC):
 
         self._save_project_config()
 
-    @public_api
     def list_datasources(self) -> List[dict]:
         """List the configurations of the datasources associated with this context.
 
@@ -1015,7 +1005,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         """
         return [ds.dict() for ds in self.datasources.values()]
 
-    @public_api
     def delete_datasource(self, datasource_name: Optional[str]) -> None:
         """Delete a given Datasource by name.
 
@@ -1035,7 +1024,6 @@ class AbstractDataContext(ConfigPeer, ABC):
 
         self._save_project_config()
 
-    @public_api
     def get_validator(  # noqa: PLR0913
         self,
         datasource_name: Optional[str] = None,
@@ -1330,7 +1318,6 @@ class AbstractDataContext(ConfigPeer, ABC):
 
         return validator
 
-    @public_api
     def get_batch_list(  # noqa: PLR0913
         self,
         datasource_name: Optional[str] = None,
@@ -1498,7 +1485,6 @@ class AbstractDataContext(ConfigPeer, ABC):
             )
         return datasource_names
 
-    @public_api
     def get_available_data_asset_names(
         self,
         datasource_names: str | list[str] | None = None,

--- a/great_expectations/datasource/fluent/schemas/BatchRequest.json
+++ b/great_expectations/datasource/fluent/schemas/BatchRequest.json
@@ -108,7 +108,6 @@
     "definitions": {
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -135,7 +134,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -165,7 +163,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -197,7 +194,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -229,7 +225,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -256,7 +251,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -283,7 +277,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -310,7 +303,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -345,7 +337,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
@@ -119,7 +119,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -146,7 +145,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -176,7 +174,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -208,7 +205,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -240,7 +236,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -267,7 +262,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -294,7 +288,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -321,7 +314,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -356,7 +348,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
@@ -75,7 +75,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -102,7 +101,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -132,7 +130,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -164,7 +161,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -196,7 +192,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -223,7 +218,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -250,7 +244,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +270,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -312,7 +304,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
@@ -70,7 +70,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -97,7 +96,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -127,7 +125,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -159,7 +156,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -191,7 +187,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -218,7 +213,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -245,7 +239,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +265,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -307,7 +299,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/Datasource.json
@@ -52,7 +52,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -79,7 +78,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -109,7 +107,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -141,7 +138,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -173,7 +169,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -200,7 +195,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -227,7 +221,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -254,7 +247,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -289,7 +281,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
@@ -98,7 +98,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -125,7 +124,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -155,7 +153,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -187,7 +184,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -219,7 +215,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -246,7 +241,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -273,7 +267,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -300,7 +293,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -335,7 +327,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
@@ -70,7 +70,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -97,7 +96,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -127,7 +125,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -159,7 +156,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -191,7 +187,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -218,7 +213,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -245,7 +239,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +265,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -307,7 +299,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
@@ -110,7 +110,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -137,7 +136,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -167,7 +165,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -199,7 +196,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -231,7 +227,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -258,7 +253,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -285,7 +279,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -312,7 +305,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -347,7 +339,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
@@ -94,7 +94,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -121,7 +120,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -151,7 +149,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -183,7 +180,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -215,7 +211,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -242,7 +237,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -269,7 +263,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -296,7 +289,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -331,7 +323,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
@@ -59,10 +59,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
@@ -59,10 +59,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource.json
@@ -55,7 +55,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -82,7 +81,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -112,7 +110,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -144,7 +141,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -176,7 +172,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -203,7 +198,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -230,7 +224,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -257,7 +250,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -292,7 +284,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
@@ -384,7 +384,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -411,7 +410,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -441,7 +439,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -473,7 +470,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -505,7 +501,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -532,7 +527,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -559,7 +553,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -586,7 +579,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -621,7 +613,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
@@ -75,7 +75,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -102,7 +101,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -132,7 +130,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -164,7 +161,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -196,7 +192,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -223,7 +218,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -250,7 +244,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +270,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -312,7 +304,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
@@ -68,7 +68,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -95,7 +94,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -125,7 +123,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -157,7 +154,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -189,7 +185,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -216,7 +211,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -243,7 +237,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -270,7 +263,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -305,7 +297,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
@@ -70,10 +70,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }
@@ -275,7 +275,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -302,7 +301,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -332,7 +330,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -364,7 +361,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -396,7 +392,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -423,7 +418,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -450,7 +444,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -477,7 +470,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -512,7 +504,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
@@ -124,7 +124,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -151,7 +150,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -181,7 +179,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -213,7 +210,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -245,7 +241,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +267,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -299,7 +293,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -326,7 +319,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -361,7 +353,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
@@ -98,7 +98,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -125,7 +124,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -155,7 +153,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -187,7 +184,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -219,7 +215,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -246,7 +241,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -273,7 +267,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -300,7 +293,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -335,7 +327,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
@@ -122,7 +122,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -149,7 +148,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -179,7 +177,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -211,7 +208,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -243,7 +239,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -270,7 +265,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -297,7 +291,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -324,7 +317,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -359,7 +351,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
@@ -136,7 +136,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -163,7 +162,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -193,7 +191,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -225,7 +222,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -257,7 +253,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -284,7 +279,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -311,7 +305,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -338,7 +331,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -373,7 +365,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
@@ -196,7 +196,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -223,7 +222,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -253,7 +251,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -285,7 +282,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -317,7 +313,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -344,7 +339,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -371,7 +365,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -398,7 +391,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -433,7 +425,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
@@ -183,7 +183,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -210,7 +209,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -240,7 +238,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -272,7 +269,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -304,7 +300,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -331,7 +326,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -358,7 +352,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -385,7 +378,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -420,7 +412,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
@@ -94,7 +94,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -121,7 +120,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -151,7 +149,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -183,7 +180,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -215,7 +211,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -242,7 +237,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -269,7 +263,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -296,7 +289,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -331,7 +323,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
@@ -108,7 +108,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -135,7 +134,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -165,7 +163,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -197,7 +194,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -229,7 +225,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -256,7 +251,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -283,7 +277,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -310,7 +303,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -345,7 +337,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
@@ -107,7 +107,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -134,7 +133,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -164,7 +162,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -196,7 +193,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -228,7 +224,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -255,7 +250,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -282,7 +276,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -309,7 +302,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -344,7 +336,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
@@ -124,7 +124,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -151,7 +150,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -181,7 +179,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -213,7 +210,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -245,7 +241,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +267,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -299,7 +293,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -326,7 +319,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -361,7 +353,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
@@ -104,7 +104,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -131,7 +130,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -161,7 +159,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -193,7 +190,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -225,7 +221,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -252,7 +247,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -279,7 +273,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -306,7 +299,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -341,7 +333,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
@@ -151,7 +151,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -178,7 +177,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -208,7 +206,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -240,7 +237,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -272,7 +268,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -299,7 +294,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -326,7 +320,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -353,7 +346,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -388,7 +380,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
@@ -143,7 +143,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -170,7 +169,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -200,7 +198,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -232,7 +229,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -264,7 +260,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -291,7 +286,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -318,7 +312,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -345,7 +338,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -380,7 +372,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
@@ -126,7 +126,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -153,7 +152,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -183,7 +181,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -215,7 +212,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -247,7 +243,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -274,7 +269,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -301,7 +295,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -328,7 +321,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -363,7 +355,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
@@ -152,7 +152,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -179,7 +178,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -209,7 +207,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -241,7 +238,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -273,7 +269,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -300,7 +295,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -327,7 +321,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -354,7 +347,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -389,7 +381,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
@@ -380,7 +380,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -407,7 +406,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -437,7 +435,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -469,7 +466,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -501,7 +497,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -528,7 +523,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -555,7 +549,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -582,7 +575,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -617,7 +609,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
@@ -160,7 +160,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -187,7 +186,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -217,7 +215,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -249,7 +246,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -281,7 +277,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -308,7 +303,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -335,7 +329,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -362,7 +355,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -397,7 +389,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
@@ -59,10 +59,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
@@ -59,10 +59,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
@@ -59,10 +59,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
@@ -119,7 +119,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -146,7 +145,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -176,7 +174,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -208,7 +205,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -240,7 +236,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -267,7 +262,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -294,7 +288,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -321,7 +314,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -356,7 +348,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
@@ -70,7 +70,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -97,7 +96,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -127,7 +125,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -159,7 +156,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -191,7 +187,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -218,7 +213,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -245,7 +239,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +265,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -307,7 +299,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
@@ -75,7 +75,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -102,7 +101,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -132,7 +130,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -164,7 +161,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -196,7 +192,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -223,7 +218,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -250,7 +244,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +270,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -312,7 +304,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource.json
@@ -116,7 +116,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -143,7 +142,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -173,7 +171,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -205,7 +202,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -237,7 +233,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -264,7 +259,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -291,7 +285,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -318,7 +311,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -353,7 +345,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
@@ -70,7 +70,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -97,7 +96,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -127,7 +125,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -159,7 +156,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -191,7 +187,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -218,7 +213,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -245,7 +239,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +265,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -307,7 +299,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
@@ -75,7 +75,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -102,7 +101,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -132,7 +130,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -164,7 +161,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -196,7 +192,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -223,7 +218,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -250,7 +244,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +270,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -312,7 +304,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -124,7 +124,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -151,7 +150,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -181,7 +179,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -213,7 +210,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -245,7 +241,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +267,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -299,7 +293,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -326,7 +319,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -361,7 +353,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
@@ -70,7 +70,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -97,7 +96,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -127,7 +125,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -159,7 +156,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -191,7 +187,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -218,7 +213,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -245,7 +239,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +265,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -307,7 +299,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
@@ -75,7 +75,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -102,7 +101,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -132,7 +130,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -164,7 +161,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -196,7 +192,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -223,7 +218,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -250,7 +244,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +270,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -312,7 +304,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
@@ -582,7 +582,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -609,7 +608,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -639,7 +637,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -671,7 +668,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -703,7 +699,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -730,7 +725,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -757,7 +751,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -784,7 +777,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -819,7 +811,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
@@ -325,7 +325,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -352,7 +351,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -382,7 +380,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -414,7 +411,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -446,7 +442,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -473,7 +468,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -500,7 +494,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -527,7 +520,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -562,7 +554,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
@@ -84,7 +84,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -111,7 +110,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -141,7 +139,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -173,7 +170,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -205,7 +201,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -232,7 +227,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -259,7 +253,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -286,7 +279,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -321,7 +313,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
@@ -296,7 +296,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -323,7 +322,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -353,7 +351,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -385,7 +382,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -417,7 +413,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -444,7 +439,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -471,7 +465,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -498,7 +491,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -533,7 +525,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
@@ -132,7 +132,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -159,7 +158,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -189,7 +187,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -221,7 +218,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -253,7 +249,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -280,7 +275,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -307,7 +301,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -334,7 +327,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -369,7 +361,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
@@ -149,7 +149,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -176,7 +175,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -206,7 +204,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -238,7 +235,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -270,7 +266,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -297,7 +292,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -324,7 +318,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -351,7 +344,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -386,7 +378,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
@@ -129,7 +129,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -156,7 +155,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -186,7 +184,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -218,7 +215,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -250,7 +246,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +272,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -304,7 +298,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -331,7 +324,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -366,7 +358,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
@@ -572,7 +572,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -599,7 +598,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -629,7 +627,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -661,7 +658,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -693,7 +689,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -720,7 +715,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -747,7 +741,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -774,7 +767,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -809,7 +801,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
@@ -325,7 +325,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -352,7 +351,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -382,7 +380,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -414,7 +411,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -446,7 +442,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -473,7 +468,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -500,7 +494,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -527,7 +520,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -562,7 +554,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
@@ -84,7 +84,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -111,7 +110,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -141,7 +139,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -173,7 +170,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -205,7 +201,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -232,7 +227,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -259,7 +253,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -286,7 +279,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -321,7 +313,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
@@ -296,7 +296,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -323,7 +322,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -353,7 +351,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -385,7 +382,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -417,7 +413,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -444,7 +439,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -471,7 +465,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -498,7 +491,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -533,7 +525,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
@@ -132,7 +132,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -159,7 +158,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -189,7 +187,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -221,7 +218,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -253,7 +249,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -280,7 +275,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -307,7 +301,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -334,7 +327,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -369,7 +361,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
@@ -149,7 +149,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -176,7 +175,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -206,7 +204,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -238,7 +235,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -270,7 +266,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -297,7 +292,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -324,7 +318,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -351,7 +344,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -386,7 +378,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
@@ -129,7 +129,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -156,7 +155,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -186,7 +184,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -218,7 +215,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -250,7 +246,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +272,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -304,7 +298,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -331,7 +324,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -366,7 +358,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource.json
@@ -85,7 +85,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -112,7 +111,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -142,7 +140,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -174,7 +171,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -206,7 +202,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -233,7 +228,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -260,7 +254,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -287,7 +280,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -322,7 +314,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
@@ -68,7 +68,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -95,7 +94,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -125,7 +123,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -157,7 +154,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -189,7 +185,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -216,7 +211,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -243,7 +237,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -270,7 +263,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -305,7 +297,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
@@ -572,7 +572,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -599,7 +598,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -629,7 +627,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -661,7 +658,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -693,7 +689,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -720,7 +715,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -747,7 +741,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -774,7 +767,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -809,7 +801,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
@@ -325,7 +325,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -352,7 +351,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -382,7 +380,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -414,7 +411,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -446,7 +442,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -473,7 +468,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -500,7 +494,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -527,7 +520,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -562,7 +554,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
@@ -84,7 +84,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -111,7 +110,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -141,7 +139,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -173,7 +170,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -205,7 +201,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -232,7 +227,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -259,7 +253,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -286,7 +279,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -321,7 +313,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
@@ -296,7 +296,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -323,7 +322,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -353,7 +351,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -385,7 +382,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -417,7 +413,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -444,7 +439,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -471,7 +465,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -498,7 +491,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -533,7 +525,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
@@ -132,7 +132,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -159,7 +158,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -189,7 +187,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -221,7 +218,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -253,7 +249,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -280,7 +275,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -307,7 +301,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -334,7 +327,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -369,7 +361,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
@@ -149,7 +149,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -176,7 +175,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -206,7 +204,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -238,7 +235,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -270,7 +266,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -297,7 +292,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -324,7 +318,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -351,7 +344,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -386,7 +378,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
@@ -129,7 +129,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -156,7 +155,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -186,7 +184,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -218,7 +215,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -250,7 +246,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +272,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -304,7 +298,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -331,7 +324,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -366,7 +358,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
@@ -587,7 +587,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -614,7 +613,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -644,7 +642,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -676,7 +673,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -708,7 +704,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -735,7 +730,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -762,7 +756,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -789,7 +782,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -824,7 +816,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
@@ -325,7 +325,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -352,7 +351,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -382,7 +380,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -414,7 +411,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -446,7 +442,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -473,7 +468,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -500,7 +494,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -527,7 +520,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -562,7 +554,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
@@ -84,7 +84,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -111,7 +110,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -141,7 +139,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -173,7 +170,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -205,7 +201,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -232,7 +227,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -259,7 +253,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -286,7 +279,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -321,7 +313,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
@@ -296,7 +296,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -323,7 +322,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -353,7 +351,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -385,7 +382,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -417,7 +413,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -444,7 +439,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -471,7 +465,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -498,7 +491,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -533,7 +525,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
@@ -132,7 +132,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -159,7 +158,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -189,7 +187,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -221,7 +218,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -253,7 +249,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -280,7 +275,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -307,7 +301,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -334,7 +327,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -369,7 +361,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
@@ -149,7 +149,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -176,7 +175,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -206,7 +204,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -238,7 +235,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -270,7 +266,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -297,7 +292,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -324,7 +318,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -351,7 +344,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -386,7 +378,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
@@ -129,7 +129,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -156,7 +155,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -186,7 +184,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -218,7 +215,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -250,7 +246,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +272,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -304,7 +298,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -331,7 +324,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -366,7 +358,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
@@ -587,7 +587,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -614,7 +613,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -644,7 +642,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -676,7 +673,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -708,7 +704,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -735,7 +730,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -762,7 +756,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -789,7 +782,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -824,7 +816,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
@@ -325,7 +325,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -352,7 +351,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -382,7 +380,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -414,7 +411,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -446,7 +442,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -473,7 +468,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -500,7 +494,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -527,7 +520,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -562,7 +554,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
@@ -84,7 +84,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -111,7 +110,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -141,7 +139,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -173,7 +170,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -205,7 +201,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -232,7 +227,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -259,7 +253,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -286,7 +279,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -321,7 +313,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
@@ -296,7 +296,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -323,7 +322,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -353,7 +351,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -385,7 +382,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -417,7 +413,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -444,7 +439,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -471,7 +465,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -498,7 +491,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -533,7 +525,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
@@ -132,7 +132,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -159,7 +158,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -189,7 +187,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -221,7 +218,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -253,7 +249,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -280,7 +275,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -307,7 +301,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -334,7 +327,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -369,7 +361,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
@@ -149,7 +149,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -176,7 +175,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -206,7 +204,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -238,7 +235,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -270,7 +266,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -297,7 +292,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -324,7 +318,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -351,7 +344,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -386,7 +378,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
@@ -129,7 +129,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -156,7 +155,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -186,7 +184,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -218,7 +215,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -250,7 +246,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +272,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -304,7 +298,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -331,7 +324,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -366,7 +358,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
@@ -119,7 +119,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -146,7 +145,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -176,7 +174,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -208,7 +205,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -240,7 +236,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -267,7 +262,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -294,7 +288,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -321,7 +314,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -356,7 +348,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
@@ -70,7 +70,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -97,7 +96,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -127,7 +125,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -159,7 +156,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -191,7 +187,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -218,7 +213,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -245,7 +239,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -272,7 +265,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -307,7 +299,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -75,7 +75,6 @@
         },
         "PartitionerColumnValue": {
             "title": "PartitionerColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -102,7 +101,6 @@
         },
         "PartitionerMultiColumnValue": {
             "title": "PartitionerMultiColumnValue",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_names": {
@@ -132,7 +130,6 @@
         },
         "PartitionerDividedInteger": {
             "title": "PartitionerDividedInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "divisor": {
@@ -164,7 +161,6 @@
         },
         "PartitionerModInteger": {
             "title": "PartitionerModInteger",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "mod": {
@@ -196,7 +192,6 @@
         },
         "ColumnPartitionerYearly": {
             "title": "ColumnPartitionerYearly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -223,7 +218,6 @@
         },
         "ColumnPartitionerMonthly": {
             "title": "ColumnPartitionerMonthly",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -250,7 +244,6 @@
         },
         "ColumnPartitionerDaily": {
             "title": "ColumnPartitionerDaily",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -277,7 +270,6 @@
         },
         "PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "datetime_parts": {
@@ -312,7 +304,6 @@
         },
         "PartitionerConvertedDatetime": {
             "title": "PartitionerConvertedDatetime",
-            "description": "--Public API--",
             "type": "object",
             "properties": {
                 "column_name": {

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch_manager import BatchManager
 from great_expectations.core.metric_domain_types import MetricDomainTypes
@@ -77,7 +76,6 @@ class MetricComputationConfiguration(DictDot):
     compute_domain_kwargs: Optional[dict] = None
     accessor_domain_kwargs: Optional[dict] = None
 
-    @public_api
     @override
     def to_dict(self) -> dict:
         """Returns: this MetricComputationConfiguration as a Python dictionary
@@ -87,7 +85,6 @@ class MetricComputationConfiguration(DictDot):
         """
         return asdict(self)
 
-    @public_api
     def to_json_dict(self) -> dict:
         """Returns: this MetricComputationConfiguration as a JSON dictionary
 
@@ -108,7 +105,6 @@ class PartitionDomainKwargs:
     accessor: dict
 
 
-@public_api
 class ExecutionEngine(ABC):
     """ExecutionEngine defines interfaces and provides common methods for loading Batch of data and compute metrics.
 
@@ -289,7 +285,6 @@ class ExecutionEngine(ABC):
         """Resolve a bundle of metrics with the same compute Domain as part of a single trip to the compute engine."""  # noqa: E501
         raise NotImplementedError
 
-    @public_api
     def get_domain_records(
         self,
         domain_kwargs: dict,
@@ -305,7 +300,6 @@ class ExecutionEngine(ABC):
 
         raise NotImplementedError
 
-    @public_api
     def get_compute_domain(
         self,
         domain_kwargs: dict,

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -22,7 +22,6 @@ from typing import (
 import pandas as pd
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import aws, azure, google
 from great_expectations.compatibility.sqlalchemy_and_pandas import (
     execute_pandas_reader_fn,
@@ -67,7 +66,6 @@ HASH_THRESHOLD = 1e9
 DataFrameFactoryFn: TypeAlias = Callable[..., pd.DataFrame]
 
 
-@public_api
 class PandasExecutionEngine(ExecutionEngine):
     """PandasExecutionEngine instantiates the ExecutionEngine API to support computations using Pandas.
 
@@ -484,7 +482,6 @@ not {batch_spec.__class__.__name__}"""  # noqa: E501
         """Resolve a bundle of metrics with the same compute Domain as part of a single trip to the compute engine."""  # noqa: E501
         return {}  # This is NO-OP for "PandasExecutionEngine" (no bundling for direct execution computational backend).  # noqa: E501
 
-    @public_api
     @override
     def get_domain_records(  # noqa: C901, PLR0912
         self,
@@ -594,7 +591,6 @@ not {batch_spec.__class__.__name__}"""  # noqa: E501
 
         return data
 
-    @public_api
     @override
     def get_compute_domain(
         self,

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -22,7 +22,7 @@ from typing import (
 
 from dateutil.parser import parse
 
-from great_expectations._docs_decorators import deprecated_argument, public_api
+from great_expectations._docs_decorators import deprecated_argument
 from great_expectations.compatibility import py4j, pyspark
 from great_expectations.compatibility.pyspark import (
     functions as F,
@@ -91,7 +91,6 @@ def apply_dateutil_parse(column):
     "The existing Spark context will be reused if possible. If a spark_config is passed that doesn't match "  # noqa: E501
     "the existing config, the context will be stopped and restarted in local environments only.",
 )
-@public_api
 class SparkDFExecutionEngine(ExecutionEngine):
     """SparkDFExecutionEngine instantiates the ExecutionEngine API to support computations using Spark platform.
 
@@ -620,7 +619,6 @@ illegal.  Please check your config."""  # noqa: E501
                 f"Unable to find reader_method {reader_method} in spark.",
             )
 
-    @public_api
     @override
     def get_domain_records(  # noqa: C901, PLR0912, PLR0915
         self,
@@ -752,7 +750,6 @@ illegal.  Please check your config."""  # noqa: E501
             condition=joined_condition, condition_type=RowConditionParserType.SPARK_SQL
         )
 
-    @public_api
     @override
     def get_compute_domain(
         self,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -35,7 +35,7 @@ from great_expectations._version import get_versions  # isort:skip
 
 __version__ = get_versions()["version"]  # isort:skip
 
-from great_expectations._docs_decorators import new_method_or_class, public_api
+from great_expectations._docs_decorators import new_method_or_class
 from great_expectations.compatibility import aws, snowflake, sqlalchemy, trino
 from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.sqlalchemy import Subquery
@@ -248,7 +248,6 @@ def _dialect_requires_persisted_connection(
     return return_val
 
 
-@public_api
 class SqlAlchemyExecutionEngine(ExecutionEngine):
     """SparkDFExecutionEngine instantiates the ExecutionEngine API to support computations using Spark platform.
 
@@ -590,7 +589,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             create_engine_kwargs,
         )
 
-    @public_api
     @override
     def get_domain_records(  # noqa: C901, PLR0912, PLR0915
         self,
@@ -787,7 +785,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
 
         return selectable
 
-    @public_api
     @override
     def get_compute_domain(
         self,
@@ -1307,7 +1304,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             with self.engine.connect() as connection:
                 yield connection
 
-    @public_api
     @new_method_or_class(version="0.16.14")
     def execute_query(
         self, query: sqlalchemy.Selectable
@@ -1325,7 +1321,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
 
         return result
 
-    @public_api
     @new_method_or_class(version="0.16.14")
     def execute_query_in_transaction(
         self, query: sqlalchemy.Selectable

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1186,7 +1186,6 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         pass  # no-op
 
     # Renamed from validate due to collision with Pydantic method of the same name
-    @public_api
     def validate_(  # noqa: PLR0913
         self,
         validator: Validator,

--- a/great_expectations/experimental/rule_based_profiler/rule_based_profiler_result.py
+++ b/great_expectations/experimental/rule_based_profiler/rule_based_profiler_result.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import (
     ExpectationSuite,  # noqa: TCH001
@@ -25,7 +24,6 @@ if TYPE_CHECKING:
     from great_expectations.alias_types import JSONValues
 
 
-@public_api
 @dataclass(frozen=True)
 class RuleBasedProfilerResult(SerializableDictDot):
     """
@@ -101,7 +99,6 @@ class RuleBasedProfilerResult(SerializableDictDot):
             "citation": self.citation,
         }
 
-    @public_api
     @override
     def to_json_dict(self) -> dict[str, JSONValues]:
         """
@@ -112,7 +109,6 @@ class RuleBasedProfilerResult(SerializableDictDot):
         """
         return self.to_dict()
 
-    @public_api
     def get_expectation_suite(self, expectation_suite_name: str) -> ExpectationSuite:
         """
         Retrieve the `ExpectationSuite` generated during the `RuleBasedProfiler` run.

--- a/great_expectations/profile/base.py
+++ b/great_expectations/profile/base.py
@@ -5,7 +5,6 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.core.profiler_types_mapping import ProfilerTypeMapping
 
 if TYPE_CHECKING:
@@ -141,8 +140,7 @@ class Profiler(metaclass=abc.ABCMeta):
     def __init__(self, configuration: Optional[dict] = None) -> None:
         self.configuration = configuration
 
-    @public_api  # noqa: B027
-    def validate(  # empty-method-without-abstract-decorator
+    def validate(  # noqa: B027  # empty-method-without-abstract-decorator
         self, item_to_validate: Any
     ) -> None:
         """Raise an exception if `item_to_validate` cannot be profiled.

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from typing import Optional, Tuple, Union
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.core.domain import Domain
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.metric_domain_types import MetricDomainTypes
@@ -11,7 +10,6 @@ from great_expectations.experimental.metric_repository.metrics import MetricType
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 
-@public_api
 class MetricConfiguration:
     """An interface for configuring Metrics.
 
@@ -159,7 +157,6 @@ class MetricConfiguration:
             self.metric_value_kwargs_id,
         )
 
-    @public_api
     def to_json_dict(self) -> dict:
         """Returns a JSON-serializable dict representation of this MetricConfiguration.
 

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.exception_info import ExceptionInfo
 from great_expectations.validator.metric_configuration import MetricConfiguration
@@ -52,7 +51,6 @@ class MetricsCalculator:
     def show_progress_bars(self, enable: bool) -> None:
         self._show_progress_bars = enable
 
-    @public_api
     def columns(self, domain_kwargs: Optional[Dict[str, Any]] = None) -> List[str]:
         """
         Convenience method to run "table.columns" metric.
@@ -78,7 +76,6 @@ class MetricsCalculator:
 
         return columns
 
-    @public_api
     def head(
         self,
         n_rows: int = 5,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -27,7 +27,7 @@ import pandas as pd
 from marshmallow import ValidationError
 
 from great_expectations import __version__ as ge_version
-from great_expectations._docs_decorators import deprecated_argument, public_api
+from great_expectations._docs_decorators import deprecated_argument
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.expectation_suite import (
     ExpectationSuite,
@@ -126,7 +126,6 @@ class ValidationDependencies:
         return list(self.metric_configurations.values())
 
 
-@public_api
 class Validator:
     """Validator is the key object used to create Expectations, validate Expectations, and get Metrics for Expectations.
 
@@ -285,7 +284,6 @@ class Validator:
     def load_batch_list(self, batch_list: Sequence[Batch | FluentBatch]) -> None:
         self._execution_engine.batch_manager.load_batch_list(batch_list=batch_list)
 
-    @public_api
     def get_metric(
         self,
         metric: MetricConfiguration,
@@ -341,7 +339,6 @@ class Validator:
             min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
         )
 
-    @public_api
     def columns(self, domain_kwargs: Optional[Dict[str, Any]] = None) -> List[str]:
         """Convenience method to obtain Batch columns.
 
@@ -353,7 +350,6 @@ class Validator:
         """
         return self._metrics_calculator.columns(domain_kwargs=domain_kwargs)
 
-    @public_api
     def head(
         self,
         n_rows: int = 5,
@@ -843,7 +839,6 @@ class Validator:
 
         return evrs
 
-    @public_api
     def remove_expectation(
         self,
         expectation_configuration: ExpectationConfiguration,
@@ -949,7 +944,6 @@ class Validator:
 
         self._default_expectation_args[argument] = value
 
-    @public_api
     def get_expectation_suite(  # noqa: C901, PLR0912, PLR0913
         self,
         discard_failed_expectations: bool = True,
@@ -1041,7 +1035,6 @@ class Validator:
             logger.info(message + settings_message)
         return expectation_suite
 
-    @public_api
     def save_expectation_suite(  # noqa: PLR0913
         self,
         filepath: Optional[str] = None,
@@ -1089,7 +1082,6 @@ class Validator:
         else:
             raise ValueError("Unable to save config: filepath or data_context must be available.")  # noqa: TRY003
 
-    @public_api
     @deprecated_argument(
         argument_name="run_id",
         message="Only the str version of this argument is deprecated. run_id should be a RunIdentifier or dict. Support will be removed in 0.16.0.",  # noqa: E501


### PR DESCRIPTION
For a doc listing all the public methods we are keeping vs removing see:
https://greatexpectations.atlassian.net/wiki/spaces/SUP/pages/1205534723/V1+Public+API


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
