### PR TITLE
[BUGFIX] Remove illegible duplicate local Data Docs link from Slack renderer

### DIFF
--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -71,7 +71,7 @@ class SlackRenderer(Renderer):
         summary_text += f"*Asset*: {data_asset_name}  "
         # Slack does not allow links to local files due to security risks
         # DataDocs links will be added in a block after this summary text when applicable
-        if validation_link is not None and "file://" not in validation_link:
+        if validation_link and "file://" not in validation_link:
             summary_text += (
                 f"*Expectation Suite*: {expectation_suite_name}  <{validation_link}|View Results>"
             )

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -69,7 +69,9 @@ class SlackRenderer(Renderer):
         expectation_suite_name = validation_result.suite_name
         data_asset_name = validation_result.asset_name or "__no_data_asset_name__"
         summary_text += f"*Asset*: {data_asset_name}  "
-        if validation_link is not None:
+        # Slack does not allow links to local files due to security risks
+        # DataDocs links will be added in a block after this summary text when applicable
+        if validation_link is not None and "file://" not in validation_link:
             summary_text += (
                 f"*Expectation Suite*: {expectation_suite_name}  <{validation_link}|View Results>"
             )
@@ -137,8 +139,8 @@ class SlackRenderer(Renderer):
         report_element = None
         if docs_link:
             try:
+                # Slack does not allow links to local files due to security risks
                 if "file://" in docs_link:
-                    # handle special case since Slack does not render these links
                     report_element = {
                         "type": "section",
                         "text": {

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -22,6 +22,7 @@ def test_SlackRenderer_render():
         validation_result=validation_result,
         data_docs_pages=data_docs_pages,
         notify_with=notify_with,
+        validation_result_urls=["file:///localsite/index.html"],
     )
 
     assert output == [


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/dad40711-e8a1-41b3-af3a-9ad38bce5170)

After:
![image](https://github.com/user-attachments/assets/4020b010-445b-4d66-8ad2-bfff790fba04)


------------

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
