### PR TITLE
[DOCS] Transition feedback Jira tickets to kanban board

### DIFF
--- a/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
+++ b/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
@@ -48,11 +48,15 @@ exports.handler = async (req, context) => {
         const result = await response.json()
 
         if (result.id) {
-            await httpPostRequest(`${JIRA_ISSUE_ENDPOINT_URL}/${result.id}/transitions`, {
-                "transition": {
-                    "id": TO_DO_STATE_ID
-                }
-            })
+            try {
+                await httpPostRequest(`${JIRA_ISSUE_ENDPOINT_URL}/${result.id}/transitions`, {
+                    "transition": {
+                        "id": TO_DO_STATE_ID
+                    }
+                })
+            } catch (error) {
+                console.error("Fetch failed", error.message)
+            }
         }
 
         return {

--- a/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
+++ b/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
@@ -47,11 +47,13 @@ exports.handler = async (req, context) => {
 
         const result = await response.json()
 
-        await httpPostRequest(`${JIRA_ISSUE_ENDPOINT_URL}/${result.id}/transitions`, {
-            "transition": {
-                "id": TO_DO_STATE_ID
-            }
-        })
+        if (result.id) {
+            await httpPostRequest(`${JIRA_ISSUE_ENDPOINT_URL}/${result.id}/transitions`, {
+                "transition": {
+                    "id": TO_DO_STATE_ID
+                }
+            })
+        }
 
         return {
             statusCode: response.status,

--- a/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
+++ b/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
@@ -1,7 +1,8 @@
 const TITLE_MAX_CHARACTERS = 120;
 const DOCUMENTATION_BOARD_ID = 10019;
 const STORY_ISSUETYPE_ID = 10011;
-const CREATE_JIRA_ISSUE_ENDPOINT_URL = "https://greatexpectations.atlassian.net/rest/api/2/issue"
+const JIRA_ISSUE_ENDPOINT_URL = "https://greatexpectations.atlassian.net/rest/api/2/issue"
+const TO_DO_STATE_ID = 291;
 
 const truncateDescription = (description) => {
     return description.length > TITLE_MAX_CHARACTERS ? description.substring(0, TITLE_MAX_CHARACTERS) + "..." : description;
@@ -14,33 +15,43 @@ const fullDescription = (description, name, email, selectedValue) => {
     return `*Name:* ${formatOptionalValue(name)}\n*Email:* ${formatOptionalValue(email)}\n*Selected feedback type:* ${formattedSelectedValue}\n\n*Description:* ${description}`;
 }
 
+const httpPostRequest = async (url, body) => {
+    return await fetch(url, {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Basic ' + Buffer.from(process.env.JIRA_API_USER + ":" + process.env.JIRA_API_TOKEN).toString('base64')
+        },
+        body: JSON.stringify(body)
+    })
+}
+
 exports.handler = async (req, context) => {
     const { description, name, email, selectedValue } = JSON.parse(req.body);
     try {
-        const response = await fetch(CREATE_JIRA_ISSUE_ENDPOINT_URL, {
-            method: "POST",
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': 'Basic ' + Buffer.from(process.env.JIRA_API_USER + ":" + process.env.JIRA_API_TOKEN).toString('base64')
-            },
-            body: JSON.stringify({
-                "fields": {
-                    "project": {
-                        "id": DOCUMENTATION_BOARD_ID
-                    },
-                    "summary": truncateDescription(description),
-                    "description": fullDescription(description, name, email, selectedValue),
-                    "issuetype": {
-                        "id": STORY_ISSUETYPE_ID
-                    },
-                    "labels": [
-                        "feedback_modal"
-                    ],
-                }
-            })
+        const response = await httpPostRequest(JIRA_ISSUE_ENDPOINT_URL, {
+            "fields": {
+                "project": {
+                    "id": DOCUMENTATION_BOARD_ID
+                },
+                "summary": truncateDescription(description),
+                "description": fullDescription(description, name, email, selectedValue),
+                "issuetype": {
+                    "id": STORY_ISSUETYPE_ID
+                },
+                "labels": [
+                    "feedback_modal"
+                ],
+            }
         })
 
         const result = await response.json()
+
+        await httpPostRequest(`${JIRA_ISSUE_ENDPOINT_URL}/${result.id}/transitions`, {
+            "transition": {
+                "id": TO_DO_STATE_ID
+            }
+        })
 
         return {
             statusCode: response.status,


### PR DESCRIPTION
## Description
Jira tickets created from feedback modal were first located in the intake board and had to be manually moved to "to do" list so they appear in the docs kanban board. This PR is to automatically move them by changing their status once they're created so this doesn't have to be done manually

## Video
[Grabación de pantalla desde 14-08-24 14:52:47.webm](https://github.com/user-attachments/assets/1862efaa-8ff9-4120-aac1-52a4ee944608)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
