### PR TITLE
[DOCS] Updates broken internal link in GX Cloud docs for v1.0 and v0.18

### DIFF
--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -79,7 +79,7 @@ The following table lists the available GX Cloud Expectations.
 
 4. Click **New Expectation**.
 
-5. Select an Expectation type. See [Available Expectation types](#available-expectation-types).
+5. Select an Expectation type. See [Available Expectations](#available-expectations).
 
 6. If you are adding your first expectation on this data asset, you may be able to select a time-based Batch interval for that asset.
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/expectations/manage_expectations.md
@@ -79,7 +79,7 @@ The following table lists the available GX Cloud Expectations.
 
 4. Click **New Expectation**.
 
-5. Select an Expectation type. See [Available Expectation types](#available-expectation-types).
+5. Select an Expectation type. See [Available Expectations](#available-expectations).
 
 6. If you are adding your first expectation on this data asset, you may be able to select a time-based Batch interval for that asset.
 


### PR DESCRIPTION
## Description
- Fixes internal link to available Expectations table in GX Cloud docs for v1.0 and v0.18

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated
