### PR TITLE
BUGFIX: dataframe leakage into validation result json

### DIFF
--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -270,6 +270,10 @@ class ValidationDefinition(BaseModel):
             batch_parameters_copy = {k: v for k, v in batch_parameters.items()}
             if "dataframe" in batch_parameters_copy:
                 batch_parameters_copy["dataframe"] = DATAFRAME_INDICATOR
+                results.meta["active_batch_definition"]["batch_identifiers"]["dataframe"] = (
+                    DATAFRAME_INDICATOR
+                )
+
             results.meta["batch_parameters"] = batch_parameters_copy
         else:
             results.meta["batch_parameters"] = None


### PR DESCRIPTION
Proposed fix for data leakage into the validation result JSON when a pandas data source and asset are used and a pandas dataframe is passed to a validation definition through batch_parameters at runtime (e.g. ```batch_parameters = {"dataframe": df_at_runtime}```

The proposed fix follows the same approach that was used to mask the dataframe in the batch_parameters meta section when a dataframe is passed in the batch_parameters.

Linked issue: https://github.com/great-expectations/great_expectations/issues/10327
