### PR TITLE
[DOCS] Update Learn data quality use case articles to use <small> tags

### DIFF
--- a/docs/docusaurus/docs/reference/learn/data_quality_use_cases/missingness.md
+++ b/docs/docusaurus/docs/reference/learn/data_quality_use_cases/missingness.md
@@ -39,7 +39,7 @@ Ensures that values within a column are `NULL`.
 ```python title="" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/missingness_resources/missingness_expectations.py ExpectColumnValuesToBeNull"
 ```
 
-<sup>View `ExpectColumnValuesToBeNull` in the [Expectation Gallery](https://greatexpectations.io/expectations/expect_column_values_to_be_null).</sup>
+<small>View `ExpectColumnValuesToBeNull` in the [Expectation Gallery](https://greatexpectations.io/expectations/expect_column_values_to_be_null).</small>
 
 ### Expect Column Values To Not Be Null
 
@@ -50,7 +50,7 @@ Ensures that values within a specific column are not `NULL`.
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/missingness_resources/missing_expectations.py ExpectColumnValuesToNotBeNull"
 ```
 
-<sup>View `ExpectColumnValuesToNotBeNull` in the [Expectation Gallery](https://greatexpectations.io/expectations/expect_column_values_to_not_be_null).</sup>
+<small>View `ExpectColumnValuesToNotBeNull` in the [Expectation Gallery](https://greatexpectations.io/expectations/expect_column_values_to_not_be_null).</small>
 
 <br/>
 <br/>

--- a/docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema.md
+++ b/docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema.md
@@ -62,8 +62,8 @@ compared to the previous Expectation, suitable for scenarios needing strict type
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_expectations.py ExpectColumnValuesToBeOfType"
 ```
 
-<sup>View `ExpectColumnValuesToBeOfType` in the [Expectation
-Gallery](https://greatexpectations.io/expectations/expect_column_values_to_be_of_type).</sup>
+<small>View `ExpectColumnValuesToBeOfType` in the [Expectation
+Gallery](https://greatexpectations.io/expectations/expect_column_values_to_be_of_type).</small>
 
 
 #### Expect Column Values To Be In Type List
@@ -76,8 +76,8 @@ not be strictly enforced, aiding smooth data migration and validation.
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_expectations.py ExpectColumnValuesToBeInTypeList"
 ```
 
-<sup>View `ExpectColumnValuesToBeInTypeList` in the [Expectation
-Gallery](https://greatexpectations.io/expectations/expect_column_values_to_be_in_type_list).</sup>
+<small>View `ExpectColumnValuesToBeInTypeList` in the [Expectation
+Gallery](https://greatexpectations.io/expectations/expect_column_values_to_be_in_type_list).</small>
 
 <br/>
 <br/>
@@ -103,7 +103,7 @@ essential fields are present before proceeding with downstream processing.
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_expectations.py ExpectColumnToExist"
 ```
 
-<sup>View `ExpectColumnToExist` in the [Expectation Gallery](https://greatexpectations.io/expectations/expect_column_to_exist).</sup>
+<small>View `ExpectColumnToExist` in the [Expectation Gallery](https://greatexpectations.io/expectations/expect_column_to_exist).</small>
 
 
 #### Expect Table Column Count To Equal
@@ -116,8 +116,8 @@ fixed schema structure, providing a strong safeguard against unexpected changes.
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_expectations.py ExpectTableColumnCountToEqual"
 ```
 
-<sup>View `ExpectTableColumnCountToEqual` in the [Expectation
-Gallery](https://greatexpectations.io/expectations/expect_table_column_count_to_equal).</sup>
+<small>View `ExpectTableColumnCountToEqual` in the [Expectation
+Gallery](https://greatexpectations.io/expectations/expect_table_column_count_to_equal).</small>
 
 
 #### Expect Table Columns To Match Ordered List
@@ -131,8 +131,8 @@ columns are computed during serialization.
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_expectations.py ExpectTableColumnsToMatchOrderedList"
 ```
 
-<sup>View `ExpectTableColumnsToMatchOrderedList` in the [Expectation
-Gallery](https://greatexpectations.io/expectations/expect_table_columns_to_match_ordered_list).</sup>
+<small>View `ExpectTableColumnsToMatchOrderedList` in the [Expectation
+Gallery](https://greatexpectations.io/expectations/expect_table_columns_to_match_ordered_list).</small>
 
 
 #### Expect Table Columns To Match Set
@@ -145,8 +145,8 @@ flexibility where column presence is more critical than their sequence.
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_expectations.py ExpectTableColumnsToMatchSet"
 ```
 
-<sup>View `ExpectTableColumnsToMatchSet` in the [Expectation
-Gallery](https://greatexpectations.io/expectations/expect_table_columns_to_match_set).</sup>
+<small>View `ExpectTableColumnsToMatchSet` in the [Expectation
+Gallery](https://greatexpectations.io/expectations/expect_table_columns_to_match_set).</small>
 
 
 #### Expect Table Column Count To Be Between
@@ -159,8 +159,8 @@ datasets that can expand or contract within a known boundary.
 ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_expectations.py ExpectTableColumnCountToBeBetween"
 ```
 
-<sup>View `ExpectTableColumnCountToBeBetween` in the [Expectation
-Gallery](https://greatexpectations.io/expectations/expect_table_column_count_to_be_between).</sup>
+<small>View `ExpectTableColumnCountToBeBetween` in the [Expectation
+Gallery](https://greatexpectations.io/expectations/expect_table_column_count_to_be_between).</small>
 
 <br/>
 <br/>


### PR DESCRIPTION
This PR updates the existing data quality Learn articles to correctly use `<small>` text tags instead of `<sup>` (superscript).

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
