### PR TITLE
[DOCS] Adds query strings and headers to all full code examples in GX Core docs

### DIFF
--- a/docs/docusaurus/docs/core/_create_expectations/expectation_suites/manage_expectation_suites.md
+++ b/docs/docusaurus/docs/core/_create_expectations/expectation_suites/manage_expectation_suites.md
@@ -24,9 +24,16 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 ## Create an Expectation Suite
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Import the GX Core library and the `ExpectationSuite` class:
 
@@ -69,9 +76,16 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 ## Get an existing Expectation Suite
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -97,7 +111,7 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Get the Expectation Suite to rename.  This could be an [existing Expectation Suite you retrieve from your Data Context](#get-an-existing-expectation-suite) or a [new Expectation Suite](#create-an-expectation-suite) that you have referenced earlier in your code.
 
@@ -130,7 +144,7 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -161,7 +175,7 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. [Create a new](#create-an-expectation-suite) or [get an existing](#get-an-existing-expectation-suite) Expectation Suite.
 
@@ -200,7 +214,7 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. [Get an existing Expectation Suite](#get-an-existing-expectation-suite) that contains Expectations or [add some Expectations to a new Expectation Suite](#add-expectations-to-an-expectation-suite).
 
@@ -226,7 +240,7 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. [Get the Expectation to edit](#get-an-expectation-from-an-expectation-suite) from its Expectation Suite.
 
@@ -261,7 +275,7 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. [Get an existing Expectation Suite](#get-an-existing-expectation-suite) that contains Expectations, or [add some Expectations to a new Expectation Suite](#add-expectations-to-an-expectation-suite). 
 
@@ -292,7 +306,7 @@ An Expectation Suite contains a group of Expectations that describe the same set
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. [Get the Expectation Suite containing the Expectation to delete](#get-an-existing-expectation-suite).
 

--- a/docs/docusaurus/docs/core/_create_expectations/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/core/_create_expectations/expectations/manage_expectations.md
@@ -24,7 +24,7 @@ An Expectation is a verifiable assertion about your data. Expectations make impl
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Import the `expectations` module from the GX Core library:
 
@@ -57,7 +57,7 @@ An Expectation is a verifiable assertion about your data. Expectations make impl
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. [Retrieve a Batch of data](/core/manage_and_access_data/request_data.md) to test the Expectation against.  
 
@@ -111,7 +111,7 @@ An Expectation is a verifiable assertion about your data. Expectations make impl
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Get the Expectation to modify.  This could be a [newly created](#create-an-expectation) Expectation that you wish to adjust, an Expectation [retrieved from an Expectation Suite](/core/_create_expectations/expectation_suites/manage_expectation_suites.md#get-an-expectation-from-an-expectation-suite), or a pre-existing Expectation from your code.  
 
@@ -156,7 +156,7 @@ An Expectation is a verifiable assertion about your data. Expectations make impl
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Choose and import a base Expectation class:
 

--- a/docs/docusaurus/docs/core/_validate_data/checkpoints/manage_checkpoints.md
+++ b/docs/docusaurus/docs/core/_validate_data/checkpoints/manage_checkpoints.md
@@ -20,7 +20,7 @@ If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. 
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Import the GX library and the `Checkpoint` class:
 
@@ -74,7 +74,7 @@ If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. 
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -100,7 +100,7 @@ If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. 
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -126,7 +126,7 @@ If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. 
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -158,7 +158,7 @@ If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. 
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -195,7 +195,7 @@ If the list of Actions for a Checkpoint is empty, the Checkpoint can still run. 
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 

--- a/docs/docusaurus/docs/core/_validate_data/validation_definitions/manage_validation_definitions.md
+++ b/docs/docusaurus/docs/core/_validate_data/validation_definitions/manage_validation_definitions.md
@@ -27,7 +27,7 @@ A Validation Definition is a fixed reference that links a Batch of data to an Ex
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Import the `ValidationDefinition` class from the GX library.
 
@@ -112,7 +112,7 @@ validation_definition = context.validation_definitions.add(ValidationDefinition(
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -149,7 +149,7 @@ for definition in context.validation_definitions:
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -185,7 +185,7 @@ validation_definition = context.validation_definitions.get(name=definition_name)
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -255,7 +255,7 @@ validation_definitions_for_asset = [
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. <StepRequestADataContext/>.
 
@@ -299,7 +299,7 @@ context.validation_definitions.delete(validation_definition.name)
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 Validation definitions are intended to be fixed references that link a set of data to an Expectation Suite.  As such, they do not include an update method.  However, multiple Validation Definitions with the same Batch Definition and Expectation Suite can exist as long as each has a unique name.
 
@@ -381,7 +381,7 @@ context.validation_definitions.delete(original_validation_definition)
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Create a new or retrieve an existing Validation Definition.
 

--- a/docs/docusaurus/docs/core/configure_project_settings/configure_data_docs/configure_data_docs.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_data_docs/configure_data_docs.md
@@ -36,13 +36,14 @@ To host Data Docs in an environment other than a local or networked filesystem, 
 - Optional. <PrereqAbsInstalled/> and [credentials configured](/core/configure_project_settings/configure_credentials/configure_credentials.md).
 
 ### Procedure
+
 <Tabs 
-  queryString="procedure"
-  defaultValue="instructions" 
-  values={[
-    {value: 'instructions', label:'Instructions'},
-    {value:'sample_code', label:'Sample code'}
-  ]}
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
 >
 
 <TabItem value="instructions" label="Instructions">

--- a/docs/docusaurus/docs/core/configure_project_settings/configure_metadata_stores/configure_metadata_stores.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_metadata_stores/configure_metadata_stores.md
@@ -25,9 +25,18 @@ By default, Store files are created in folders within the `base_folder` of the F
 - <PrereqGxInstalled/>.
 - <PrereqFileDataContext/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Load a File Data Context.
 

--- a/docs/docusaurus/docs/core/connect_to_data/dataframes/dataframes.md
+++ b/docs/docusaurus/docs/core/connect_to_data/dataframes/dataframes.md
@@ -29,7 +29,14 @@ Because the dataframes reside in memory you do not need to specify the location 
 
 ### Procedure
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
 <TabItem value="instructions" label="Instructions">
 
@@ -110,7 +117,14 @@ A dataframe Data Asset is used to group your Validation Results.  For instance, 
 
 ### Procedure
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
 <TabItem value="instructions" label="Instructions">
 
@@ -167,7 +181,14 @@ This means that Batch Definitions for dataframe Data Assets don't work to subdiv
 
 ### Procedure
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
 <TabItem value="instructions" label="Instructions">
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_tab-directory_batch_definition.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_tab-directory_batch_definition.md
@@ -9,9 +9,18 @@ Batch Definitions for a Directory Data Asset can be configured to return all of 
 - <PreReqDataContext/>.  The variable `context` is used for your Data Context in the following example code.
 - [A File Data Asset on a Filesystem Data Source](#create-a-data-asset).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Asset.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_tab-file_batch_definition.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_tab-file_batch_definition.md
@@ -11,7 +11,7 @@ Batch Definitions for File Data Assets can be configured to return the content o
 
 <Tabs>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Asset.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_abs/_tab-directory_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_abs/_tab-directory_data_asset.md
@@ -12,9 +12,18 @@ import PrereqSparkFilesystemDataSource from '../../../../_core_components/prereq
 - <PrereqDataContext/>.
 - [A Filesystem Data Source configured to access data files in Azure Blob Storage](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=abs#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
    Replace the value of `data_source_name` in the following code with the name of your Data Source and execute it to retrieve your Data Source from the Data Context:

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_abs/_tab-file_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_abs/_tab-file_data_asset.md
@@ -12,9 +12,18 @@ import PrereqDataContext from '../../../../_core_components/prerequisites/_preco
 - Access to data files in Azure Blob Storage.
 - A pandas or Spark [Filesystem Data Source configured for Azure Blob Storage data files](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=abs#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_gcs/_tab-directory_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_gcs/_tab-directory_data_asset.md
@@ -12,9 +12,18 @@ import PrereqSparkFilesystemDataSource from '../../../../_core_components/prereq
 - <PrereqDataContext/>.
 - [A Filesystem Data Source configured to access data files in Google Cloud Storage](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=gcs#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_gcs/_tab-file_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_gcs/_tab-file_data_asset.md
@@ -12,9 +12,18 @@ import PrereqDataContext from '../../../../_core_components/prerequisites/_preco
 - Access to data files in Google Cloud Storage.
 - [A pandas](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=pandas&environment=gcs#create-a-data-source) or [Spark Filesystem Data Source configured for Google Cloud Storage data files](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=gcs#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_local_or_networked/_tab-directory_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_local_or_networked/_tab-directory_data_asset.md
@@ -12,9 +12,18 @@ import PrereqSparkFilesystemDataSource from '../../../../_core_components/prereq
 - <PrereqDataContext/>.
 - [A Spark Filesystem Data Source configured to access data files in a local or networked folder hierarchy](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=filesystem#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_local_or_networked/_tab-file_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_local_or_networked/_tab-file_data_asset.md
@@ -13,9 +13,18 @@ import PrereqSparkFilesystemDataSource from '../../../../_core_components/prereq
 - Access to data files (such as `.csv` or `.parquet` files) in a local or networked folder hierarchy.
 - [A pandas](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=pandas&environment=filesystem#create-a-data-source) or [Spark Filesystem Data Source configured for local or networked data files](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=filesystem#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_s3/_tab-directory_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_s3/_tab-directory_data_asset.md
@@ -12,9 +12,18 @@ import PrereqSparkFilesystemDataSource from '../../../../_core_components/prereq
 - <PrereqDataContext/>.
 - [A Filesystem Data Source configured to access data files in S3](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=s3#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_s3/_tab-file_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_s3/_tab-file_data_asset.md
@@ -12,9 +12,18 @@ import PrereqDataContext from '../../../../_core_components/prerequisites/_preco
 - Access to data files in S3.
 - [A Filesystem Data Source configured to access data files in S3](/core/connect_to_data/filesystem_data/filesystem_data.md?data_source_type=spark&environment=s3#create-a-data-source).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_abs/_abs.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_abs/_abs.md
@@ -12,9 +12,18 @@ import PrereqDataContext from '../../../../_core_components/prerequisites/_preco
 - <PrereqDataContext/>
 - Access to data files in Azure Blob Storage.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Define the Data Source's parameters.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_gcs.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_gcs.md
@@ -12,9 +12,18 @@ import PrereqDataContext from '../../../../_core_components/prerequisites/_preco
 - <PrereqDataContext/>
 - Access to data files in Google Cloud Storage.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Set up the Data Source's credentials.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_local_or_networked/_local_or_networked.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_local_or_networked/_local_or_networked.md
@@ -18,9 +18,18 @@ import PandasDefault from './_pandas_default.md'
 <PandasDefault/>
 :::
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Define the Data Source's parameters.
 

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_s3.md
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_s3.md
@@ -12,9 +12,18 @@ import PrereqDataContext from '../../../../_core_components/prerequisites/_preco
 - <PrereqDataContext/>
 - Access to data files on a S3 bucket.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Define the Data Source's parameters.
 

--- a/docs/docusaurus/docs/core/connect_to_data/sql_data/_create_a_batch_definition/_create_a_batch_definition.md
+++ b/docs/docusaurus/docs/core/connect_to_data/sql_data/_create_a_batch_definition/_create_a_batch_definition.md
@@ -7,9 +7,18 @@ import PreReqDataContext from '../../../_core_components/prerequisites/_preconfi
 - <PreReqDataContext/>.  The variable `context` is used for your Data Context in the following example code.
 - [A Data Asset on a SQL Data Source](#create-a-data-asset).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Asset.
 

--- a/docs/docusaurus/docs/core/connect_to_data/sql_data/_create_a_data_asset/_create_a_data_asset.md
+++ b/docs/docusaurus/docs/core/connect_to_data/sql_data/_create_a_data_asset/_create_a_data_asset.md
@@ -13,9 +13,18 @@ Data Assets are collections of records within a Data Source.  With SQL Data Sour
 - <PreReqDataContext/>.  The variable `context` is used for your Data Context in the following example code.
 - <PrereqDataSource/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Data Source.
 

--- a/docs/docusaurus/docs/core/connect_to_data/sql_data/_create_a_data_source/_create_a_data_source.md
+++ b/docs/docusaurus/docs/core/connect_to_data/sql_data/_create_a_data_source/_create_a_data_source.md
@@ -15,9 +15,18 @@ import DatasourceMethodReferenceTable from './_datasource_method_reference_table
 - <PreReqDataContext/>.
 - <PreReqCredentials/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Import GX and instantiate a Data Context:
 

--- a/docs/docusaurus/docs/core/customize_expectations/define_a_custom_expectation_class.md
+++ b/docs/docusaurus/docs/core/customize_expectations/define_a_custom_expectation_class.md
@@ -24,9 +24,18 @@ Advantages of subclassing an Expectation and providing customized attributes rat
 - <PrereqPreconfiguredDataContext/>.
 - Recommended. <PrereqPreconfiguredDataSourceAndAsset/> for [testing your customized Expectation](/core/define_expectations/test_an_expectation.md).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Choose a base Expectation class.
 

--- a/docs/docusaurus/docs/core/customize_expectations/expectation_row_conditions.md
+++ b/docs/docusaurus/docs/core/customize_expectations/expectation_row_conditions.md
@@ -30,9 +30,18 @@ Great Expectations lets you express Conditional Expectations with a `row_conditi
 - <PrereqPreconfiguredDataContext/>.
 - Recommended. <PrereqPreconfiguredDataSourceAndAsset/> for [testing your customized Expectation](/core/define_expectations/test_an_expectation.md).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 In this procedure, your Data Context is assumed to be stored in the variable `context` and your Expectation Suite is assumed to be stored in the variable `suite`.  `suite` can be a newly created and empty Expectation Suite, or an existing Expectation Suite retrieved from the Data Context.
 

--- a/docs/docusaurus/docs/core/customize_expectations/use_sql_to_define_a_custom_expectation.md
+++ b/docs/docusaurus/docs/core/customize_expectations/use_sql_to_define_a_custom_expectation.md
@@ -24,9 +24,18 @@ You customize an `UnexpectedRowsExpectation` in essentially the same manner as y
 - <PrereqPreconfiguredDataContext/>.
 - Recommended. <PrereqPreconfiguredDataSourceAndAsset/> for [testing your customized Expectation](/core/define_expectations/test_an_expectation.md).
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Create a new Expectation class that inherits the `UnexpectedRowsExpectation` class.
   

--- a/docs/docusaurus/docs/core/define_expectations/_retrieve_a_batch_of_test_data/_from_a_batch_definition.md
+++ b/docs/docusaurus/docs/core/define_expectations/_retrieve_a_batch_of_test_data/_from_a_batch_definition.md
@@ -15,9 +15,18 @@ Batch Definitions both organize a Data Asset's records into Batches and provide 
 - <PrereqDataContext/>.  These examples assume the variable `context` contains your Data Context.
 - <PrereqDataSourceAndAssetConnectedToData/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Batch Definition.
 

--- a/docs/docusaurus/docs/core/define_expectations/_retrieve_a_batch_of_test_data/_from_pandas_default.md
+++ b/docs/docusaurus/docs/core/define_expectations/_retrieve_a_batch_of_test_data/_from_pandas_default.md
@@ -18,9 +18,18 @@ Because the `pandas_default` Data Source's `.read_*(...)` methods only return a 
 - <PrereqDataContext/>.  These examples assume the variable `context` contains your Data Context.
 - Data in a file format supported by pandas, such as `.csv` or `.parquet`.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Define the path to the datafile.
 

--- a/docs/docusaurus/docs/core/define_expectations/create_an_expectation.md
+++ b/docs/docusaurus/docs/core/define_expectations/create_an_expectation.md
@@ -17,9 +17,18 @@ An Expectation is a verifiable assertion about your data. Expectations make impl
 - <PrereqPythonInstalled/>.
 - <PrereqGxInstalled/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Choose an Expectation to create.
 

--- a/docs/docusaurus/docs/core/define_expectations/organize_expectation_suites.md
+++ b/docs/docusaurus/docs/core/define_expectations/organize_expectation_suites.md
@@ -19,10 +19,18 @@ An Expectation Suite contains a group of Expectations that describe the same set
 - Recommended. <PrereqPreconfiguredDataContext/>.
 - Recommended. <PrereqPreconfiguredDataSourceAndAsset/>.
 
+### Procedure
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve or create a Data Context.
 

--- a/docs/docusaurus/docs/core/define_expectations/test_an_expectation.md
+++ b/docs/docusaurus/docs/core/define_expectations/test_an_expectation.md
@@ -21,9 +21,18 @@ Data can be validated against individual Expectations.  This workflow is general
 - [A Batch of sample data](/core/define_expectations/retrieve_a_batch_of_test_data.md).  This guide assumes the variable `batch` contains your sample data.
 - <PrereqExpectation/>.  This guide assumes the variable `expectation` contains the Expectation to be tested.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Run the Expectation on the Batch of data.
 

--- a/docs/docusaurus/docs/core/introduction/try_gx.md
+++ b/docs/docusaurus/docs/core/introduction/try_gx.md
@@ -1,5 +1,7 @@
 ---
 title: Try GX Core
+toc_min_heading_level: 2
+toc_max_heading_level: 2
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/docusaurus/docs/core/introduction/try_gx.md
+++ b/docs/docusaurus/docs/core/introduction/try_gx.md
@@ -55,9 +55,18 @@ This example workflow walks you through connecting to data in a Pandas DataFrame
 This example requires that [Pandas](https://pandas.pydata.org/) is installed in the same Python environment where you are running GX Core.
 :::
 
-<Tabs>
+### Procedure
 
-<TabItem value="exploratory_walkthrough" label="Walkthrough">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 Run the following steps in a Python interpreter, IDE, notebook, or script.
 
@@ -110,7 +119,8 @@ Run the following steps in a Python interpreter, IDE, notebook, or script.
 
 </TabItem>
 
-<TabItem value="exploratory_full_example" label="Full example code">
+<TabItem value="sample_code" label="Sample code">
+
 ```python title="Full example code" name="docs/docusaurus/docs/core/introduction/try_gx_exploratory.py full exploratory script"
 ```
 
@@ -121,9 +131,18 @@ Run the following steps in a Python interpreter, IDE, notebook, or script.
 ## Validate data in a SQL table
 This example workflow walks you through connecting to data in a Postgres table, creating an Expectation Suite, and setting up a Checkpoint to validate the data.
 
-<Tabs>
+### Procedure
 
-<TabItem value="end2end_walkthrough" label="Walkthrough">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 Run the following steps in a Python interpreter, IDE, notebook, or script.
 
@@ -169,20 +188,22 @@ Run the following steps in a Python interpreter, IDE, notebook, or script.
    ```python title="Python input" name="docs/docusaurus/docs/core/introduction/try_gx_end_to_end.py create and run checkpoint"
    ```
 
-The returned results reflect the passing of one Expectation and the failure of one Expectation.
+   The returned results reflect the passing of one Expectation and the failure of one Expectation.
 
-When an Expectation fails, the Validation Results of the failed Expectation include metrics to help you assess the severity of the issue:
+   When an Expectation fails, the Validation Results of the failed Expectation include metrics to help you assess the severity of the issue:
 
    ```python title="Python input" name="docs/docusaurus/docs/core/introduction/try_gx_end_to_end.py checkpoint result"
    ```
 
-To reduce the size of the results and make it easier to review, only a portion of the failed values and record indexes are included in the Checkpoint results. The failed counts and percentages correspond to the failed records in the validated data.
+   To reduce the size of the results and make it easier to review, only a portion of the failed values and record indexes are included in the Checkpoint results. The failed counts and percentages correspond to the failed records in the validated data.
 
 </TabItem>
 
-<TabItem value="end2end_full_example" label="Full example code">
+<TabItem value="sample_code" label="Sample code">
+
 ```python title="Full example code" name="docs/docusaurus/docs/core/introduction/try_gx_end_to_end.py full end2end script"
 ```
+
 </TabItem>
 </Tabs>
 

--- a/docs/docusaurus/docs/core/run_validations/create_a_validation_definition.md
+++ b/docs/docusaurus/docs/core/run_validations/create_a_validation_definition.md
@@ -24,9 +24,18 @@ A Validation Definition is a fixed reference that links a Batch of data to an Ex
 - <PrereqPreconfiguredDataSourceAndAsset/>.
 - <PrereqPreconfiguredExpectationSuiteAndExpectations/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve an Expectation Suite with Expectations.
 

--- a/docs/docusaurus/docs/core/run_validations/run_a_validation_definition.md
+++ b/docs/docusaurus/docs/core/run_validations/run_a_validation_definition.md
@@ -18,9 +18,18 @@ import PrereqValidationDefinition from '../_core_components/prerequisites/_valid
 - <PrereqPreconfiguredDataContext/>. In this guide the variable `context` is assumed to contain your Data Context.
 - <PrereqValidationDefinition/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve your Validation Definition.
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_cloud_data_context.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_cloud_data_context.md
@@ -12,9 +12,16 @@ import PrereqGxInstallation from '../../_core_components/prerequisites/_gx_insta
 
 ## Create a Cloud Data Context
 
-<Tabs queryString="cloud-tab">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Run the following code to request a GX Cloud Data Context:
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_ephemeral_data_context.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_ephemeral_data_context.md
@@ -11,9 +11,16 @@ import PrereqGxInstallation from '../../_core_components/prerequisites/_gx_insta
 
 ## Create an Ephemeral Data Context
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Run the following code to request an Ephemeral Data Context:
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_file_data_context.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_file_data_context.md
@@ -11,9 +11,16 @@ import PrereqGxInstallation from '../../_core_components/prerequisites/_gx_insta
 
 ## Create a File Data Context
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Run the following code to request a File Data Context:
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_quick_start.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_quick_start.md
@@ -11,9 +11,16 @@ import PrereqGxInstallation from '../../_core_components/prerequisites/_gx_insta
 
 ## Request an available Data Context
 
-<Tabs>
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
 
-<TabItem value="procedure" label="Procedure">
+<TabItem value="instructions" label="Instructions">
 
 1. Run the following code to request a Data Context:
 

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_checkpoint_with_actions.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_checkpoint_with_actions.md
@@ -18,9 +18,18 @@ A Checkpoint executes one or more Validation Definitions and then performs a set
 - <PrereqPreconfiguredDataContext/>. In this guide the variable `context` is assumed to contain your Data Context.
 - <PrereqValidationDefinition/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 1. Retrieve the Validation Definitions the Checkpoint will run.
 

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/run_a_checkpoint.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/run_a_checkpoint.md
@@ -19,9 +19,18 @@ At runtime, a Checkpoint can take in a `batch_parameters` dictionary that select
 - <PrereqPreconfiguredDataContext/>.
 - <PrereqCheckpoint/>.
 
-<Tabs>
+### Procedure
 
-<TabItem value="procedure" label="Procedure">
+<Tabs 
+   queryString="procedure"
+   defaultValue="instructions"
+   values={[
+      {value: 'instructions', label: 'Instructions'},
+      {value: 'sample_code', label: 'Sample code'}
+   ]}
+>
+
+<TabItem value="instructions" label="Instructions">
 
 In this procedure your Data Context is assumed to be stored in the variable `context` and your Checkpoint is assumed to be stored in the variable `checkpoint`.
 


### PR DESCRIPTION
## Description
Permits linking directly to full example code for any given example in the GX Core docs:
- Adds query strings to all procedure/sample_code tab groups in the GX Core docs.
- Adds headers above all procedure/sample_code tab groups in the GX Core docs.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated
