### PR TITLE
[DOCS] Remove DatabricksSQL references to a `/database` path in connection string.

### DIFF
--- a/docs/docusaurus/docs/core/connect_to_data/configure_credentials/_connection_string_reference_table.md
+++ b/docs/docusaurus/docs/core/connect_to_data/configure_credentials/_connection_string_reference_table.md
@@ -4,7 +4,7 @@
 | PostgreSQL      | `postgresql+psycopg2://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>`                                                                                           |
 | SQLite          | `sqlite:///<PATH_TO_DB_FILE>`                                                                                                                                    |
 | Snowflake       | `snowflake://<USER_NAME>:<PASSWORD>@<ACCOUNT_NAME>/<DATABASE_NAME>/<SCHEMA_NAME>?warehouse=<WAREHOUSE_NAME>&role=<ROLE_NAME>&application=great_expectations_oss` |
-| Databricks SQL  | `databricks://token:<TOKEN>@<HOST>:<PORT>/<DATABASE>?http_path=<HTTP_PATH>&catalog=<CATALOG>&schema=<SCHEMA>`                                                   |
+| Databricks SQL  | `databricks://token:<TOKEN>@<HOST>:<PORT>?http_path=<HTTP_PATH>&catalog=<CATALOG>&schema=<SCHEMA>`                                                   |
 | BigQuery SQL    | `bigquery://<GCP_PROJECT>/<BIGQUERY_DATASET>?credentials_path=/path/to/your/credentials.json`                                                                    |
 
 

--- a/docs/docusaurus/versioned_docs/version-0.17/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.17/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -400,7 +400,7 @@ The following code examples use a Databricks SQL connection string. A connection
 The following code is an example of a Databricks SQL connection string format:
 
 ```python title="Python"
-my_connection_string = f"databricks://token:{token}@{host}:{port}/{database}?http_path={http_path}&catalog={catalog}&schema={schema}"
+my_connection_string = f"databricks://token:{token}@{host}:{port}?http_path={http_path}&catalog={catalog}&schema={schema}"
 ```
 
 ### Create a Databricks SQL Data Source

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -335,7 +335,7 @@ The following code examples use a Databricks SQL connection string. A connection
 The following code is an example of a Databricks SQL connection string format:
 
 ```python
-my_connection_string = f"databricks://token:{token}@{host}:{port}/{database}?http_path={http_path}&catalog={catalog}&schema={schema}"
+my_connection_string = f"databricks://token:{token}@{host}:{port}?http_path={http_path}&catalog={catalog}&schema={schema}"
 ```
 
 ### Create a Databricks SQL Data Source

--- a/great_expectations/datasource/fluent/databricks_sql_datasource.py
+++ b/great_expectations/datasource/fluent/databricks_sql_datasource.py
@@ -181,7 +181,7 @@ class DatabricksSQLDatasource(SQLDatasource):
     Args:
         name: The name of this DatabricksSQL datasource.
         connection_string: The SQLAlchemy connection string used to connect to the postgres database.
-            For example: "databricks://token:<token>@<host>:<port>/<database>?http_path=<http_path>&catalog=<catalog>&schema=<schema>""
+            For example: "databricks://token:<token>@<host>:<port>?http_path=<http_path>&catalog=<catalog>&schema=<schema>""
         assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose values
             are TableAsset or QueryAsset objects.
     """  # noqa: E501

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "DatabricksSQLDatasource",
-    "description": "--Public API--Adds a DatabricksSQLDatasource to the data context.\n\nArgs:\n    name: The name of this DatabricksSQL datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the postgres database.\n        For example: \"databricks://token:<token>@<host>:<port>/<database>?http_path=<http_path>&catalog=<catalog>&schema=<schema>\"\"\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose values\n        are TableAsset or QueryAsset objects.",
+    "description": "--Public API--Adds a DatabricksSQLDatasource to the data context.\n\nArgs:\n    name: The name of this DatabricksSQL datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the postgres database.\n        For example: \"databricks://token:<token>@<host>:<port>?http_path=<http_path>&catalog=<catalog>&schema=<schema>\"\"\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose values\n        are TableAsset or QueryAsset objects.",
     "type": "object",
     "properties": {
         "type": {

--- a/tests/datasource/fluent/great_expectations.yml
+++ b/tests/datasource/fluent/great_expectations.yml
@@ -225,7 +225,7 @@ fluent_datasources:
   my_databricks_sql_ds:
     type: databricks_sql
     id: 542eec80-9b48-4174-b93f-29fb46d87bb9
-    connection_string: "databricks://token:dapi123@abc-123.cloud.databricks.com:123/default_db?http_path=/sql/1.0/warehouses/abc123&catalog=default&schema=dev"
+    connection_string: "databricks://token:dapi123@abc-123.cloud.databricks.com:123?http_path=/sql/1.0/warehouses/abc123&catalog=default&schema=dev"
     assets:
       my_table_asset_wo_partitioners:
         id: f2597c56-eeea-4bfd-b07c-5f35779a71e5

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -318,7 +318,7 @@ def databricks_sql_ds(
         "databricks_sql",
         connection_string="databricks://token:"
         "${DATABRICKS_TOKEN}@${DATABRICKS_HOST}:443"
-        "/" + RAND_SCHEMA + "?http_path=${DATABRICKS_HTTP_PATH}&catalog=ci&schema=" + RAND_SCHEMA,
+        "?http_path=${DATABRICKS_HTTP_PATH}&catalog=ci&schema=" + RAND_SCHEMA,
     )
     return ds
 

--- a/tests/datasource/fluent/test_databricks_sql_datasource.py
+++ b/tests/datasource/fluent/test_databricks_sql_datasource.py
@@ -13,7 +13,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
     "connection_string, expected_errors",
     [
         pytest.param(
-            "databricks://token:my_token>@my_host:1234/my_db",
+            "databricks://token:my_token>@my_host:1234",
             [
                 {
                     "loc": ("connection_string",),
@@ -29,7 +29,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             id="missing query",
         ),
         pytest.param(
-            "databricks://token:my_token>@my_host:1234/my_db?my_query=data",
+            "databricks://token:my_token>@my_host:1234?my_query=data",
             [
                 {
                     "loc": ("connection_string",),
@@ -45,7 +45,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             id="missing http_path",
         ),
         pytest.param(
-            "databricks://token:my_token>@my_host:1234/my_db?http_path=/path/a/&http_path=/path/b/",
+            "databricks://token:my_token>@my_host:1234?http_path=/path/a/&http_path=/path/b/",
             [
                 {
                     "loc": ("connection_string",),
@@ -61,7 +61,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             id="multiple http_paths",
         ),
         pytest.param(
-            "databricks://token:my_token>@my_host:1234/my_db?http_path=/a/b/c&schema=dev",
+            "databricks://token:my_token>@my_host:1234?http_path=/a/b/c&schema=dev",
             [
                 {
                     "loc": ("connection_string",),
@@ -77,7 +77,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             id="missing catalog",
         ),
         pytest.param(
-            "databricks://token:my_token>@my_host:1234/my_db?http_path=/a/b/c&catalog=dev",
+            "databricks://token:my_token>@my_host:1234?http_path=/a/b/c&catalog=dev",
             [
                 {
                     "loc": ("connection_string",),


### PR DESCRIPTION
DatabricksSQL data connector doesn't use a `/database` path item for anything.
It is ignored if provided.

Somehow this made it into our docs and test examples.

https://docs.databricks.com/en/dev-tools/python-sql-connector.html

