### PR TITLE
[DOCS] Fix gx core sidebar inconsistency in version 0.18

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.18/core/introduction/introduction.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/core/introduction/introduction.md
@@ -1,0 +1,88 @@
+---
+title: About Great Expectations OSS
+slug: introduction
+---
+
+Great Expectations is the leading tool for [validating](/reference/learn/terms/validation.md) and [documenting](/reference/learn/terms/data_docs.md) your data. If you're ready to get started, see the [Quickstart](/oss/tutorials/quickstart.md).
+
+Software developers have long known that automated testing is essential for managing complex codebases. Great Expectations brings the same discipline, confidence, and acceleration to data science and data engineering teams.
+
+![overview](/docs/oss/guides/images/gx_oss_process.png)
+
+### Why use Great Expectations?
+
+With Great Expectations, you can assert what you expect from the data you load and transform, and catch data issues quickly – Expectations are basically unit tests for your data. Not only that, but Great Expectations also creates data documentation and data quality reports from those Expectations. Data science and data engineering teams use Great Expectations to:
+
+- Test data they ingest from other teams or vendors and ensure its validity.
+- Validate data they transform as a step in their data pipeline in order to ensure the correctness of transformations.
+- Prevent data quality issues from slipping into data products.
+- Streamline knowledge capture from subject-matter experts and make implicit knowledge explicit.
+- Develop rich, shared documentation of their data.
+
+To learn more about how data teams are using Great Expectations, see [Case studies from Great Expectations](https://greatexpectations.io/case-studies/).
+
+### Key Features
+#### Expectations
+
+Expectations are assertions about your data. In Great Expectations, those assertions are expressed in a declarative language in the form of simple, human-readable Python methods. For example, in order to assert that you want the column “passenger_count” to be between 1 and 6, you can say:
+
+```python title="Python"
+expect_column_values_to_be_between(
+    column="passenger_count",
+    min_value=1,
+    max_value=6
+)
+```
+
+Great Expectations then uses this statement to validate whether the column passenger_count in a given table is indeed between 1 and 6, and returns a success or failure result. The library currently provides several dozen highly expressive built-in Expectations, and allows you to write custom Expectations.
+
+#### Data validation
+
+Once you’ve created your Expectations, Great Expectations can load any batch or several batches of data to validate with your suite of Expectations. Great Expectations tells you whether each Expectation in an Expectation Suite passes or fails, and returns any unexpected values that failed a test, which can significantly speed up debugging data issues!
+
+#### Data Docs
+
+Great Expectations renders Expectations in a clean, human-readable format called Data Docs. These HTML docs contain both your Expectation Suites and your data Validation Results each time validation is run – think of it as a continuously updated data quality report. The following image shows a sample Data Doc:
+
+![Screenshot of Data Docs](/docs/oss/guides/images/datadocs.png)
+
+#### Support for various Data Sources and Store backends
+
+Great Expectations currently supports native execution of Expectations against various Data Sources, such as Pandas dataframes, Spark dataframes, and SQL databases via SQLAlchemy. This means you’re not tied to having your data in a database in order to validate it: You can also run Great Expectations against CSV files or any piece of data you can load into a dataframe.
+
+Great Expectations is highly configurable. It allows you to store all relevant metadata, such as the Expectations and Validation Results in file systems, database backends, as well as cloud storage such as S3 and Google Cloud Storage, by configuring metadata Stores.
+
+### What does Great Expectations NOT do?
+
+Great Expectations is NOT a pipeline execution framework.
+
+Great Expectations integrates seamlessly with DAG execution tools such as [Airflow](https://airflow.apache.org/), [dbt](https://www.getdbt.com/), [Prefect](https://www.prefect.io/), [Dagster](https://github.com/dagster-io/dagster), and [Kedro](https://github.com/quantumblacklabs/kedro). Great Expectations does not execute your pipelines for you, but instead, validation can simply be run as a step in your pipeline.
+
+Great Expectations is NOT a data versioning tool.
+
+Great Expectations does not store data itself. Instead, it deals in metadata about data: Expectations, Validation Results, etc. If you want to bring your data itself under version control, check out tools like: [DVC](https://dvc.org/), [Quilt](https://github.com/quiltdata/quilt), and [lakeFS](https://github.com/treeverse/lakeFS/).
+
+Great Expectations currently works best in a Python environment.
+
+Great Expectations is Python-based. You can invoke it from the command line without using a Python programming environment, but if you’re working in another ecosystem, other tools might be a better choice. If you’re running in a pure R environment, you might consider [assertR](https://github.com/ropensci/assertr)  as an alternative. Within the TensorFlow ecosystem, [TFDV](https://www.tensorflow.org/tfx/guide/tfdv) fulfills a similar function as Great Expectations.
+
+### Community Resources
+
+Great Expectations is committed to supporting and the growing Great Expectations community. It’s not enough to build a great tool. Great Expectations wants to build a great community as well.
+
+Open source doesn’t always have the best reputation for being friendly and welcoming, and that makes us sad. Everyone belongs in open source, and Great Expectations is dedicated to making you feel welcome.
+
+#### Contact Great Expectations
+Join the Great Expectations [public Slack channel](https://greatexpectations.io/slack). Before you post for the first time, review the [Slack Guidelines](https://discourse.greatexpectations.io/t/slack-guidelines/1195).
+
+#### Ask a question
+Slack is good for that, too: [join Slack](https://greatexpectations.io/slack) and read [How to write a good question in Slack](https://github.com/great-expectations/great_expectations/discussions/4951). You can also use [GitHub Discussions](https://github.com/great-expectations/great_expectations/discussions/4951).
+
+#### File a bug report or feature request
+If you have bugfix or feature request, see [upvote an existing issue](https://github.com/great-expectations/great_expectations/issues) or [open a new issue](https://github.com/great-expectations/great_expectations/issues/new).
+
+#### Contribute code or documentation
+To make a contribution to Great Expectations, see [Contribute](../../oss/contributing/contributing_overview.md).
+
+#### Not interested in managing your own configuration or infrastructure? 
+Learn more about Great Expectations Cloud, a fully managed SaaS offering. Sign up for [the weekly cloud workshop](https://greatexpectations.io/cloud)! You’ll get to preview the latest features and participate in the private Alpha program!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/oss.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/oss.md
@@ -6,7 +6,6 @@ hide_table_of_contents: true
 pagination_next: null
 pagination_prev: null
 slug: '/oss/'
-displayed_sidebar: gx_oss
 hide_feedback_survey: true
 ---
 

--- a/docs/docusaurus/versioned_sidebars/version-0.18-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-0.18-sidebars.json
@@ -1,8 +1,8 @@
 {
-  "gx_oss": [
+  "gx_core": [
     {
       "type": "doc",
-      "id": "oss/intro",
+      "id": "core/introduction/introduction",
       "label": "About GX OSS"
     },
     {


### PR DESCRIPTION
## Description
Problems:
- Current version dropdown changes from version 0.18 to 1.0 when someone selects the Gx Core tab because of naming changes in the section and its corresponding sidebar
- When a user is on GX Core tab in version 1.0 and changes the version to 0.18, the highlighting of the tab gets lost

We've decided to rename `gx_oss` sidebar to `core` so it matches the version 1.0 naming convention and keeps highlighting

## Videos
### Before
[Grabación de pantalla desde 28-08-24 15:10:54.webm](https://github.com/user-attachments/assets/ef115b87-7f19-468d-88fe-b8e2361e1b79)

[Grabación de pantalla desde 28-08-24 15:15:37.webm](https://github.com/user-attachments/assets/300b30a6-a226-4526-a9f0-23335f4c9456)

### After
[Grabación de pantalla desde 28-08-24 15:06:18.webm](https://github.com/user-attachments/assets/2912053e-873c-418c-8954-c157cc897195)

[Grabación de pantalla desde 28-08-24 15:16:04.webm](https://github.com/user-attachments/assets/0d92d9de-e68d-4ace-a070-bc443a6fd786)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
