### PR TITLE
[DOCS] DSB-796: Fix syntax highlighting

### DIFF
--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_checkpoint_with_actions.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_checkpoint_with_actions.md
@@ -59,7 +59,7 @@ A Checkpoint executes one or more Validation Definitions and then performs a set
    ]
    ```
 
-   In the above example, string substitution is used to pull the value of `slack_token` from an environment variable.  For more information on securely storing credentials and access tokens see [Configure credentials](/core/configure_project_settings/configure_credentials/configure_credentials.md).
+   In the above example, string substitution is used to pull the value of `slack_token` from an environment variable.  For more information on securely storing credentials and access tokens see [Connect to Data using SQL: Configure Credentials](/core/connect_to_data/sql_data/sql_data.md#configure-credentials).
 
    If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. Its Validation Results are saved to the Data Context, but no tasks are executed.
 

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_checkpoint_with_actions.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_checkpoint_with_actions.md
@@ -59,7 +59,7 @@ A Checkpoint executes one or more Validation Definitions and then performs a set
    ]
    ```
 
-   In the above example, string substitution is used to pull the value of `slack_token` from an environment variable.  For more information on securely storing credentials and access tokens see [Connect to Data using SQL: Configure Credentials](/core/connect_to_data/sql_data/sql_data.md#configure-credentials).
+   In the above example, string substitution is used to pull the value of `slack_token` from an environment variable.  For more information on securely storing credentials and access tokens see [Configure credentials](/core/configure_project_settings/configure_credentials/configure_credentials.md).
 
    If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. Its Validation Results are saved to the Data Context, but no tasks are executed.
 

--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -74,6 +74,7 @@ module.exports = {
       contextualSearch: true,
     },
     prism: {
+      additionalLanguages: ['bash'],
       theme: require('./src/theme/CodeBlock/theme'),
     },
     colorMode: {

--- a/docs/docusaurus/src/theme/CodeBlock/theme.js
+++ b/docs/docusaurus/src/theme/CodeBlock/theme.js
@@ -14,7 +14,7 @@ const codeBlockTheme = {
             color: "#B6C647"
         }
     }, {
-        types: ["builtin", "changed", "keyword", "interpolation-punctuation"],
+        types: ["builtin", "changed", "keyword", "interpolation-punctuation", "boolean"],
         style: {
             color: "#F3C62D"
         }


### PR DESCRIPTION
## Problems solved
- Boolean values were not being highlighted because there was no color configured for their particular CSS class
- Consoles using showing Bash code were not being highlighted because default configuration of Docusaurus comes with a subset of common languages, which included Python but not Bash

## Screenshots
### Boolean
BEFORE:
![image](https://github.com/user-attachments/assets/af8453be-de5e-4cce-ba6d-aeb0d265ef1b)

AFTER:
![image](https://github.com/user-attachments/assets/12bf5266-92d3-440a-a9ae-acef286b0157)

### Bash highlighting
BEFORE:
![image](https://github.com/user-attachments/assets/c53eb161-e2a8-472f-8134-229308d8f110)

AFTER:
![image](https://github.com/user-attachments/assets/f8b7ad05-357a-4f06-9949-8ac54d3bc705)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
