### PR TITLE
[MAINTENANCE] Ensure CloudDataStore session is closed

### DIFF
--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -161,13 +161,10 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         if not self._suppress_store_backend_id:
             _ = self.store_backend_id
 
-        self._session = create_session(access_token=self._ge_cloud_credentials["access_token"])
+        self.session = create_session(access_token=self._ge_cloud_credentials["access_token"])
         # Finalizer to close the session when the object is garbage collected.
         # https://docs.python.org/3.11/library/weakref.html#weakref.finalize
-        self._finalizer = weakref.finalize(
-            self,
-            self._close_session,
-        )
+        self._finalizer = weakref.finalize(self, close_session, self.session)
 
         # Gather the call arguments of the present function (include the "module_name" and add the "class_name"), filter  # noqa: E501
         # out the Falsy values, and set the instance "_config" variable equal to the resulting dictionary.  # noqa: E501
@@ -223,7 +220,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     def _send_get_request_to_api(self, url: str, params: dict | None = None) -> dict:
         try:
-            response = self._session.get(
+            response = self.session.get(
                 url=url,
                 params=params,
             )
@@ -285,7 +282,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             url = urljoin(f"{url}/", id)
 
         try:
-            response = self._session.put(url, json=data)
+            response = self.session.put(url, json=data)
             response_status_code = response.status_code
 
             # 2022-07-28 - Chetan - GX Cloud does not currently support PUT requests
@@ -295,7 +292,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 response_status_code == 405  # noqa: PLR2004
                 and resource_type is GXCloudRESTResource.EXPECTATION_SUITE
             ):
-                response = self._session.patch(url, json=data)
+                response = self.session.patch(url, json=data)
                 response_status_code = response.status_code
 
             response.raise_for_status()
@@ -341,7 +338,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             return True
         if not (kwarg_names <= self.allowed_set_kwargs):
             extra_kwargs = kwarg_names - self.allowed_set_kwargs
-            raise ValueError(f'Invalid kwargs: {(", ").join(extra_kwargs)}')  # noqa: TRY003
+            raise ValueError(  # noqa: TRY003
+                f'Invalid kwargs: {(", ").join(extra_kwargs)}'
+            )
         return None
 
     @override
@@ -388,7 +387,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         )
 
         try:
-            response = self._session.post(url, json=data)
+            response = self.session.post(url, json=data)
             response.raise_for_status()
             response_json = response.json()
 
@@ -501,7 +500,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                     resource_name=self.ge_cloud_resource_name,
                     id=id,
                 )
-                response = self._session.delete(url)
+                response = self.session.delete(url)
                 response.raise_for_status()
                 return True
             # delete by name
@@ -511,7 +510,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                     organization_id=self.ge_cloud_credentials["organization_id"],
                     resource_name=self.ge_cloud_resource_name,
                 )
-                response = self._session.delete(url, params={"name": resource_object_name})
+                response = self.session.delete(url, params={"name": resource_object_name})
                 response.raise_for_status()
                 return True
         except requests.HTTPError as http_exc:
@@ -739,5 +738,16 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     def _is_v1_resource(self) -> bool:
         return self._ENDPOINT_VERSION_LOOKUP.get(self.ge_cloud_resource_type) == EndpointVersion.V1
 
-    def _close_session(self):
-        self._session.close()
+
+def close_session(session: requests.Session):
+    """Close the session.
+    Used by a finalizer to close the session when the GXCloudStoreBackend is garbage collected.
+
+    This is not a bound method on the GXCloudStoreBackend class because of this note
+    in the Python docs (https://docs.python.org/3.11/library/weakref.html#weakref.finalize):
+    Note It is important to ensure that func, args and kwargs do not own any references to obj,
+    either directly or indirectly, since otherwise obj will never be garbage collected.
+    In particular, func should not be a bound method of obj.
+
+    """
+    session.close()

--- a/great_expectations/experimental/metric_repository/cloud_data_store.py
+++ b/great_expectations/experimental/metric_repository/cloud_data_store.py
@@ -68,13 +68,13 @@ class CloudDataStore(DataStore[StorableTypes]):
         super().__init__(context=context)
         assert context.ge_cloud_config is not None
         assert self._context.ge_cloud_config is not None
-        self.session = create_session(
+        self._session = create_session(
             access_token=context.ge_cloud_config.access_token,
             retry_count=0,  # Do not retry on authentication errors
         )
         # Finalizer to close the session when the object is garbage collected.
         # https://docs.python.org/3.11/library/weakref.html#weakref.finalize
-        self._finalizer = weakref.finalize(self, close_session, self.session)
+        self._finalizer = weakref.finalize(self, close_session, self._session)
 
     def _map_to_url(self, value: StorableTypes) -> str:
         if isinstance(value, MetricRun):
@@ -113,7 +113,7 @@ class CloudDataStore(DataStore[StorableTypes]):
         """
         url = self._build_url(value)
         payload = self._build_payload(value)
-        response = self.session.post(url=url, data=payload)
+        response = self._session.post(url=url, data=payload)
         response.raise_for_status()
 
         response_json = response.json()

--- a/great_expectations/experimental/metric_repository/cloud_data_store.py
+++ b/great_expectations/experimental/metric_repository/cloud_data_store.py
@@ -11,6 +11,7 @@ from great_expectations.experimental.metric_repository.data_store import DataSto
 from great_expectations.experimental.metric_repository.metrics import MetricRun
 
 if TYPE_CHECKING:
+    import requests
     from typing_extensions import TypeAlias
 
     from great_expectations.data_context import CloudDataContext
@@ -61,15 +62,22 @@ class CloudDataStore(DataStore[StorableTypes]):
     Uses JSON:API https://jsonapi.org/
     """
 
+    # TODO: Will dependency injection work here? I.e. can we inject the session in the constructor?
     @override
-    def __init__(self, context: CloudDataContext):
+    def __init__(self, context: CloudDataContext, session: requests.Session = None):
         super().__init__(context=context)
         assert context.ge_cloud_config is not None
         assert self._context.ge_cloud_config is not None
-        self._session = create_session(
-            access_token=context.ge_cloud_config.access_token,
-            retry_count=0,  # Do not retry on authentication errors
-        )
+        if session:
+            self._session = session
+        else:
+            # Avoid this pattern as it is not recommended to create a session per request.
+            # It is here for backward compatibility with the existing code.
+            create_session(
+                access_token=context.ge_cloud_config.access_token,
+                retry_count=0,  # Do not retry on authentication errors
+            )
+            self._session = session
 
     def _map_to_url(self, value: StorableTypes) -> str:
         if isinstance(value, MetricRun):
@@ -92,7 +100,8 @@ class CloudDataStore(DataStore[StorableTypes]):
         assert self._context.ge_cloud_config is not None
         config = self._context.ge_cloud_config
         return urllib.parse.urljoin(
-            config.base_url, f"organizations/{config.organization_id}{self._map_to_url(value)}"
+            config.base_url,
+            f"organizations/{config.organization_id}{self._map_to_url(value)}",
         )
 
     @override

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -40,10 +40,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store.session = Mock()
-        cloud_data_store.session.post = Mock()
+        cloud_data_store._session = Mock()
+        cloud_data_store._session.post = Mock()
         response_mock = Mock()
-        cloud_data_store.session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -70,7 +70,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":[0.25,0.5,0.75],"exception":null,"column":"column","quantiles":[0.25,0.5,0.75],"allow_relative_error":0.001,"value_type":"list[float]","metric_type":"ColumnQuantileValuesMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store.session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -94,10 +94,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store.session = Mock()
-        cloud_data_store.session.post = Mock()
+        cloud_data_store._session = Mock()
+        cloud_data_store._session.post = Mock()
         response_mock = Mock()
-        cloud_data_store.session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -122,7 +122,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":1,"exception":null,"column":"column","value_type":"int","metric_type":"ColumnMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store.session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -146,10 +146,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store.session = Mock()
-        cloud_data_store.session.post = Mock()
+        cloud_data_store._session = Mock()
+        cloud_data_store._session.post = Mock()
         response_mock = Mock()
-        cloud_data_store.session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -177,7 +177,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":1,"exception":{"type":"exception type","message":"exception message"},"column":"column","value_type":"int","metric_type":"ColumnMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store.session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -201,10 +201,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store.session = Mock()
-        cloud_data_store.session.post = Mock()
+        cloud_data_store._session = Mock()
+        cloud_data_store._session.post = Mock()
         response_mock = Mock()
-        cloud_data_store.session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -229,7 +229,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":2.5,"exception":null,"column":"column","value_type":"float64","metric_type":"ColumnMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store.session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 from unittest.mock import Mock  # noqa: TID251
 from uuid import UUID
 
@@ -39,10 +40,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store.session = Mock()
+        cloud_data_store.session.post = Mock()
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store.session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -69,7 +70,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":[0.25,0.5,0.75],"exception":null,"column":"column","quantiles":[0.25,0.5,0.75],"allow_relative_error":0.001,"value_type":"list[float]","metric_type":"ColumnQuantileValuesMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store.session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -93,10 +94,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store.session = Mock()
+        cloud_data_store.session.post = Mock()
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store.session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -121,7 +122,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":1,"exception":null,"column":"column","value_type":"int","metric_type":"ColumnMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store.session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -145,10 +146,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store.session = Mock()
+        cloud_data_store.session.post = Mock()
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store.session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -176,7 +177,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":1,"exception":{"type":"exception type","message":"exception message"},"column":"column","value_type":"int","metric_type":"ColumnMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store.session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -200,10 +201,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store.session = Mock()
+        cloud_data_store.session.post = Mock()
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store.session.post.return_value = response_mock
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -228,8 +229,21 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":2.5,"exception":null,"column":"column","value_type":"float64","metric_type":"ColumnMetric"}]}}}'  # noqa: E501
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store.session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
         assert uuid_from_add == response_metric_run_id
+
+
+def test_closes_session(
+    empty_cloud_context_fluent: CloudDataContext,  # used as a fixture
+):
+    """Make sure that when the CloudDataStore object is garbage collected,
+    the session is closed."""
+    cloud_data_store = CloudDataStore(context=empty_cloud_context_fluent)
+    with mock.patch("requests.Session.close", autospec=True) as mock_close:
+        # Use the finalizer to remove the object from memory.
+        # Using del or __del__ directly does not work in the test environment.
+        cloud_data_store._finalizer()
+        mock_close.assert_called_once()

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -236,6 +236,7 @@ class TestCloudDataStoreMetricRun:
         assert uuid_from_add == response_metric_run_id
 
 
+@pytest.mark.cloud
 def test_closes_session(
     empty_cloud_context_fluent: CloudDataContext,  # used as a fixture
 ):


### PR DESCRIPTION
To avoid memory leaks, we want to make sure that the session created in CloudDataStore is closed when the object is no longer needed and then garbage collected. We use weakref.finalize [python docs](https://docs.python.org/3.11/library/weakref.html#weakref.finalize) to add a callback that is executed when the CloudDataStore is garbage collected. This callback closes the connection.

Using a context manager (with) statement here is not possible since the session is created in the CloudDataStore constructor (__init__) and is needed for the lifetime of the CloudDataStore. We also considered making CloudDataStore a context manager but that would be a much larger and potentially breaking code change. We also considered using a custom __del__ method (not recommended) or dependency injection (larger code changes, potentially breaking).

NOTE: This PR also changes the GXCloudStoreBackend finalizer to use an unbound method which is recommended in the python docs (see link in the code).

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
