### PR TITLE
[MAINTENANCE] Pin setuptools

### DIFF
--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -20,7 +20,7 @@ pytest-timeout>=2.3.1
 pytest-xdist>=3.6.1
 requirements-parser>=0.9.0
 responses>=0.23.1 # requests mocking
-setuptools>=70.0.0,<71.0.2 # 70.0.0 required for python 3.12, 71.0.2 causes import error for pkg_resources
+setuptools==70.0.0 # 70.0.0 required for python 3.12, 71.0.1 causes import error for pkg_resources
 # https://github.com/syrusakbary/snapshottest/issues/166
 # not compatible with python 3.12
 snapshottest==0.6.0; python_version < "3.12" # GX Cloud atomic renderer tests

--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -20,7 +20,7 @@ pytest-timeout>=2.3.1
 pytest-xdist>=3.6.1
 requirements-parser>=0.9.0
 responses>=0.23.1 # requests mocking
-setuptools>=70.0.0 # required for python 3.12
+setuptools>=70.0.0,<71.0.2 # 70.0.0 required for python 3.12, 71.0.2 causes import error for pkg_resources
 # https://github.com/syrusakbary/snapshottest/issues/166
 # not compatible with python 3.12
 snapshottest==0.6.0; python_version < "3.12" # GX Cloud atomic renderer tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,3 @@ tqdm>=4.59.0
 typing-extensions>=4.1.0 # Leverage type annotations from recent Python releases
 tzlocal>=1.2
 urllib3>=1.26
-setuptools>=70.0.0,<71.0.2 # 70.0.0 required for python 3.12, 71.0.2 causes import error for pkg_resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ tqdm>=4.59.0
 typing-extensions>=4.1.0 # Leverage type annotations from recent Python releases
 tzlocal>=1.2
 urllib3>=1.26
+setuptools>=70.0.0,<71.0.2 # 70.0.0 required for python 3.12, 71.0.2 causes import error for pkg_resources


### PR DESCRIPTION
`setuptools` higher than [71.0.0](https://setuptools.pypa.io/en/latest/history.html#v71-0-0) causes an exception when importing `pkg_resources`:
```
 tests/integration/test_script_runner.py:15: in <module>
    import pkg_resources
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pkg_resources/__init__.py:93: in <module>
    from jaraco.text import (
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/setuptools/_vendor/jaraco/text/__init__.py:12: in <module>
    from jaraco.context import ExceptionTrap
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/setuptools/_vendor/jaraco/context.py:17: in <module>
    from backports import tarfile
E   ImportError: cannot import name 'tarfile' from 'backports' (/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/backports/__init__.py)
```

long term solution is to migrate off of `pkg_resources`, which is legacy code.