### PR TITLE
[MAINTENANCE] Add required keys to SuiteValidationResult.meta

### DIFF
--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -216,6 +216,7 @@ class ValidationDefinition(BaseModel):
         #       Meta should be reserved for user-defined information.
         if run_id:
             results.meta["run_id"] = run_id
+            results.meta["validation_time"] = run_id.run_time
 
         (
             expectation_suite_identifier,

--- a/great_expectations/validator/v1_validator.py
+++ b/great_expectations/validator/v1_validator.py
@@ -84,7 +84,9 @@ class Validator:
                     self._wrapped_validator.active_batch_spec
                 ),
                 "batch_markers": self._wrapped_validator.active_batch_markers,
-                "active_batch_definition": self._wrapped_validator.active_batch_definition,
+                "active_batch_definition": convert_to_json_serializable(
+                    self._wrapped_validator.active_batch_definition
+                ),
             },
             batch_id=self.active_batch_id,
         )

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -761,6 +761,15 @@ class TestCheckpointResult:
         # The meta attribute of each run result should contain the requisite IDs
         run_results = tuple(result.run_results.values())
         meta = run_results[0].meta
-        assert sorted(meta.keys()) == ["checkpoint_id", "run_id", "validation_id"]
+        assert sorted(meta.keys()) == [
+            "active_batch_definition",
+            "batch_markers",
+            "batch_spec",
+            "checkpoint_id",
+            "great_expectations_version",
+            "run_id",
+            "validation_id",
+            "validation_time",
+        ]
         assert meta["checkpoint_id"] == checkpoint.id
         assert meta["validation_id"] == checkpoint.validation_definitions[0].id


### PR DESCRIPTION
Early in the V1 work, we removed most fields from SuiteValidationResult.meta. We've since discovered that gx cloud depends on several of them, so this PR adds them back.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
