### PR TITLE
[MAINTENANCE] Revert "[BUGFIX] Ensure that all diagnostics for a Checkpoint's children validation definitions appear in error messages"

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -167,9 +167,12 @@ class Checkpoint(BaseModel):
             raise CheckpointRunWithoutValidationDefinitionError()
 
         diagnostics = self.is_added()
-        diagnostics.raise_for_errors_except_parent_not_added_error()
-        if not self.id:
-            self._add_to_store()
+        if not diagnostics.is_added:
+            # The checkpoint itself is not added but all children are - we can add it for the user
+            if not diagnostics.parent_added and diagnostics.children_added:
+                self._add_to_store()
+            else:
+                diagnostics.raise_for_error()
 
         run_id = run_id or RunIdentifier(run_time=dt.datetime.now(dt.timezone.utc))
         run_results = self._run_validation_definitions(

--- a/great_expectations/core/added_diagnostics.py
+++ b/great_expectations/core/added_diagnostics.py
@@ -38,7 +38,7 @@ class AddedDiagnostics:
         return len(self.errors) == 0
 
     @abstractmethod
-    def raise_for_errors(self) -> None:
+    def raise_for_error(self) -> None:
         """
         Conditionally raises an error if the resource has not been added successfully;
         should prescribe the correct action(s) to take.
@@ -49,7 +49,7 @@ class AddedDiagnostics:
 @dataclass
 class _ChildAddedDiagnostics(AddedDiagnostics):
     @override
-    def raise_for_errors(self) -> None:
+    def raise_for_error(self) -> None:
         if not self.is_added:
             raise self.errors[0]  # Child node so only one error
 
@@ -68,32 +68,25 @@ class ExpectationSuiteAddedDiagnostics(_ChildAddedDiagnostics):
 class _ParentAddedDiagnostics(AddedDiagnostics):
     parent_error_class: ClassVar[Type[ResourceNotAddedError]]
     children_error_classes: ClassVar[Tuple[Type[ResourceNotAddedError], ...]]
-    exception_class: ClassVar[Type[ResourcesNotAddedError]]
+    raise_for_error_class: ClassVar[Type[ResourcesNotAddedError]]
 
     def update_with_children(self, *children_diagnostics: AddedDiagnostics) -> None:
         for diagnostics in children_diagnostics:
             # Child errors should be prepended to parent errors so diagnostics are in order
             self.errors = diagnostics.errors + self.errors
 
-    @override
-    def raise_for_errors(self) -> None:
-        if not self.is_added:
-            raise self.exception_class(errors=self.errors)
+    @property
+    def parent_added(self) -> bool:
+        return all(not isinstance(err, self.parent_error_class) for err in self.errors)
 
     @property
-    def _dependencies_added_except_parent(self) -> bool:
-        return len(self.errors) == 1 and isinstance(self.errors[0], self.parent_error_class)
+    def children_added(self) -> bool:
+        return all(not isinstance(err, self.children_error_classes) for err in self.errors)
 
-    def raise_for_errors_except_parent_not_added_error(self) -> None:
-        """
-        Conditionally raises an error if the resource has not been added successfully;
-        if the only error is the parent resource not being added, the error is not raised.
-
-        This is useful when downstream callers add the parent resource on behalf of the user.
-        (e.g., Checkpoint.run())
-        """
-        if not self.is_added and not self._dependencies_added_except_parent:
-            raise self.exception_class(errors=self.errors)
+    @override
+    def raise_for_error(self) -> None:
+        if not self.is_added:
+            raise self.raise_for_error_class(errors=self.errors)
 
 
 @dataclass
@@ -103,7 +96,7 @@ class ValidationDefinitionAddedDiagnostics(_ParentAddedDiagnostics):
         ExpectationSuiteNotAddedError,
         BatchDefinitionNotAddedError,
     )
-    exception_class: ClassVar[Type[ResourcesNotAddedError]] = (
+    raise_for_error_class: ClassVar[Type[ResourcesNotAddedError]] = (
         ValidationDefinitionRelatedResourcesNotAddedError
     )
 
@@ -114,6 +107,6 @@ class CheckpointAddedDiagnostics(_ParentAddedDiagnostics):
     children_error_classes: ClassVar[Tuple[Type[ResourceNotAddedError], ...]] = (
         ValidationDefinitionNotAddedError,
     )
-    exception_class: ClassVar[Type[ResourcesNotAddedError]] = (
+    raise_for_error_class: ClassVar[Type[ResourcesNotAddedError]] = (
         CheckpointRelatedResourcesNotAddedError
     )

--- a/great_expectations/core/batch_definition.py
+++ b/great_expectations/core/batch_definition.py
@@ -86,7 +86,7 @@ class BatchDefinition(pydantic.GenericModel, Generic[PartitionerT]):
     def identifier_bundle(self) -> _EncodedValidationData:
         # Utilized as a custom json_encoder
         diagnostics = self.is_added()
-        diagnostics.raise_for_errors()
+        diagnostics.raise_for_error()
 
         asset = self.data_asset
         data_source = asset.datasource

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -598,7 +598,7 @@ class ExpectationSuite(SerializableDictDot):
     def identifier_bundle(self) -> _IdentifierBundle:
         # Utilized as a custom json_encoder
         diagnostics = self.is_added()
-        diagnostics.raise_for_errors()
+        diagnostics.raise_for_error()
 
         return _IdentifierBundle(name=self.name, id=self.id)
 

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -219,9 +219,12 @@ class ValidationDefinition(BaseModel):
         run_id: RunIdentifier | None = None,
     ) -> ExpectationSuiteValidationResult:
         diagnostics = self.is_added()
-        diagnostics.raise_for_errors_except_parent_not_added_error()
-        if not self.id:
-            self._add_to_store()
+        if not diagnostics.is_added:
+            # The validation definition itself is not added but all children are - we can add it for the user # noqa: E501
+            if not diagnostics.parent_added and diagnostics.children_added:
+                self._add_to_store()
+            else:
+                diagnostics.raise_for_error()
 
         validator = Validator(
             batch_definition=self.batch_definition,
@@ -299,7 +302,7 @@ class ValidationDefinition(BaseModel):
     def identifier_bundle(self) -> _IdentifierBundle:
         # Utilized as a custom json_encoder
         diagnostics = self.is_added()
-        diagnostics.raise_for_errors()
+        diagnostics.raise_for_error()
 
         return _IdentifierBundle(name=self.name, id=self.id)
 

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -63,14 +63,6 @@ class CheckpointStore(Store):
     def serialize(self, value):
         # In order to enable the custom json_encoders in Checkpoint, we need to set `models_as_dict` off  # noqa: E501
         # Ref: https://docs.pydantic.dev/1.10/usage/exporting_models/#serialising-self-reference-or-other-models
-        diagnostics = value.is_added()
-        if self.cloud_mode:
-            # Cloud provides the parent ID
-            diagnostics.raise_for_errors_except_parent_not_added_error()
-        else:
-            # File/ephemeral will add the ID prior to this step
-            diagnostics.raise_for_errors()
-
         data = value.json(models_as_dict=False, indent=2, sort_keys=True, exclude_none=True)
 
         if self.cloud_mode:

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -211,7 +211,6 @@ class TestCheckpointSerialization:
             name="my_checkpoint",
             validation_definitions=validation_definitions,
             actions=actions,
-            id=str(uuid.uuid4()),
         )
 
         actual = json.loads(cp.json(models_as_dict=False))
@@ -237,6 +236,111 @@ class TestCheckpointSerialization:
         # Validation definitions should be persisted and obtain IDs before serialization
         self._assert_valid_uuid(actual["validation_definitions"][0]["id"])
         self._assert_valid_uuid(actual["validation_definitions"][1]["id"])
+
+    @pytest.mark.filesystem
+    def test_checkpoint_filesystem_round_trip_adds_ids(
+        self,
+        tmp_path: pathlib.Path,
+        actions: list[CheckpointAction],
+    ):
+        with working_directory(tmp_path):
+            context = gx.get_context(mode="file")
+
+        ds_name = "my_datasource"
+        asset_name = "my_asset"
+        batch_definition_name_1 = "my_batch1"
+        suite_name_1 = "my_suite1"
+        validation_definition_name_1 = "my_validation1"
+        batch_definition_name_2 = "my_batch2"
+        suite_name_2 = "my_suite2"
+        validation_definition_name_2 = "my_validation2"
+        cp_name = "my_checkpoint"
+
+        ds = context.data_sources.add_pandas(ds_name)
+        asset = ds.add_csv_asset(asset_name, "my_file.csv")  # type: ignore[arg-type]
+
+        bc1 = asset.add_batch_definition(batch_definition_name_1)
+        suite1 = context.suites.add(ExpectationSuite(suite_name_1))
+        vc1 = context.validation_definitions.add(
+            ValidationDefinition(name=validation_definition_name_1, data=bc1, suite=suite1)
+        )
+
+        bc2 = asset.add_batch_definition(batch_definition_name_2)
+        suite2 = context.suites.add(ExpectationSuite(suite_name_2))
+        vc2 = context.validation_definitions.add(
+            ValidationDefinition(name=validation_definition_name_2, data=bc2, suite=suite2)
+        )
+
+        validation_definitions = [vc1, vc2]
+        cp = Checkpoint(
+            name=cp_name, validation_definitions=validation_definitions, actions=actions
+        )
+
+        serialized_checkpoint = cp.json(models_as_dict=False)
+        serialized_checkpoint_dict = json.loads(serialized_checkpoint)
+
+        assert serialized_checkpoint_dict == {
+            "name": cp_name,
+            "validation_definitions": [
+                {
+                    "id": mock.ANY,
+                    "name": validation_definition_name_1,
+                },
+                {
+                    "id": mock.ANY,
+                    "name": validation_definition_name_2,
+                },
+            ],
+            "actions": [
+                {
+                    "name": "my_slack_action",
+                    "notify_on": "all",
+                    "notify_with": None,
+                    "renderer": {
+                        "class_name": "SlackRenderer",
+                        "module_name": "great_expectations.render.renderer.slack_renderer",
+                    },
+                    "show_failed_expectations": False,
+                    "slack_channel": None,
+                    "slack_token": None,
+                    "slack_webhook": "slack_webhook",
+                    "type": "slack",
+                },
+                {
+                    "name": "my_teams_action",
+                    "notify_on": "all",
+                    "renderer": {
+                        "class_name": "MicrosoftTeamsRenderer",
+                        "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",  # noqa: E501
+                    },
+                    "teams_webhook": "teams_webhook",
+                    "type": "microsoft",
+                },
+            ],
+            "result_format": ResultFormat.SUMMARY,
+            "id": None,
+        }
+
+        cp = Checkpoint.parse_raw(serialized_checkpoint)
+
+        # Check that all nested objects have been built properly with their appropriate names
+        assert cp.name == cp_name
+        assert cp.validation_definitions[0].data_source.name == ds_name
+        assert cp.validation_definitions[0].asset.name == asset_name
+
+        assert cp.validation_definitions[0].name == validation_definition_name_1
+        assert cp.validation_definitions[0].batch_definition.name == batch_definition_name_1
+        assert cp.validation_definitions[0].suite.name == suite_name_1
+
+        assert cp.validation_definitions[1].name == validation_definition_name_2
+        assert cp.validation_definitions[1].batch_definition.name == batch_definition_name_2
+        assert cp.validation_definitions[1].suite.name == suite_name_2
+
+        # Check that all validation_definitions and nested suites have been assigned IDs during serialization  # noqa: E501
+        self._assert_valid_uuid(id=cp.validation_definitions[0].id)
+        self._assert_valid_uuid(id=cp.validation_definitions[1].id)
+        self._assert_valid_uuid(id=cp.validation_definitions[0].suite.id)
+        self._assert_valid_uuid(id=cp.validation_definitions[1].suite.id)
 
     def _assert_valid_uuid(self, id: str | None) -> None:
         if not id:
@@ -911,50 +1015,3 @@ def test_is_added(
 
     assert diagnostics.is_added is is_added
     assert [type(err) for err in diagnostics.errors] == error_list
-
-
-@pytest.mark.unit
-def test_adding_with_multiple_child_validation_definitions_raises_error():
-    context = gx.get_context(mode="ephemeral")
-
-    suite_name = "my_suite"
-    validation_definition_name_1 = "my_first_validation"
-    validation_definition_name_2 = "my_second_validation"
-
-    datasource = context.data_sources.add_pandas(name="my_pandas_datasource")
-    asset = datasource.add_dataframe_asset(name="my_pandas_asset")
-    batch_definition = asset.add_batch_definition_whole_dataframe(name="my_batch_definition")
-
-    suite = gx.ExpectationSuite(name=suite_name)
-    expectation = gx.expectations.ExpectColumnValuesToBeBetween(
-        column="passenger_count", min_value=1, max_value=6
-    )
-    suite.add_expectation(expectation)
-
-    validation_definition_1 = gx.ValidationDefinition(
-        name=validation_definition_name_1, data=batch_definition, suite=suite
-    )
-    validation_definition_2 = gx.ValidationDefinition(
-        name=validation_definition_name_2, data=batch_definition, suite=suite
-    )
-
-    with pytest.raises(CheckpointRelatedResourcesNotAddedError) as e:
-        context.checkpoints.add(
-            gx.Checkpoint(
-                name="my_checkpoint",
-                validation_definitions=[validation_definition_1, validation_definition_2],
-            )
-        )
-
-    errors = e.value.errors
-    assert len(errors) == 4
-    assert isinstance(errors[0], ExpectationSuiteNotAddedError) and suite_name in errors[0].message
-    assert (
-        isinstance(errors[1], ValidationDefinitionNotAddedError)
-        and validation_definition_name_2 in errors[1].message
-    )
-    assert isinstance(errors[2], ExpectationSuiteNotAddedError) and suite_name in errors[2].message
-    assert (
-        isinstance(errors[3], ValidationDefinitionNotAddedError)
-        and validation_definition_name_1 in errors[3].message
-    )

--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -319,7 +319,7 @@ def test_checkpoint_factory_all_with_bad_config(
 
     # Make checkpoint_2 invalid. Pydantic will validate the object at creation time
     # but we can invalidate via assignment.
-    checkpoint_2.result_format = "not_valid"  # type: ignore[assignment] # done intentionally for test
+    checkpoint_2.validation_definitions = None  # type: ignore[assignment] # done intentionally for test
     checkpoint_2.save()
 
     # Act


### PR DESCRIPTION
Reverts great-expectations/great_expectations#10250