### PR TITLE
[MAINTENANCE] Ensure GXCloudStoreBackend session is closed

### DIFF
--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -341,8 +341,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             return True
         if not (kwarg_names <= self.allowed_set_kwargs):
             extra_kwargs = kwarg_names - self.allowed_set_kwargs
-            error_text = f'Invalid kwargs: {(", ").join(extra_kwargs)}'
-            raise ValueError(error_text)
+            raise ValueError(f'Invalid kwargs: {(", ").join(extra_kwargs)}')  # noqa: TRY003
         return None
 
     @override
@@ -415,8 +414,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ) from timeout_exc
         except Exception as e:
             logger.debug(str(e))
-            error_text = f"Unable to set object in GX Cloud Store Backend: {e}"
-            raise StoreBackendError(error_text) from e
+            raise StoreBackendError(  # noqa: TRY003
+                f"Unable to set object in GX Cloud Store Backend: {e}"
+            ) from e
 
     @property
     def ge_cloud_base_url(self) -> str:
@@ -463,8 +463,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             return keys
         except Exception as e:
             logger.debug(str(e))
-            error_text = f"Unable to list keys in GX Cloud Store Backend: {e}"
-            raise StoreBackendError(error_text) from e
+            raise StoreBackendError(  # noqa: TRY003
+                f"Unable to list keys in GX Cloud Store Backend: {e}"
+            ) from e
 
     @override
     def get_url_for_key(  # type: ignore[override]

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import weakref
 from abc import ABCMeta
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -161,6 +162,12 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             _ = self.store_backend_id
 
         self._session = create_session(access_token=self._ge_cloud_credentials["access_token"])
+        # Finalizer to close the session when the object is garbage collected.
+        # https://docs.python.org/3.11/library/weakref.html#weakref.finalize
+        self._finalizer = weakref.finalize(
+            self,
+            self._close_session,
+        )
 
         # Gather the call arguments of the present function (include the "module_name" and add the "class_name"), filter  # noqa: E501
         # out the Falsy values, and set the instance "_config" variable equal to the resulting dictionary.  # noqa: E501
@@ -334,7 +341,8 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             return True
         if not (kwarg_names <= self.allowed_set_kwargs):
             extra_kwargs = kwarg_names - self.allowed_set_kwargs
-            raise ValueError(f'Invalid kwargs: {(", ").join(extra_kwargs)}')  # noqa: TRY003
+            error_text = f'Invalid kwargs: {(", ").join(extra_kwargs)}'
+            raise ValueError(error_text)
         return None
 
     @override
@@ -407,7 +415,8 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ) from timeout_exc
         except Exception as e:
             logger.debug(str(e))
-            raise StoreBackendError(f"Unable to set object in GX Cloud Store Backend: {e}") from e  # noqa: TRY003
+            error_text = f"Unable to set object in GX Cloud Store Backend: {e}"
+            raise StoreBackendError(error_text) from e
 
     @property
     def ge_cloud_base_url(self) -> str:
@@ -454,7 +463,8 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             return keys
         except Exception as e:
             logger.debug(str(e))
-            raise StoreBackendError(f"Unable to list keys in GX Cloud Store Backend: {e}") from e  # noqa: TRY003
+            error_text = f"Unable to list keys in GX Cloud Store Backend: {e}"
+            raise StoreBackendError(error_text) from e
 
     @override
     def get_url_for_key(  # type: ignore[override]
@@ -727,3 +737,6 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     @property
     def _is_v1_resource(self) -> bool:
         return self._ENDPOINT_VERSION_LOOKUP.get(self.ge_cloud_resource_type) == EndpointVersion.V1
+
+    def _close_session(self):
+        self._session.close()


### PR DESCRIPTION
To avoid memory leaks, we want to make sure that the session created in `GXCloudStoreBackend` is closed when the object is no longer needed and then garbage collected. We use `weakref.finalize` [python docs](https://docs.python.org/3.11/library/weakref.html#weakref.finalize) to add a callback that is executed when the `GXCloudStoreBackend` is garbage collected. This callback closes the connection.

Using a context manager (`with`) statement here is not possible since the session is created in the `GXCloudStoreBackend` constructor (`__init__`) and is needed for the lifetime of the `GXCloudStoreBackend`. We also considered making `GXCloudStoreBackend` a context manager but that would be a much larger and potentially breaking code change. We also considered using a custom `__del__` method (not recommended) or dependency injection (larger code changes, potentially breaking).

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
