### PR TITLE
[BUGFIX] Filter and log bad expectations when loading a suite

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -78,7 +78,14 @@ class ExpectationSuite(SerializableDictDot):
         self.name = name
         self.id = id
 
-        self.expectations = [self._process_expectation(exp) for exp in expectations or []]
+        self.expectations: list[Union[Expectation, ExpectationConfiguration, dict]] = []
+        for exp in expectations or []:
+            try:
+                self.expectations.append(self._process_expectation(exp))
+            except gx_exceptions.InvalidExpectationConfigurationError as e:
+                logger.exception(
+                    f"Could not add expectation; provided configuration is not valid: {e.message}"
+                )
 
         if suite_parameters is None:
             suite_parameters = {}

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -78,7 +78,7 @@ class ExpectationSuite(SerializableDictDot):
         self.name = name
         self.id = id
 
-        self.expectations: list[Union[Expectation, ExpectationConfiguration, dict]] = []
+        self.expectations = []
         for exp in expectations or []:
             try:
                 self.expectations.append(self._process_expectation(exp))

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -63,6 +63,15 @@ def expect_column_values_to_be_in_set_col_a_with_meta_dict() -> dict:
 
 
 @pytest.fixture
+def bad_expectation_dict() -> dict:
+    return {
+        "type": "expect_stuff_not_to_go_well",
+        "kwargs": {},
+        "meta": {"notes": "this_should_explode"},
+    }
+
+
+@pytest.fixture
 def empty_suite_with_meta(fake_expectation_suite_name: str) -> ExpectationSuite:
     return ExpectationSuite(
         name=fake_expectation_suite_name,
@@ -169,6 +178,25 @@ class TestInit:
         ]
         assert len(suite.expectations) == 2
         assert suite.expectation_configurations == test_expected_expectations
+
+    @pytest.mark.unit
+    def test_bad_expectation_configs_are_skipped(
+        self,
+        bad_expectation_dict: dict,
+        expect_column_values_to_be_in_set_col_a_with_meta_dict: dict,
+    ):
+        suite = ExpectationSuite(
+            name="test_suite",
+            expectations=[
+                bad_expectation_dict,
+                expect_column_values_to_be_in_set_col_a_with_meta_dict,
+            ],
+        )
+        assert len(suite.expectations) == 1
+        assert (
+            suite.expectations[0].expectation_type
+            == expect_column_values_to_be_in_set_col_a_with_meta_dict["type"]
+        )
 
     @pytest.mark.unit
     def test_expectation_suite_init_overrides_non_json_serializable_meta(


### PR DESCRIPTION
Errors on leaf nodes like this were causing `context.checkpoints.all` if a bad configuration happened to be stored.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
