### PR TITLE
[MAINTENANCE] Add metadata to UnexpectedRowsExpectation

### DIFF
--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": true,

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -37,6 +37,11 @@
                 }
             ]
         },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
         "catch_exceptions": {
             "title": "Catch Exceptions",
             "default": false,

--- a/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
+++ b/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
@@ -1,0 +1,130 @@
+{
+    "title": "Custom Expectation with SQL",
+    "description": "This Expectation will fail validation if the query returns one or more rows.  The WHERE clause defines the fail criteria.\n\nUnexpectedRowsExpectations facilitate the execution of SQL or Spark-SQL queries     as the core logic for an Expectation. UnexpectedRowsExpectations must implement     a `_validate(...)` method containing logic for determining whether data returned     by the executed query is successfully validated. One is written by default, but     can be overridden.\n\nA successful validation is one where the unexpected_rows_query returns no rows.\n\nUnexpectedRowsExpectation is a     [Batch Expectation](https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations).\n\nBatchExpectations are one of the most common types of Expectation.\nThey are evaluated for an entire Batch, and answer a semantic question about the Batch itself.\n\nArgs:\n    unexpected_rows_query (str): A SQL or Spark-SQL query to be executed for validation.\n\nReturns:\n    An [ExpectationSuiteValidationResult](https://docs.greatexpectations.io/docs/terms/validation_result)\n\nSupported Datasources:\n    [SQL](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Spark-SQL](https://docs.greatexpectations.io/docs/application_integration_support/)",
+    "type": "object",
+    "properties": {
+        "id": {
+            "title": "Id",
+            "type": "string"
+        },
+        "meta": {
+            "title": "Meta",
+            "type": "object"
+        },
+        "notes": {
+            "title": "Notes",
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "result_format": {
+            "title": "Result Format",
+            "default": "BASIC",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ResultFormat"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "description": {
+            "title": "Description",
+            "default": "A SQL or Spark-SQL query to be executed for validation.",
+            "type": "string"
+        },
+        "catch_exceptions": {
+            "title": "Catch Exceptions",
+            "default": false,
+            "type": "boolean"
+        },
+        "rendered_content": {
+            "title": "Rendered Content",
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
+        },
+        "batch_id": {
+            "title": "Batch Id",
+            "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "title": "Condition Parser",
+            "type": "string"
+        },
+        "unexpected_rows_query": {
+            "title": "Unexpected Rows Query",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "expectation_class": {
+                    "title": "Expectation Class",
+                    "type": "string",
+                    "const": "UnexpectedRowsExpectation"
+                },
+                "expectation_type": {
+                    "title": "Expectation Type",
+                    "type": "string",
+                    "const": "unexpected_rows_expectation"
+                },
+                "domain_type": {
+                    "title": "Domain Type",
+                    "type": "string",
+                    "const": "table",
+                    "description": "Batch"
+                },
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": []
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "This Expectation will fail validation if the query returns one or more rows.  The WHERE clause defines the fail criteria."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "SQL",
+                        "Spark-SQL"
+                    ]
+                }
+            }
+        }
+    },
+    "required": [
+        "unexpected_rows_query"
+    ],
+    "additionalProperties": false,
+    "definitions": {
+        "ResultFormat": {
+            "title": "ResultFormat",
+            "description": "An enumeration.",
+            "enum": [
+                "BOOLEAN_ONLY",
+                "BASIC",
+                "COMPLETE",
+                "SUMMARY"
+            ],
+            "type": "string"
+        }
+    }
+}

--- a/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
+++ b/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
@@ -1,6 +1,6 @@
 {
     "title": "Custom Expectation with SQL",
-    "description": "This Expectation will fail validation if the query returns one or more rows.  The WHERE clause defines the fail criteria.\n\nUnexpectedRowsExpectations facilitate the execution of SQL or Spark-SQL queries     as the core logic for an Expectation. UnexpectedRowsExpectations must implement     a `_validate(...)` method containing logic for determining whether data returned     by the executed query is successfully validated. One is written by default, but     can be overridden.\n\nA successful validation is one where the unexpected_rows_query returns no rows.\n\nUnexpectedRowsExpectation is a     [Batch Expectation](https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations).\n\nBatchExpectations are one of the most common types of Expectation.\nThey are evaluated for an entire Batch, and answer a semantic question about the Batch itself.\n\nArgs:\n    unexpected_rows_query (str): A SQL or Spark-SQL query to be executed for validation.\n\nReturns:\n    An [ExpectationSuiteValidationResult](https://docs.greatexpectations.io/docs/terms/validation_result)\n\nSupported Datasources:\n    [SQL](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Spark-SQL](https://docs.greatexpectations.io/docs/application_integration_support/)",
+    "description": "This Expectation will fail validation if the query returns one or more rows. The WHERE clause defines the fail criteria.\n\nUnexpectedRowsExpectations facilitate the execution of SQL or Spark-SQL queries     as the core logic for an Expectation. UnexpectedRowsExpectations must implement     a `_validate(...)` method containing logic for determining whether data returned     by the executed query is successfully validated. One is written by default, but     can be overridden.\n\nA successful validation is one where the unexpected_rows_query returns no rows.\n\nUnexpectedRowsExpectation is a     [Batch Expectation](https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations).\n\nBatchExpectations are one of the most common types of Expectation.\nThey are evaluated for an entire Batch, and answer a semantic question about the Batch itself.\n\nArgs:\n    unexpected_rows_query (str): A SQL or Spark-SQL query to be executed for validation.\n\nReturns:\n    An [ExpectationSuiteValidationResult](https://docs.greatexpectations.io/docs/terms/validation_result)\n\nSupported Datasources:\n    [PostgreSQL](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Snowflake](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [SQLite](https://docs.greatexpectations.io/docs/application_integration_support/)",
     "type": "object",
     "properties": {
         "id": {
@@ -39,7 +39,7 @@
         },
         "description": {
             "title": "Description",
-            "default": "A SQL or Spark-SQL query to be executed for validation.",
+            "description": "A short description of your Expectation",
             "type": "string"
         },
         "catch_exceptions": {
@@ -97,14 +97,15 @@
                 "short_description": {
                     "title": "Short Description",
                     "type": "string",
-                    "const": "This Expectation will fail validation if the query returns one or more rows.  The WHERE clause defines the fail criteria."
+                    "const": "This Expectation will fail validation if the query returns one or more rows. The WHERE clause defines the fail criteria."
                 },
                 "supported_data_sources": {
                     "title": "Supported Data Sources",
                     "type": "array",
                     "const": [
-                        "SQL",
-                        "Spark-SQL"
+                        "PostgreSQL",
+                        "Snowflake",
+                        "SQLite"
                     ]
                 }
             }

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1635,12 +1635,15 @@ representation."""  # noqa: E501
 
 
 UNEXPECTED_ROWS_EXPECTATION_SHORT_DESCRIPTION = (
-    "This Expectation will fail validation if the query returns one or more rows.  "
+    "This Expectation will fail validation if the query returns one or more rows. "
     "The WHERE clause defines the fail criteria."
 )
 UNEXPECTED_ROWS_QUERY_DESCRIPTION = "A SQL or Spark-SQL query to be executed for validation."
-SUPPORTED_DATA_SOURCES = ["SQL", "Spark-SQL"]
-
+SUPPORTED_DATA_SOURCES = [
+    "PostgreSQL",
+    "Snowflake",
+    "SQLite",
+]
 
 class UnexpectedRowsExpectation(BatchExpectation):
     __doc__ = f"""{UNEXPECTED_ROWS_EXPECTATION_SHORT_DESCRIPTION }
@@ -1668,11 +1671,10 @@ class UnexpectedRowsExpectation(BatchExpectation):
     Supported Datasources:
         [{SUPPORTED_DATA_SOURCES[0]}](https://docs.greatexpectations.io/docs/application_integration_support/)
         [{SUPPORTED_DATA_SOURCES[1]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[2]}](https://docs.greatexpectations.io/docs/application_integration_support/)
     """
 
     unexpected_rows_query: str
-
-    description = UNEXPECTED_ROWS_QUERY_DESCRIPTION
 
     metric_dependencies: ClassVar[Tuple[str, ...]] = ("unexpected_rows_query.table",)
     success_keys: ClassVar[Tuple[str, ...]] = ("unexpected_rows_query",)

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -314,7 +314,9 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     meta: Union[dict, None] = None
     notes: Union[str, List[str], None] = None
     result_format: Union[ResultFormat, dict] = ResultFormat.BASIC
-    description: ClassVar[Union[str, None]] = None
+    description: Union[str, None] = pydantic.Field(
+        default=None, description="A short description of your Expectation"
+    )
 
     catch_exceptions: bool = False
     rendered_content: Optional[List[RenderedAtomicContent]] = None
@@ -1632,19 +1634,45 @@ representation."""  # noqa: E501
         return {"success": success, "result": {"observed_value": metric_value}}
 
 
-class UnexpectedRowsExpectation(BatchExpectation):
-    """
-    UnexpectedRowsExpectations facilitate the execution of SQL or Spark-SQL queries as the core logic for an Expectation.
+UNEXPECTED_ROWS_EXPECTATION_SHORT_DESCRIPTION = (
+    "This Expectation will fail validation if the query returns one or more rows.  "
+    "The WHERE clause defines the fail criteria."
+)
+UNEXPECTED_ROWS_QUERY_DESCRIPTION = "A SQL or Spark-SQL query to be executed for validation."
+SUPPORTED_DATA_SOURCES = ["SQL", "Spark-SQL"]
 
-    UnexpectedRowsExpectations must implement a `_validate(...)` method containing logic for determining whether data returned by the executed query is successfully validated.
-    One is written by default, but can be overridden.
+
+class UnexpectedRowsExpectation(BatchExpectation):
+    __doc__ = f"""{UNEXPECTED_ROWS_EXPECTATION_SHORT_DESCRIPTION }
+
+    UnexpectedRowsExpectations facilitate the execution of SQL or Spark-SQL queries \
+    as the core logic for an Expectation. UnexpectedRowsExpectations must implement \
+    a `_validate(...)` method containing logic for determining whether data returned \
+    by the executed query is successfully validated. One is written by default, but \
+    can be overridden.
+
     A successful validation is one where the unexpected_rows_query returns no rows.
 
+    UnexpectedRowsExpectation is a \
+    [Batch Expectation](https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations).
+
+    BatchExpectations are one of the most common types of Expectation.
+    They are evaluated for an entire Batch, and answer a semantic question about the Batch itself.
+
     Args:
-        unexpected_rows_query (str): A SQL or Spark-SQL query to be executed for validation.
-    """  # noqa: E501
+        unexpected_rows_query (str): {UNEXPECTED_ROWS_QUERY_DESCRIPTION}
+
+    Returns:
+        An [ExpectationSuiteValidationResult](https://docs.greatexpectations.io/docs/terms/validation_result)
+
+    Supported Datasources:
+        [{SUPPORTED_DATA_SOURCES[0]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[1]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+    """
 
     unexpected_rows_query: str
+
+    description = UNEXPECTED_ROWS_QUERY_DESCRIPTION
 
     metric_dependencies: ClassVar[Tuple[str, ...]] = ("unexpected_rows_query.table",)
     success_keys: ClassVar[Tuple[str, ...]] = ("unexpected_rows_query",)
@@ -1653,6 +1681,32 @@ class UnexpectedRowsExpectation(BatchExpectation):
         "row_condition",
         "condition_parser",
     )
+
+    class Config:
+        title = "Custom Expectation with SQL"
+
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], model: Type[UnexpectedRowsExpectation]) -> None:
+            BatchExpectation.Config.schema_extra(schema, model)
+            schema["properties"]["metadata"]["properties"].update(
+                {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": [],
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": UNEXPECTED_ROWS_EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATA_SOURCES,
+                    },
+                }
+            )
 
     @pydantic.validator("unexpected_rows_query")
     def _validate_query(cls, query: str) -> str:

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1645,6 +1645,7 @@ SUPPORTED_DATA_SOURCES = [
     "SQLite",
 ]
 
+
 class UnexpectedRowsExpectation(BatchExpectation):
     __doc__ = f"""{UNEXPECTED_ROWS_EXPECTATION_SHORT_DESCRIPTION }
 

--- a/tasks.py
+++ b/tasks.py
@@ -523,6 +523,7 @@ def type_schema(  # noqa: C901 - too complex
         _iter_all_registered_types,
     )
     from great_expectations.expectations import core
+    from great_expectations.expectations.expectation import UnexpectedRowsExpectation
 
     data_source_schema_dir_root: Final[pathlib.Path] = (
         GX_PACKAGE_DIR / "datasource" / "fluent" / "schemas"
@@ -638,6 +639,7 @@ def type_schema(  # noqa: C901 - too complex
         core.ExpectColumnValuesToNotMatchLikePatternList,
         core.ExpectColumnValuesToNotMatchRegex,
         core.ExpectColumnValuesToNotMatchRegexList,
+        UnexpectedRowsExpectation,
     ]
     for x in supported_expectations:
         schema_path = expectation_dir.joinpath(f"{x.__name__}.json")

--- a/tests/expectations/core/test_core_model_schemas.py
+++ b/tests/expectations/core/test_core_model_schemas.py
@@ -4,14 +4,17 @@ import pytest
 
 from great_expectations.expectations import core
 from great_expectations.expectations.core import schemas
-from great_expectations.expectations.expectation import MetaExpectation
+from great_expectations.expectations.expectation import MetaExpectation, UnexpectedRowsExpectation
+
+expectation_dictionary = dict(core.__dict__)
+expectation_dictionary.update({"UnexpectedRowsExpectation": UnexpectedRowsExpectation})
 
 
 @pytest.mark.unit
 def test_all_core_model_schemas_are_serializable():
     all_models = [
         expectation
-        for expectation in core.__dict__.values()
+        for expectation in expectation_dictionary.values()
         if isinstance(expectation, MetaExpectation)
     ]
     # are they still there?
@@ -24,7 +27,7 @@ def test_all_core_model_schemas_are_serializable():
 def test_schemas_updated():
     all_models = {
         cls_name: expectation
-        for cls_name, expectation in core.__dict__.items()
+        for cls_name, expectation in expectation_dictionary.items()
         if isinstance(expectation, MetaExpectation)
     }
     schema_file_paths = Path(schemas.__file__).parent.glob("*.json")


### PR DESCRIPTION
Adds metadata to the UnexpectedRowsExpectation and updates its docstring to more closely match core Expectations.  Also makes description and instance variable.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
