### PR TITLE
[DOCS] Hide feedback survey on homepage

### DIFF
--- a/docs/docusaurus/docs/gx_welcome.md
+++ b/docs/docusaurus/docs/gx_welcome.md
@@ -6,6 +6,7 @@ displayed_sidebar: null
 pagination_next: null
 pagination_prev: null
 slug: /home/
+hide_feedback_survey: true
 ---
 
 import LinkCardGrid from '@site/src/components/LinkCardGrid';


### PR DESCRIPTION
Using front matter keyword: **hide_feedback_survey: true** in homepage
![image](https://github.com/user-attachments/assets/e836ede0-2d13-4323-955d-fb16747869bb)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
