### PR TITLE
[FEATURE] Delete batch definition by name.

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -405,7 +405,16 @@ class DataAsset(GenericBaseModel, Generic[DatasourceT, PartitionerT]):
         return batch_definition
 
     @public_api
-    def delete_batch_definition(self, batch_definition: BatchDefinition[PartitionerT]) -> None:
+    def delete_batch_definition(self, name: str) -> None:
+        """Delete a batch definition.
+
+        Args:
+            name (str): Name of the BatchDefinition to delete.
+        """
+        batch_def = self.get_batch_definition(name)
+        self._delete_batch_definition(batch_def)
+
+    def _delete_batch_definition(self, batch_definition: BatchDefinition[PartitionerT]) -> None:
         """Delete a batch definition.
 
         Args:

--- a/tests/datasource/fluent/data_asset/test_data_asset.py
+++ b/tests/datasource/fluent/data_asset/test_data_asset.py
@@ -244,7 +244,7 @@ def test_delete_batch_definition__success(
 ):
     assert persisted_batch_definition in data_asset_with_batch_definition.batch_definitions
 
-    data_asset_with_batch_definition.delete_batch_definition(persisted_batch_definition)
+    data_asset_with_batch_definition.delete_batch_definition(persisted_batch_definition.name)
 
     assert data_asset_with_batch_definition.batch_definitions == []
 
@@ -255,7 +255,7 @@ def test_delete_batch_definition__persists(
     data_asset_with_batch_definition: DataAsset,
     persisted_batch_definition: BatchDefinition,
 ):
-    data_asset_with_batch_definition.delete_batch_definition(persisted_batch_definition)
+    data_asset_with_batch_definition.delete_batch_definition(persisted_batch_definition.name)
 
     loaded_datasource = file_context_with_assets.get_datasource(DATASOURCE_NAME)
     assert isinstance(loaded_datasource, Datasource)
@@ -269,7 +269,7 @@ def test_delete_batch_definition__unsaved_batch_definition(empty_data_asset: Dat
     batch_definition = BatchDefinition[None](name="uh oh")
 
     with pytest.raises(ValueError, match="does not exist"):
-        empty_data_asset.delete_batch_definition(batch_definition)
+        empty_data_asset.delete_batch_definition(batch_definition.name)
 
 
 @pytest.mark.unit
@@ -290,11 +290,11 @@ def test_fields_set(empty_data_asset: DataAsset):
     assert "batch_definitions" in asset.__fields_set__
 
     # delete one of the batch configs and ensure we still have it in the set
-    asset.delete_batch_definition(batch_definition_a)
+    asset.delete_batch_definition(batch_definition_a.name)
     assert "batch_definitions" in asset.__fields_set__
 
     # delete the remaining batch config and ensure we don't have it in the set
-    asset.delete_batch_definition(batch_definition_b)
+    asset.delete_batch_definition(batch_definition_b.name)
     assert "batch_definitions" not in asset.__fields_set__
 
 
@@ -334,7 +334,7 @@ def _test_delete_batch_definition__does_not_clobber_other_assets(
         datasource = context.get_datasource(datasource_name)
         assert isinstance(datasource, Datasource)
         asset = datasource.get_asset(asset_name)
-        asset.delete_batch_definition(asset.batch_definitions[0])
+        asset.delete_batch_definition(asset.batch_definitions[0].name)
 
     loaded_datasource = context.get_datasource(datasource_name)
     assert isinstance(loaded_datasource, Datasource)


### PR DESCRIPTION
All other public `delete_*` methods are done by name. I considered leaving a public delete by object method since we do some checking for batch definitions with the same name. I decided against that because we enforce not allowing this in code.



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
