### PR TITLE
[BUGFIX] Prevent pydantic type coercion of Value Sets

### DIFF
--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -197,7 +197,7 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION,
     )
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -184,7 +184,7 @@ class ExpectColumnDistinctValuesToContainSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION,
     )
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -184,7 +184,7 @@ class ExpectColumnDistinctValuesToEqualSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION
     )
 

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -170,7 +170,7 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION,
     )
     ties_okay: Union[bool, None] = pydantic.Field(

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -188,7 +188,7 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION
     )
 

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -177,7 +177,7 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION
     )
 

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -72,9 +72,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -72,9 +72,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -72,9 +72,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -72,9 +72,6 @@
             "description": "A list of potential values to match.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -81,9 +81,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -144,6 +141,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -81,9 +81,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -144,6 +141,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_set.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_set.json
@@ -3,6 +3,7 @@
   "datasets" : [{
     "dataset_name": "expect_column_values_to_be_in_set_1",
     "data" : {
+      "w" : ["AK", "HI", "PR"],
       "x" : [1,2,4],
       "y" : [1.1,2.2,5.5],
       "z" : ["hello", "jello", "mello"]
@@ -117,6 +118,17 @@
           "success": false,
           "unexpected_index_list": [{"y": 1.1, "pk_index": 0}, {"y": 2.2, "pk_index": 1}, {"y": 5.5, "pk_index": 2}],
           "unexpected_list": [1.1, 2.2, 5.5]
+        }
+      },
+      {
+        "title": "positive_test_two_character_set",
+        "exact_match_out": false,
+        "in": {
+          "column": "w",
+          "value_set": ["HI", "PR", "AK"]
+        },
+        "out": {
+          "success": true
         }
       },
     {


### PR DESCRIPTION
Pydantic is coercing `value_set = ["HI", "AK"]` into `{"H": "I", "A": "K"}` because pydantic v1 `smart_union` has trouble with `Union` types nested inside of `Optional`.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated