### PR TITLE
[BUGFIX] Prevent pydantic type coercion of Value Sets

### DIFF
--- a/great_expectations_v1/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations_v1/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -197,7 +197,7 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION,
     )
 

--- a/great_expectations_v1/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations_v1/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -184,7 +184,7 @@ class ExpectColumnDistinctValuesToContainSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION,
     )
 

--- a/great_expectations_v1/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations_v1/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -184,7 +184,7 @@ class ExpectColumnDistinctValuesToEqualSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION
     )
 

--- a/great_expectations_v1/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations_v1/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -170,7 +170,7 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnAggregateExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION,
     )
     ties_okay: Union[bool, None] = pydantic.Field(

--- a/great_expectations_v1/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations_v1/expectations/core/expect_column_values_to_be_in_set.py
@@ -188,7 +188,7 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION
     )
 

--- a/great_expectations_v1/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations_v1/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -177,7 +177,7 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    value_set: Optional[Union[SuiteParameterDict, ValueSet]] = pydantic.Field(
+    value_set: Union[Optional[ValueSet], SuiteParameterDict] = pydantic.Field(
         description=VALUE_SET_DESCRIPTION
     )
 

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -72,9 +72,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -72,9 +72,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -72,9 +72,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -72,9 +72,6 @@
             "description": "A list of potential values to match.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -135,6 +132,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -81,9 +81,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -144,6 +141,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },

--- a/great_expectations_v1/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations_v1/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -81,9 +81,6 @@
             "description": "A set of objects used for comparison.",
             "anyOf": [
                 {
-                    "type": "object"
-                },
-                {
                     "title": "Value Set",
                     "description": "A set of objects used for comparison.",
                     "oneOf": [
@@ -144,6 +141,9 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "object"
                 }
             ]
         },


### PR DESCRIPTION
Cherry-pick of https://github.com/great-expectations/great_expectations/pull/10325 for use in Mercury Expectation model validation

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
