### PR TITLE
[FEATURE] BatchDefinition.get_batch_identifiers_list

### DIFF
--- a/great_expectations/core/batch_definition.py
+++ b/great_expectations/core/batch_definition.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, TypeVar
 
 from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import pydantic
@@ -80,6 +80,24 @@ class BatchDefinition(pydantic.GenericModel, Generic[PartitionerT]):
         """
         batch_request = self.build_batch_request(batch_parameters=batch_parameters)
         return self.data_asset.get_batch(batch_request)
+
+    @public_api
+    def get_batch_identifiers_list(
+        self, batch_parameters: Optional[BatchParameters] = None
+    ) -> List[Dict]:
+        """
+        Retrieves a list of available batch identifiers.
+        These identifiers can be used to fetch specific batches via batch_options.
+
+        Args:
+            batch_parameters: Additional parameters to be used in fetching the batch identifiers
+            list.
+
+        Returns:
+            A list of batch identifiers.
+        """
+        batch_request = self.build_batch_request(batch_parameters=batch_parameters)
+        return self.data_asset.get_batch_identifiers_list(batch_request)
 
     def is_fresh(self) -> BatchDefinitionFreshnessDiagnostics:
         diagnostics = self._is_added()

--- a/tests/core/test_batch_definition.py
+++ b/tests/core/test_batch_definition.py
@@ -98,6 +98,47 @@ def test_get_batch_retrieves_only_batch(mocker: pytest_mock.MockFixture):
 
 
 @pytest.mark.unit
+def test_get_batch_identifiers_list(mocker: pytest_mock.MockFixture):
+    # Arrange
+    batch_definition = BatchDefinition[None](name="test_batch_definition")
+    mock_asset = mocker.Mock(spec=DataAsset)
+    batch_definition.set_data_asset(mock_asset)
+
+    mock_batch_identifiers_list = [{"foo": "bar"}, {"baz": "qux"}]
+    mock_asset.get_batch_identifiers_list.return_value = mock_batch_identifiers_list
+
+    # Act
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list()
+
+    # Assert
+    assert batch_identifiers_list == mock_batch_identifiers_list
+    mock_asset.get_batch_identifiers_list.assert_called_once_with(
+        batch_definition.build_batch_request()
+    )
+
+
+@pytest.mark.unit
+def test_get_batch_identifiers_list_with_batch_parameters(mocker: pytest_mock.MockFixture):
+    # Arrange
+    batch_definition = BatchDefinition[None](name="test_batch_definition")
+    mock_asset = mocker.Mock(spec=DataAsset)
+    batch_definition.set_data_asset(mock_asset)
+
+    mock_batch_identifiers_list = [{"foo": "bar"}, {"baz": "qux"}]
+    mock_asset.get_batch_identifiers_list.return_value = mock_batch_identifiers_list
+
+    # Act
+    batch_parameters: BatchParameters = {"path": "my_path"}
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list(batch_parameters)
+
+    # Assert
+    assert batch_identifiers_list == mock_batch_identifiers_list
+    mock_asset.get_batch_identifiers_list.assert_called_once_with(
+        batch_definition.build_batch_request(batch_parameters)
+    )
+
+
+@pytest.mark.unit
 def test_identifier_bundle_success(in_memory_runtime_context):
     context = in_memory_runtime_context
     ds = context.data_sources.add_pandas("pandas_datasource")

--- a/tests/integration/common_workflows/test_filesystem_asset_workflows.py
+++ b/tests/integration/common_workflows/test_filesystem_asset_workflows.py
@@ -291,7 +291,7 @@ def test_get_batch_identifiers_list__no_batches(
         batch_parameters={"year": "1999"}
     )
 
-    assert len(batch_identifiers_list) == 0
+    assert batch_identifiers_list == []
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/common_workflows/test_filesystem_asset_workflows.py
+++ b/tests/integration/common_workflows/test_filesystem_asset_workflows.py
@@ -189,7 +189,7 @@ def _create_test_cases():
     "batch_definition_fixture_name",
     [
         pytest.param("pandas_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
-        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.spark]),
     ],
 )
 def test_get_batch_identifiers_list__simple(
@@ -220,7 +220,7 @@ def test_get_batch_identifiers_list__simple(
             "pandas_filesystem_monthly_batch_definition_descending", marks=[pytest.mark.filesystem]
         ),
         pytest.param(
-            "spark_filesystem_monthly_batch_definition_descending", marks=[pytest.mark.filesystem]
+            "spark_filesystem_monthly_batch_definition_descending", marks=[pytest.mark.spark]
         ),
     ],
 )
@@ -249,7 +249,7 @@ def test_get_batch_identifiers_list__respects_order(
     "batch_definition_fixture_name",
     [
         pytest.param("pandas_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
-        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.spark]),
     ],
 )
 def test_get_batch_identifiers_list__respects_batch_params(
@@ -279,7 +279,7 @@ def test_get_batch_identifiers_list__respects_batch_params(
     "batch_definition_fixture_name",
     [
         pytest.param("pandas_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
-        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.spark]),
     ],
 )
 def test_get_batch_identifiers_list__no_batches(

--- a/tests/integration/common_workflows/test_filesystem_asset_workflows.py
+++ b/tests/integration/common_workflows/test_filesystem_asset_workflows.py
@@ -185,6 +185,79 @@ def _create_test_cases():
     return test_cases
 
 
+def test_get_batch_identifiers_list__simple(
+    spark_filesystem_monthly_batch_definition: BatchDefinition,
+) -> None:
+    batch_definition = spark_filesystem_monthly_batch_definition
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list()
+
+    assert len(batch_identifiers_list) == 36
+    # just spot check the edges
+    assert batch_identifiers_list[0] == {
+        "path": "yellow_tripdata_sample_2018-01.csv",
+        "year": "2018",
+        "month": "01",
+    }
+    assert batch_identifiers_list[-1] == {
+        "path": "yellow_tripdata_sample_2020-12.csv",
+        "year": "2020",
+        "month": "12",
+    }
+
+
+def test_get_batch_identifiers_list__respects_order(
+    spark_filesystem_monthly_batch_definition_descending: BatchDefinition,
+) -> None:
+    batch_definition = spark_filesystem_monthly_batch_definition_descending
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list()
+
+    assert len(batch_identifiers_list) == 36
+    # just spot check the edges
+    assert batch_identifiers_list[0] == {
+        "path": "yellow_tripdata_sample_2020-12.csv",
+        "year": "2020",
+        "month": "12",
+    }
+    assert batch_identifiers_list[-1] == {
+        "path": "yellow_tripdata_sample_2018-01.csv",
+        "year": "2018",
+        "month": "01",
+    }
+
+
+def test_get_batch_identifiers_list__respects_batch_params(
+    spark_filesystem_monthly_batch_definition: BatchDefinition,
+) -> None:
+    batch_definition = spark_filesystem_monthly_batch_definition
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list(
+        batch_parameters={"year": "2020"}
+    )
+
+    assert len(batch_identifiers_list) == 12
+    # just spot check the edges
+    assert batch_identifiers_list[0] == {
+        "path": "yellow_tripdata_sample_2020-01.csv",
+        "year": "2020",
+        "month": "01",
+    }
+    assert batch_identifiers_list[-1] == {
+        "path": "yellow_tripdata_sample_2020-12.csv",
+        "year": "2020",
+        "month": "12",
+    }
+
+
+def test_get_batch_identifiers_list__no_batches(
+    spark_filesystem_monthly_batch_definition: BatchDefinition,
+) -> None:
+    batch_definition = spark_filesystem_monthly_batch_definition
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list(
+        batch_parameters={"year": "1999"}
+    )
+
+    assert len(batch_identifiers_list) == 0
+
+
 @pytest.mark.parametrize(
     ("expectation", "batch_definition_fixture_name", "batch_parameters"),
     _create_test_cases(),

--- a/tests/integration/common_workflows/test_filesystem_asset_workflows.py
+++ b/tests/integration/common_workflows/test_filesystem_asset_workflows.py
@@ -185,10 +185,18 @@ def _create_test_cases():
     return test_cases
 
 
+@pytest.mark.parametrize(
+    "batch_definition_fixture_name",
+    [
+        pytest.param("pandas_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+    ],
+)
 def test_get_batch_identifiers_list__simple(
-    spark_filesystem_monthly_batch_definition: BatchDefinition,
+    batch_definition_fixture_name: str,
+    request: pytest.FixtureRequest,
 ) -> None:
-    batch_definition = spark_filesystem_monthly_batch_definition
+    batch_definition: BatchDefinition = request.getfixturevalue(batch_definition_fixture_name)
     batch_identifiers_list = batch_definition.get_batch_identifiers_list()
 
     assert len(batch_identifiers_list) == 36
@@ -205,10 +213,22 @@ def test_get_batch_identifiers_list__simple(
     }
 
 
+@pytest.mark.parametrize(
+    "batch_definition_fixture_name",
+    [
+        pytest.param(
+            "pandas_filesystem_monthly_batch_definition_descending", marks=[pytest.mark.filesystem]
+        ),
+        pytest.param(
+            "spark_filesystem_monthly_batch_definition_descending", marks=[pytest.mark.filesystem]
+        ),
+    ],
+)
 def test_get_batch_identifiers_list__respects_order(
-    spark_filesystem_monthly_batch_definition_descending: BatchDefinition,
+    batch_definition_fixture_name: str,
+    request: pytest.FixtureRequest,
 ) -> None:
-    batch_definition = spark_filesystem_monthly_batch_definition_descending
+    batch_definition: BatchDefinition = request.getfixturevalue(batch_definition_fixture_name)
     batch_identifiers_list = batch_definition.get_batch_identifiers_list()
 
     assert len(batch_identifiers_list) == 36
@@ -225,10 +245,18 @@ def test_get_batch_identifiers_list__respects_order(
     }
 
 
+@pytest.mark.parametrize(
+    "batch_definition_fixture_name",
+    [
+        pytest.param("pandas_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+    ],
+)
 def test_get_batch_identifiers_list__respects_batch_params(
-    spark_filesystem_monthly_batch_definition: BatchDefinition,
+    batch_definition_fixture_name: str,
+    request: pytest.FixtureRequest,
 ) -> None:
-    batch_definition = spark_filesystem_monthly_batch_definition
+    batch_definition: BatchDefinition = request.getfixturevalue(batch_definition_fixture_name)
     batch_identifiers_list = batch_definition.get_batch_identifiers_list(
         batch_parameters={"year": "2020"}
     )
@@ -247,10 +275,18 @@ def test_get_batch_identifiers_list__respects_batch_params(
     }
 
 
+@pytest.mark.parametrize(
+    "batch_definition_fixture_name",
+    [
+        pytest.param("pandas_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+        pytest.param("spark_filesystem_monthly_batch_definition", marks=[pytest.mark.filesystem]),
+    ],
+)
 def test_get_batch_identifiers_list__no_batches(
-    spark_filesystem_monthly_batch_definition: BatchDefinition,
+    batch_definition_fixture_name: str,
+    request: pytest.FixtureRequest,
 ) -> None:
-    batch_definition = spark_filesystem_monthly_batch_definition
+    batch_definition: BatchDefinition = request.getfixturevalue(batch_definition_fixture_name)
     batch_identifiers_list = batch_definition.get_batch_identifiers_list(
         batch_parameters={"year": "1999"}
     )

--- a/tests/integration/common_workflows/test_sql_asset_workflows.py
+++ b/tests/integration/common_workflows/test_sql_asset_workflows.py
@@ -155,7 +155,7 @@ def test_get_batch_identifiers_list__no_batches(
         batch_parameters={"year": 1900}
     )
 
-    assert len(batch_identifiers_list) == 0
+    assert batch_identifiers_list == []
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/common_workflows/test_sql_asset_workflows.py
+++ b/tests/integration/common_workflows/test_sql_asset_workflows.py
@@ -109,6 +109,55 @@ def _create_test_cases():
     ]
 
 
+def test_get_batch_identifiers_list__simple(
+    postgres_daily_batch_definition: BatchDefinition,
+) -> None:
+    batch_definition = postgres_daily_batch_definition
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list()
+
+    assert len(batch_identifiers_list) == 10
+    # just spot check the edges
+    assert batch_identifiers_list[0] == {"year": None, "month": None, "day": None}
+    assert batch_identifiers_list[-1] == {"year": 2001, "month": 1, "day": 1}
+
+
+def test_get_batch_identifiers_list__respects_order(
+    postgres_daily_batch_definition_descending: BatchDefinition,
+) -> None:
+    batch_definition = postgres_daily_batch_definition_descending
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list()
+
+    assert len(batch_identifiers_list) == 10
+    # just spot check the edges
+    assert batch_identifiers_list[0] == {"year": 2001, "month": 1, "day": 1}
+    assert batch_identifiers_list[-1] == {"year": None, "month": None, "day": None}
+
+
+def test_get_batch_identifiers_list__respects_batch_params(
+    postgres_daily_batch_definition: BatchDefinition,
+) -> None:
+    batch_definition = postgres_daily_batch_definition
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list(
+        batch_parameters={"year": 2000}
+    )
+
+    assert len(batch_identifiers_list) == 6
+    # just spot check the edges
+    assert batch_identifiers_list[0] == {"year": 2000, "month": 1, "day": 1}
+    assert batch_identifiers_list[-1] == {"year": 2000, "month": 6, "day": 1}
+
+
+def test_get_batch_identifiers_list__no_batches(
+    postgres_daily_batch_definition: BatchDefinition,
+) -> None:
+    batch_definition = postgres_daily_batch_definition
+    batch_identifiers_list = batch_definition.get_batch_identifiers_list(
+        batch_parameters={"year": 1900}
+    )
+
+    assert len(batch_identifiers_list) == 0
+
+
 @pytest.mark.parametrize(
     ("expectation", "batch_definition_fixture_name", "batch_parameters"),
     _create_test_cases(),


### PR DESCRIPTION
This method is a follow up to https://github.com/great-expectations/great_expectations/pull/10295. Some users previously used `get_batch_list_from_batch_request` to see the available batches, but that was replaced with private methods. This PR exposes a public method on `BatchDefinition` to get the available batch identifiers list. Unlike the previous method, this will not read in all data, and is more performant.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
