### PR TITLE
[BUGFIX] Patch issue with data docs page retrieval in checkpoint actions

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -131,7 +131,10 @@ class ValidationAction(BaseModel):
         self, action_context: ActionContext | None
     ) -> list[dict] | None:
         if action_context:
-            return action_context.filter_results(class_=UpdateDataDocsAction)
+            data_docs_results = action_context.filter_results(class_=UpdateDataDocsAction)
+            data_docs_pages = {}
+            for result in data_docs_results:
+                data_docs_pages.update(result)
 
         return None
 
@@ -285,7 +288,9 @@ class SlackNotificationAction(DataDocsAction):
     ) -> list[dict]:
         data_docs_pages = None
         if action_context:
-            data_docs_pages = action_context.filter_results(class_=UpdateDataDocsAction)
+            data_docs_pages = self._get_data_docs_pages_from_prior_action(
+                action_context=action_context
+            )
 
         # Assemble complete GX Cloud URL for a specific validation result
         data_docs_urls: list[dict[str, str]] = self._get_docs_sites_urls(

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -129,12 +129,13 @@ class ValidationAction(BaseModel):
 
     def _get_data_docs_pages_from_prior_action(
         self, action_context: ActionContext | None
-    ) -> list[dict] | None:
+    ) -> dict[ValidationResultIdentifier, dict] | None:
         if action_context:
             data_docs_results = action_context.filter_results(class_=UpdateDataDocsAction)
             data_docs_pages = {}
             for result in data_docs_results:
                 data_docs_pages.update(result)
+            return data_docs_pages
 
         return None
 

--- a/great_expectations/render/renderer/microsoft_teams_renderer.py
+++ b/great_expectations/render/renderer/microsoft_teams_renderer.py
@@ -23,7 +23,9 @@ class MicrosoftTeamsRenderer(Renderer):
     MICROSOFT_TEAMS_SCHEMA_URL = "http://adaptivecards.io/schemas/adaptive-card.json"
 
     @override
-    def render(self, checkpoint_result: CheckpointResult, data_docs_pages: dict | None = None):
+    def render(
+        self, checkpoint_result: CheckpointResult, data_docs_pages: dict | None = None
+    ) -> dict:
         checkpoint_blocks: list[list[dict[str, str]]] = []
         for result_identifier, result in checkpoint_result.run_results.items():
             validation_blocks = self._render_validation_result(

--- a/great_expectations/render/renderer/microsoft_teams_renderer.py
+++ b/great_expectations/render/renderer/microsoft_teams_renderer.py
@@ -23,9 +23,7 @@ class MicrosoftTeamsRenderer(Renderer):
     MICROSOFT_TEAMS_SCHEMA_URL = "http://adaptivecards.io/schemas/adaptive-card.json"
 
     @override
-    def render(
-        self, checkpoint_result: CheckpointResult, data_docs_pages: list[dict] | None = None
-    ):
+    def render(self, checkpoint_result: CheckpointResult, data_docs_pages: dict | None = None):
         checkpoint_blocks: list[list[dict[str, str]]] = []
         for result_identifier, result in checkpoint_result.run_results.items():
             validation_blocks = self._render_validation_result(
@@ -100,9 +98,7 @@ class MicrosoftTeamsRenderer(Renderer):
         check_details_text = f"*{n_checks_succeeded}* of *{n_checks}* expectations were met"
         return self._render_validation_result_element(key="Summary", value=check_details_text)
 
-    def _render_data_docs_links(
-        self, data_docs_pages: list[dict] | None
-    ) -> list[dict[str, str]] | None:
+    def _render_data_docs_links(self, data_docs_pages: dict | None) -> list[dict[str, str]] | None:
         if not data_docs_pages:
             return None
 

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -19,11 +19,11 @@ class SlackRenderer(Renderer):
     def render(
         self,
         validation_result: ExpectationSuiteValidationResult,
-        data_docs_pages: list[dict] | None = None,
+        data_docs_pages: dict | None = None,
         notify_with: list[str] | None = None,
         validation_result_urls: list[str] | None = None,
     ) -> list[dict]:
-        data_docs_pages = data_docs_pages or []
+        data_docs_pages = data_docs_pages or {}
         notify_with = notify_with or []
         validation_result_urls = validation_result_urls or []
         blocks: list[dict] = []
@@ -169,7 +169,7 @@ class SlackRenderer(Renderer):
         return report_element
 
     def _build_report_element_block(
-        self, data_docs_pages: list[dict], notify_with: list[str]
+        self, data_docs_pages: dict, notify_with: list[str]
     ) -> dict | None:
         if not data_docs_pages:
             return None

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+from requests import Session
 
 import great_expectations as gx
 from great_expectations import expectations as gxe
@@ -750,7 +751,10 @@ class TestCheckpointResult:
         }
         assert actual == expected
 
-    def _build_file_backed_checkpoint(self, tmp_path: pathlib.Path) -> Checkpoint:
+    def _build_file_backed_checkpoint(
+        self, tmp_path: pathlib.Path, actions: list[CheckpointAction] | None = None
+    ) -> Checkpoint:
+        actions = actions or []
         with working_directory(tmp_path):
             context = gx.get_context(mode="file")
 
@@ -787,7 +791,11 @@ class TestCheckpointResult:
             )
         )
 
-        return Checkpoint(name=self.checkpoint_name, validation_definitions=[validation_definition])
+        return Checkpoint(
+            name=self.checkpoint_name,
+            validation_definitions=[validation_definition],
+            actions=actions,
+        )
 
     @pytest.mark.unit
     def test_checkpoint_result_does_not_contain_dataframe(self, tmp_path: pathlib.Path):
@@ -920,6 +928,25 @@ class TestCheckpointResult:
         ]
         assert meta["checkpoint_id"] == checkpoint.id
         assert meta["validation_id"] == checkpoint.validation_definitions[0].id
+
+    @pytest.mark.filesystem
+    def test_checkpoint_run_with_data_docs_and_slack_actions_emit_page_links(
+        self, tmp_path: pathlib.Path
+    ):
+        actions = [
+            UpdateDataDocsAction(name="docs_action"),
+            SlackNotificationAction(name="slack_action", slack_webhook="webhook"),
+        ]
+        checkpoint = self._build_file_backed_checkpoint(tmp_path=tmp_path, actions=actions)
+
+        with mock.patch.object(Session, "post") as mock_post:
+            _ = checkpoint.run()
+
+        mock_post.assert_called_once()
+        docs_block = mock_post.call_args.kwargs["json"]["blocks"][3]["text"]["text"]
+        assert "*DataDocs*" in docs_block
+        assert "local_site" in docs_block
+        assert "file:///" in docs_block
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
```
File /local_disk0/.ephemeral_nfs/envs/pythonEnv-7048a166-73a8-4fdf-aa6c-fb34a0b4805e/lib/python3.10/site-packages/great_expectations/render/renderer/microsoft_teams_renderer.py:114, in MicrosoftTeamsRenderer._render_data_docs_links(self, data_docs_pages)
    112 if docs_link_key == "class":
    113     continue
--> 114 docs_link = data_docs_pages[docs_link_key]
    115 report_element = self._get_report_element(docs_link)
    116 elements.append(report_element)

TypeError: list indices must be integers or slices, not ValidationResultIdentifier
```

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
