### PR TITLE
[BUGFIX] Checkpoint references the instance of ValidationDefinition t…

### DIFF
--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -63,6 +63,9 @@ class ValidationDefinition(BaseModel):
     class Config:
         extra = Extra.forbid
         arbitrary_types_allowed = True  # Necessary for compatibility with suite's Marshmallow dep
+        copy_on_model_validation = (
+            "none"  # Necessary to prevent cloning when passing to a checkpoint
+        )
         validate_assignment = True
         """
         When serialized, the suite and data fields should be encoded as a set of identifiers.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,11 +24,13 @@ from great_expectations.analytics.config import ENV_CONFIG
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
+from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
 from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
+from great_expectations.core.validation_definition import ValidationDefinition
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import (
     AbstractDataContext,
@@ -2172,6 +2174,35 @@ def ephemeral_context_with_defaults() -> EphemeralDataContext:
         store_backend_defaults=InMemoryStoreBackendDefaults(init_temp_docs_sites=True)
     )
     return get_context(project_config=project_config, mode="ephemeral")
+
+
+@pytest.fixture
+def arbitrary_batch_definition(empty_data_context: AbstractDataContext) -> BatchDefinition:
+    return (
+        empty_data_context.data_sources.add_pandas("my_datasource_with_batch_def")
+        .add_dataframe_asset("my_asset")
+        .add_batch_definition_whole_dataframe(name="my_dataframe_batch_definition")
+    )
+
+
+@pytest.fixture
+def arbitrary_suite(empty_data_context: AbstractDataContext) -> ExpectationSuite:
+    return empty_data_context.suites.add(ExpectationSuite("my_suite"))
+
+
+@pytest.fixture
+def arbitrary_validation_definition(
+    empty_data_context: AbstractDataContext,
+    arbitrary_suite: ExpectationSuite,
+    arbitrary_batch_definition: BatchDefinition,
+) -> ValidationDefinition:
+    return empty_data_context.validation_definitions.add(
+        ValidationDefinition(
+            name="my_validation_definition",
+            suite=arbitrary_suite,
+            data=arbitrary_batch_definition,
+        )
+    )
 
 
 @pytest.fixture

--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -22,15 +22,16 @@ from great_expectations.exceptions import DataContextError
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_get_uses_store_get(mocker: MockerFixture):
+def test_checkpoint_factory_get_uses_store_get(
+    mocker: MockerFixture,
+    arbitrary_validation_definition: ValidationDefinition,
+):
     # Arrange
     name = "test-checkpoint"
     store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = True
     key = store.get_key.return_value
-    checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
-    )
+    checkpoint = Checkpoint(name=name, validation_definitions=[arbitrary_validation_definition])
     store.get.return_value = checkpoint
     factory = CheckpointFactory(store=store)
 
@@ -44,14 +45,15 @@ def test_checkpoint_factory_get_uses_store_get(mocker: MockerFixture):
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_get_raises_error_on_missing_key(mocker: MockerFixture):
+def test_checkpoint_factory_get_raises_error_on_missing_key(
+    mocker: MockerFixture,
+    arbitrary_validation_definition: ValidationDefinition,
+):
     # Arrange
     name = "test-checkpoint"
     store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = False
-    checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
-    )
+    checkpoint = Checkpoint(name=name, validation_definitions=[arbitrary_validation_definition])
     store.get.return_value = checkpoint
     factory = CheckpointFactory(store=store)
 

--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -66,7 +66,9 @@ def test_checkpoint_factory_get_raises_error_on_missing_key(
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_add_uses_store_add(mocker: MockerFixture):
+def test_checkpoint_factory_add_uses_store_add(
+    mocker: MockerFixture, arbitrary_validation_definition: ValidationDefinition
+):
     # Arrange
     name = "test-checkpoint"
     store = mocker.MagicMock(spec=CheckpointStore)
@@ -74,9 +76,7 @@ def test_checkpoint_factory_add_uses_store_add(mocker: MockerFixture):
     key = store.get_key.return_value
     store.get.return_value = None
     factory = CheckpointFactory(store=store)
-    checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
-    )
+    checkpoint = Checkpoint(name=name, validation_definitions=[arbitrary_validation_definition])
     store.get.return_value = checkpoint
 
     # Act


### PR DESCRIPTION
…hat was passed in

Resolves https://greatexpectations.atlassian.net/browse/V1-496. This was the simplest fix I could identify, though it uses the deprecated (as of pydantic v2) `Config` class. AFAIK, when we stop using the `Config` class, we'll need to migrate to a custom validator. We currently use a deprecated (in v2) `@validator`

Had to update a couple other tests to not use `Mock`, but instead use real live `ValidationDefinitions`.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
