### PR TITLE
[BUGFIX] Remove illegible duplicate local Data Docs link from Slack renderer

### DIFF
--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -79,7 +79,7 @@ class SlackRenderer(Renderer):
                             """
 
             summary_text += f"*Asset*: {data_asset_name}  "
-            if validation_link is not None:
+            if validation_link is not None and "file://" not in validation_link:
                 summary_text += f"*Expectation Suite*: {expectation_suite_name}  <{validation_link}|View Results>"
             else:
                 summary_text += f"*Expectation Suite*: {expectation_suite_name}"

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -79,6 +79,7 @@ class SlackRenderer(Renderer):
                             """
 
             summary_text += f"*Asset*: {data_asset_name}  "
+            # Slack does not allow links to local files due to security risks
             if validation_link is not None and "file://" not in validation_link:
                 summary_text += f"*Expectation Suite*: {expectation_suite_name}  <{validation_link}|View Results>"
             else:
@@ -148,8 +149,8 @@ class SlackRenderer(Renderer):
         report_element = None
         if docs_link:
             try:
+                # Slack does not allow links to local files due to security risks
                 if "file://" in docs_link:
-                    # handle special case since Slack does not render these links
                     report_element = {
                         "type": "section",
                         "text": {

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -81,7 +81,7 @@ class SlackRenderer(Renderer):
             summary_text += f"*Asset*: {data_asset_name}  "
             # Slack does not allow links to local files due to security risks
             # DataDocs links will be added in a block after this summary text when applicable
-            if validation_link is not None and "file://" not in validation_link:
+            if validation_link and "file://" not in validation_link:
                 summary_text += f"*Expectation Suite*: {expectation_suite_name}  <{validation_link}|View Results>"
             else:
                 summary_text += f"*Expectation Suite*: {expectation_suite_name}"

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -80,6 +80,7 @@ class SlackRenderer(Renderer):
 
             summary_text += f"*Asset*: {data_asset_name}  "
             # Slack does not allow links to local files due to security risks
+            # DataDocs links will be added in a block after this summary text when applicable
             if validation_link is not None and "file://" not in validation_link:
                 summary_text += f"*Expectation Suite*: {expectation_suite_name}  <{validation_link}|View Results>"
             else:

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -95,6 +95,7 @@ def test_SlackRenderer_validation_results_with_datadocs(
         validation_result=validation_result_suite,
         checkpoint_name="checkpoint_name_testing",
         name="testing",
+        validation_result_urls=["file:///localsite/index.html"],
     )
 
     expected_output = {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/dad40711-e8a1-41b3-af3a-9ad38bce5170)

After:
![image](https://github.com/user-attachments/assets/4020b010-445b-4d66-8ad2-bfff790fba04)


------------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
