### PR TITLE
[BUGFIX] Patch `active_batch_definition` retrieval within `EmailRenderer`

### DIFF
--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -519,7 +519,7 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
     @property
     def asset_name(self) -> str | None:
         if "active_batch_definition" in self.meta:
-            return self.meta["active_batch_definition"].data_asset_name
+            return self.meta["active_batch_definition"].get("data_asset_name")
         return None
 
     def __eq__(self, other):  # type: ignore[explicit-override] # FIXME

--- a/tests/render/conftest.py
+++ b/tests/render/conftest.py
@@ -49,7 +49,15 @@ def v1_checkpoint_result(mocker: pytest_mock.MockFixture):
     result_a = mocker.MagicMock(
         spec=ExpectationSuiteValidationResult,
         suite_name="my_bad_suite",
-        meta={},
+        # Converted LegacyBatchDefinition within V1 Validator
+        meta={
+            "active_batch_definition": {
+                "datasource_name": "my_first_ds",
+                "data_connector_name": "my_first_dc",
+                "data_asset_name": "my_first_asset",
+                "batch_identifiers": {},
+            }
+        },
         statistics={"successful_expectations": 3, "evaluated_expectations": 5},
         batch_id="my_batch",
         success=False,
@@ -58,7 +66,9 @@ def v1_checkpoint_result(mocker: pytest_mock.MockFixture):
     result_b = mocker.MagicMock(
         spec=ExpectationSuiteValidationResult,
         suite_name="my_good_suite",
-        meta={"run_id": "my_run_id"},
+        meta={
+            "run_id": "my_run_id",
+        },
         statistics={"successful_expectations": 1, "evaluated_expectations": 1},
         batch_id="my_other_batch",
         success=True,


### PR DESCRIPTION
Active batch definition is guaranteed to be a dict due to conversion by the V1 validator - we should not be using dot notation here

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
