### PR TITLE
[DOCS] Add pathname to Docs JIRA tickets description

### DIFF
--- a/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
+++ b/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
@@ -3,6 +3,7 @@ const DOCUMENTATION_BOARD_ID = 10019;
 const STORY_ISSUETYPE_ID = 10011;
 const JIRA_ISSUE_ENDPOINT_URL = "https://greatexpectations.atlassian.net/rest/api/2/issue"
 const TO_DO_STATE_ID = 291;
+const DOCS_BASE_URL = "https://docs.greatexpectations.io";
 
 const truncateDescription = (description) => {
     return description.length > TITLE_MAX_CHARACTERS ? description.substring(0, TITLE_MAX_CHARACTERS) + "..." : description;
@@ -10,9 +11,9 @@ const truncateDescription = (description) => {
 
 const formatOptionalValue = (value) => value || '-';
 
-const fullDescription = (description, name, email, selectedValue) => {
+const fullDescription = (description, name, email, selectedValue, pathname) => {
     const formattedSelectedValue = selectedValue.replaceAll("-"," ");
-    return `*Name:* ${formatOptionalValue(name)}\n*Email:* ${formatOptionalValue(email)}\n*Selected feedback type:* ${formattedSelectedValue}\n\n*Description:* ${description}`;
+    return `*Name:* ${formatOptionalValue(name)}\n*Email:* ${formatOptionalValue(email)}\n*Selected feedback type:* ${formattedSelectedValue}\n*URL:* ${DOCS_BASE_URL}${pathname}\n\n*Description:* ${description}`;
 }
 
 const httpPostRequest = async (url, body) => {
@@ -27,7 +28,7 @@ const httpPostRequest = async (url, body) => {
 }
 
 exports.handler = async (req, context) => {
-    const { description, name, email, selectedValue } = JSON.parse(req.body);
+    const { description, name, email, selectedValue, pathname } = JSON.parse(req.body);
     try {
         const response = await httpPostRequest(JIRA_ISSUE_ENDPOINT_URL, {
             "fields": {
@@ -35,7 +36,7 @@ exports.handler = async (req, context) => {
                     "id": DOCUMENTATION_BOARD_ID
                 },
                 "summary": truncateDescription(description),
-                "description": fullDescription(description, name, email, selectedValue),
+                "description": fullDescription(description, name, email, selectedValue, pathname),
                 "issuetype": {
                     "id": STORY_ISSUETYPE_ID
                 },

--- a/docs/docusaurus/src/components/WasThisHelpful/index.js
+++ b/docs/docusaurus/src/components/WasThisHelpful/index.js
@@ -74,7 +74,7 @@ export default function WasThisHelpful(){
                     headers: {
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify(formData)
+                    body: JSON.stringify({...formData, pathname })
                 });
                 if (response.ok) {
                     setIsOpen(false)


### PR DESCRIPTION
## Description
Right now JIRA tickets get created in the Docs Board but there's no info on which specific page the feedback was sent. This PR adds the pathname to the description of the ticket.

## Screenshot
![image](https://github.com/user-attachments/assets/b914fea9-a001-4c04-996a-6001c8634abc)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
