### PR TITLE
[MAINTENANCE] Update import path for UnexpectedRowsExpectation

### DIFF
--- a/docs/docusaurus/docs/snippets/unexpected_row_expectation.py
+++ b/docs/docusaurus/docs/snippets/unexpected_row_expectation.py
@@ -28,7 +28,7 @@ load_data_into_test_database(
 
 # <snippet name="docs/docusaurus/docs/snippets/unexpected_row_expectation.py define_custom_expectation">
 class UnexpectedTripDistance(UnexpectedRowsExpectation):
-    unexpected_rows_query = """
+    unexpected_rows_query: str = """
         SELECT
             vendor_id, pickup_datetime
         FROM

--- a/great_expectations/expectations/__init__.py
+++ b/great_expectations/expectations/__init__.py
@@ -1,4 +1,4 @@
-from great_expectations.expectations.expectation import Expectation
+from great_expectations.expectations.expectation import Expectation, UnexpectedRowsExpectation
 
 from .core import (
     ExpectColumnDistinctValuesToBeInSet,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1613,7 +1613,7 @@ representation."""  # noqa: E501
         return {"success": success, "result": {"observed_value": metric_value}}
 
 
-class UnexpectedRowsExpectation(BatchExpectation, ABC):
+class UnexpectedRowsExpectation(BatchExpectation):
     """
     UnexpectedRowsExpectations facilitate the execution of SQL or Spark-SQL queries as the core logic for an Expectation.
 

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -9,11 +9,11 @@ import great_expectations.expectations as gxe
 from great_expectations.compatibility import pydantic
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.expectations import UnexpectedRowsExpectation
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
     ColumnPairMapExpectation,
     MulticolumnMapExpectation,
-    UnexpectedRowsExpectation,
     _validate_dependencies_against_available_metrics,
 )
 from great_expectations.expectations.expectation_configuration import (


### PR DESCRIPTION
We want to be able to import `UnexpectedRowsExpectation` the way we do other Expectations.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
