### PR TITLE
[BUGFIX] Allow 0 ValidationDefinitions on a Checkpoint

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -29,6 +29,7 @@ from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,
 )
+from great_expectations.exceptions.exceptions import CheckpointRunWithoutValidationDefinitionError
 from great_expectations.render.renderer.renderer import Renderer
 
 if TYPE_CHECKING:
@@ -149,6 +150,9 @@ class Checkpoint(BaseModel):
         expectation_parameters: Dict[str, Any] | None = None,
         run_id: RunIdentifier | None = None,
     ) -> CheckpointResult:
+        if not self.validation_definitions:
+            raise CheckpointRunWithoutValidationDefinitionError()
+
         if not self.id:
             self._add_to_store()
 

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -109,10 +109,7 @@ class Checkpoint(BaseModel):
     ) -> list[ValidationDefinition]:
         from great_expectations.data_context.data_context.context_factory import project_manager
 
-        if len(validation_definitions) == 0:
-            raise ValueError("Checkpoint must contain at least one validation definition")  # noqa: TRY003
-
-        if isinstance(validation_definitions[0], dict):
+        if validation_definitions and isinstance(validation_definitions[0], dict):
             validation_definition_store = project_manager.get_validation_definition_store()
             identifier_bundles = [
                 _IdentifierBundle(**v)  # type: ignore[arg-type] # All validation configs are dicts if the first one is

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -65,6 +65,14 @@ class CheckpointNotFoundError(CheckpointError):
     pass
 
 
+class CheckpointRunWithoutValidationDefinitionError(CheckpointError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Checkpoint.run() requires at least one validation definition. "
+            "Please add one and try your action again."
+        )
+
+
 class StoreBackendError(DataContextError):
     pass
 

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -49,11 +49,9 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.unit
-def test_checkpoint_no_validation_definitions_raises_error():
-    with pytest.raises(ValueError) as e:
-        Checkpoint(name="my_checkpoint", validation_definitions=[])
-
-    assert "Checkpoint must contain at least one validation definition" in str(e.value)
+def test_checkpoint_no_validation_definitions_does_not_raise():
+    Checkpoint(name="my_checkpoint", validation_definitions=[])
+    # see, no errors!
 
 
 @pytest.mark.unit
@@ -330,16 +328,6 @@ class TestCheckpointSerialization:
     @pytest.mark.parametrize(
         "serialized_checkpoint, expected_error",
         [
-            pytest.param(
-                {
-                    "name": "my_checkpoint",
-                    "validation_definitions": [],
-                    "actions": [],
-                    "id": "c758816-64c8-46cb-8f7e-03c12cea1d67",
-                },
-                "Checkpoint must contain at least one validation definition",
-                id="missing_validations",
-            ),
             pytest.param(
                 {
                     "name": "my_checkpoint",

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -41,6 +41,7 @@ from great_expectations.data_context.data_context.ephemeral_data_context import 
 from great_expectations.data_context.types.resource_identifiers import (
     ValidationResultIdentifier,
 )
+from great_expectations.exceptions.exceptions import CheckpointRunWithoutValidationDefinitionError
 from great_expectations.expectations.expectation_configuration import ExpectationConfiguration
 from tests.test_utils import working_directory
 
@@ -468,6 +469,15 @@ class TestCheckpointResult:
 
         with mock.patch.object(ValidationDefinition, "run", return_value=mock_run_result):
             yield validation_definition
+
+    @pytest.mark.unit
+    def test_checkpoint_run_no_validation_definitions(self, mocker):
+        context = mocker.Mock(spec=AbstractDataContext)
+        set_context(project=context)
+        checkpoint = Checkpoint(name=self.checkpoint_name, validation_definitions=[])
+
+        with pytest.raises(CheckpointRunWithoutValidationDefinitionError):
+            checkpoint.run()
 
     @pytest.mark.unit
     def test_checkpoint_run_no_actions(self, validation_definition: ValidationDefinition):


### PR DESCRIPTION
This a) seems reasonable, but b) unblocks some flows, like deleting the last ValidationDefinition from a Checkpoint.



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
