### PR TITLE
[BUGFIX] Add directive to control generation of reader methods.

### DIFF
--- a/great_expectations/datasource/fluent/pandas_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_datasource.py
@@ -618,6 +618,9 @@ class PandasDatasource(_PandasDatasource):
             are Pandas DataAsset objects.
     """
 
+    # class directive to automatically generate read_* methods for assets
+    ADD_READER_METHODS: ClassVar[bool] = True
+
     # class attributes
     asset_types: ClassVar[Sequence[Type[DataAsset]]] = _DYNAMIC_ASSET_TYPES + [DataFrameAsset]
 


### PR DESCRIPTION
The issue here is we always generate read methods when we dynamically generate `add_type_asset` methods. The pandas datasource hierarchy looks like:
```
_PandasDatasource
    PandasDatasource(_PandasDatasource)

    _PandasFilePathDatasource(_PandasDatasource)
        PandasFilesystemDatasource
            PandasDBFSDatasource
        PandasGoogleCloudStorageDatasource
        PandasAzureBlobStorageDatasource
        PandasS3Datasource
```
We only want the reader methods for `PandasDatasource` but for no other ones. To do this I've added a "class directive" to control the generation of reader methods that defaults to `False`. It seems a little bad to have to look at the guts of the metaprogramming code to find this directive but I didn't want to add a top level attribute for all `Datasource`s since most don't care about this at all. There is pandas logic already baked into the reader methods where this is introduced (`name = asset_name or DEFAULT_PANDAS_DATA_ASSET_NAME`). There is likely some more general solution about adding directives but I don't think we should sort that out until there is more examples of this needed.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
