### PR TITLE
[DOCS] 1.0 updates to community resources page

### DIFF
--- a/docs/docusaurus/docs/core/introduction/community_resources.md
+++ b/docs/docusaurus/docs/core/introduction/community_resources.md
@@ -1,7 +1,6 @@
 ---
 title: 'Community resources'
 ---
-import GxCloudAdvert from '/static/docs/_static_components/_gx_cloud_advert.md'
 
 Great Expectations (GX) is committed to building a great application and a great community.
 
@@ -41,8 +40,4 @@ If you're interested in helping out, review the [GitHub issues list](https://git
 
 ## Connect with our community
 
-Join the GX [public Slack channel](https://greatexpectations.io/slack) to connect with other GX users and see how they're using GX. Before you post for the first time, review the [Slack Guidelines](https://discourse.greatexpectations.io/t/slack-guidelines/1195).
-
-## GX Cloud
-
-<GxCloudAdvert/>
+Check out the [GX community](https://greatexpectations.io/community) and connect with other GX users and see how they're using GX in the GX [public Slack channel](https://greatexpectations.io/slack). Before you post for the first time, review the [Slack Guidelines](https://discourse.greatexpectations.io/t/slack-guidelines/1195).

--- a/docs/docusaurus/docs/core/introduction/community_resources.md
+++ b/docs/docusaurus/docs/core/introduction/community_resources.md
@@ -40,4 +40,6 @@ If you're interested in helping out, review the [GitHub issues list](https://git
 
 ## Connect with our community
 
-Check out the [GX community](https://greatexpectations.io/community) and connect with other GX users and see how they're using GX in the GX [public Slack channel](https://greatexpectations.io/slack). Before you post for the first time, review the [Slack Guidelines](https://discourse.greatexpectations.io/t/slack-guidelines/1195).
+Check out the [GX community](https://greatexpectations.io/community) for the latest news on GX development, events and workshops, job opprotunities, and ways to contribute or collaborate with the GX team and fellow community members.  
+
+Connect with other GX users and see how they're using GX in the GX [public Slack channel](https://greatexpectations.io/slack). Before you post for the first time, review the [Slack Guidelines](https://discourse.greatexpectations.io/t/slack-guidelines/1195).

--- a/docs/docusaurus/docs/resources/get_support.md
+++ b/docs/docusaurus/docs/resources/get_support.md
@@ -32,7 +32,7 @@ Search the docs you're using currently for an answer to your issue or question.
 
 If you're new to GX Cloud, review [About GX Cloud](/cloud/about_gx.md).
 
-If you're new to GX OSS, see [About Great Expectations](/core/introduction/about_gx.md).
+If you're new to GX OSS, see [About Great Expectations](/core/introduction/gx_overview.md).
 
 ### Include all the relevant information
 

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -20,11 +20,6 @@ module.exports = {
           id: 'core/introduction/try_gx',
           label: 'Try GX'
         },
-        {
-          type: 'doc',
-          id: 'core/introduction/community_resources',
-          label: 'Community resources'
-        },
       ],
     },
     {
@@ -148,6 +143,11 @@ module.exports = {
       type: 'doc',
       id: 'oss/changelog',
       label: 'Changelog'
+    },
+    {
+      type: 'doc',
+      id: 'core/introduction/community_resources',
+      label: 'Community resources'
     },
   ],
   gx_cloud: [


### PR DESCRIPTION
## Description
- Community resources page:
   - Removes GX Cloud advert
   - Updates message in "Connect to community" section
   - Links "Connect to community" section to the external community home page.
   - Moves page out of "Introduction" and to end of ToC.
- Updates support page to link new OSS users to "GX Overview" instead of "About GX"


## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated