### PR TITLE
[DOCS] Update Get Started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For data sources and other integrations that GX supports, see [GX integration su
 
 ## Get started
 
-GX recommends deploying GX Core within a virtual environment. For more information about getting started with GX Core, see [Get started with Great Expectations](https://docs.greatexpectations.io/docs/oss/tutorials/quickstart).
+GX recommends deploying GX Core within a virtual environment. For more information about getting started with GX Core, see [Get started with Great Expectations](https://docs.greatexpectations.io/docs/core/introduction/try_gx).
 
 1. Run the following command in an empty base directory inside a Python virtual environment to install GX Core:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For data sources and other integrations that GX supports, see [GX integration su
 
 ## Get started
 
-GX recommends deploying GX Core within a virtual environment. For more information about getting started with GX Core, see [Get started with Great Expectations](https://docs.greatexpectations.io/docs/core/introduction/try_gx).
+GX recommends deploying GX Core within a virtual environment. For more information about getting started with GX Core, see [Get started with Great Expectations](https://docs.greatexpectations.io/docs/core/introduction/try_gx/).
 
 1. Run the following command in an empty base directory inside a Python virtual environment to install GX Core:
 


### PR DESCRIPTION
Getting started link was a 404, I believe this is the best substitute.

https://github.com/great-expectations/great_expectations/issues/10321

There was also [Introduction to GX Core](https://docs.greatexpectations.io/docs/core/introduction/) but I thought this picked up the journey in a better location.
The link on contributing in this PR template is also out of date.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`) - *NA*
- [x] Appropriate tests and docs have been updated - *N/A*

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
