### PR TITLE
[FEATURE] Rename suite_param to expectation_param in validation_definitition

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -180,7 +180,7 @@ class Checkpoint(BaseModel):
             validation_result = validation_definition.run(
                 checkpoint_id=self.id,
                 batch_parameters=batch_parameters,
-                suite_parameters=expectation_parameters,
+                expectation_parameters=expectation_parameters,
                 result_format=result_format,
                 run_id=run_id,
             )

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -196,7 +196,7 @@ class ValidationDefinition(BaseModel):
         *,
         checkpoint_id: Optional[str] = None,
         batch_parameters: Optional[BatchParameters] = None,
-        suite_parameters: Optional[dict[str, Any]] = None,
+        expectation_parameters: Optional[dict[str, Any]] = None,
         result_format: ResultFormat | dict = ResultFormat.SUMMARY,
         run_id: RunIdentifier | None = None,
     ) -> ExpectationSuiteValidationResult:
@@ -208,7 +208,7 @@ class ValidationDefinition(BaseModel):
             batch_parameters=batch_parameters,
             result_format=result_format,
         )
-        results = validator.validate_expectation_suite(self.suite, suite_parameters)
+        results = validator.validate_expectation_suite(self.suite, expectation_parameters)
         results.meta["validation_id"] = self.id
         results.meta["checkpoint_id"] = checkpoint_id
 

--- a/great_expectations/validator/v1_validator.py
+++ b/great_expectations/validator/v1_validator.py
@@ -44,7 +44,7 @@ class Validator:
     def validate_expectation(
         self,
         expectation: Expectation,
-        suite_parameters: Optional[dict[str, Any]] = None,
+        expectation_parameters: Optional[dict[str, Any]] = None,
     ) -> ExpectationValidationResult:
         """Run a single expectation against the batch definition"""
         results = self._validate_expectation_configs([expectation.configuration])
@@ -55,12 +55,12 @@ class Validator:
     def validate_expectation_suite(
         self,
         expectation_suite: ExpectationSuite,
-        suite_parameters: Optional[dict[str, Any]] = None,
+        expectation_parameters: Optional[dict[str, Any]] = None,
     ) -> ExpectationSuiteValidationResult:
         """Run an expectation suite against the batch definition"""
         results = self._validate_expectation_configs(
             expectation_suite.expectation_configurations,
-            suite_parameters,
+            expectation_parameters,
         )
         statistics = calc_validation_statistics(results)
 
@@ -98,11 +98,11 @@ class Validator:
     def _validate_expectation_configs(
         self,
         expectation_configs: list[ExpectationConfiguration],
-        suite_parameters: Optional[dict[str, Any]] = None,
+        expectation_parameters: Optional[dict[str, Any]] = None,
     ) -> list[ExpectationValidationResult]:
         """Run a list of expectation configurations against the batch definition"""
         processed_expectation_configs = self._wrapped_validator.process_expectations_for_validation(
-            expectation_configs, suite_parameters
+            expectation_configs, expectation_parameters
         )
 
         runtime_configuration: dict

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -565,7 +565,7 @@ class TestCheckpointResult:
         validation_definition.run.assert_called_with(  # type: ignore[attr-defined]
             checkpoint_id=checkpoint_id,
             batch_parameters=batch_parameters,
-            suite_parameters=expectation_parameters,
+            expectation_parameters=expectation_parameters,
             result_format=ResultFormat.SUMMARY,
             run_id=mock.ANY,
         )

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -156,7 +156,7 @@ class TestValidationRun:
 
         validation_definition.run(
             batch_parameters={"year": 2024},
-            suite_parameters={"max_value": 9000},
+            expectation_parameters={"max_value": 9000},
             result_format=ResultFormat.COMPLETE,
         )
 


### PR DESCRIPTION
I updated this parameter name in validation_definition.py and the v1_validator.py which is uses. `ValidationDefinition` is public and wanted it to mirror `Checkpoint`. I left it as suite parameter in the rest of the codebase (such as the `Validator` class) since these are private and there are a large number of places where we use `suite_parameter` and it will take some care to do this correctly.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
