### PR TITLE
[BUGFIX] Fix action equality

### DIFF
--- a/great_expectations/render/renderer/email_renderer.py
+++ b/great_expectations/render/renderer/email_renderer.py
@@ -80,3 +80,7 @@ class EmailRenderer(Renderer):
         else:
             logger.warning("No docs link found. Skipping data docs link in the email message.")
         return report_element
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, EmailRenderer)

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from great_expectations.compatibility.typing_extensions import override
+
 logger = logging.getLogger(__name__)
 
 from great_expectations.render.renderer.renderer import Renderer
@@ -205,3 +207,7 @@ class SlackRenderer(Renderer):
                 return report_element
 
         return None
+
+    @override
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, SlackRenderer)

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -810,6 +810,14 @@ class TestV1ActionRun:
         assert "Successfully posted results" in result["result"]
 
     @pytest.mark.unit
+    def test_UpdateDataDocsAction_equality(self):
+        """I kow, this one seems silly. But this was a bug for other actions."""
+        a = UpdateDataDocsAction(name="my_action")
+        b = UpdateDataDocsAction(name="my_action")
+
+        assert a == b
+
+    @pytest.mark.unit
     def test_UpdateDataDocsAction_run(
         self, mocker: MockerFixture, checkpoint_result: CheckpointResult
     ):

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -380,6 +380,7 @@ class TestV1ActionRun:
             ],
         )
 
+    @pytest.mark.unit
     def test_EmailAction_equality(self):
         """I know, this one seems silly. But this was a bug."""
         a = EmailAction(

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -380,6 +380,23 @@ class TestV1ActionRun:
             ],
         )
 
+    def test_EmailAction_equality(self):
+        """I know, this one seems silly. But this was a bug."""
+        a = EmailAction(
+            name="my_action",
+            smtp_address="test",
+            smtp_port="587",
+            receiver_emails="test@gmail.com",
+        )
+        b = EmailAction(
+            name="my_action",
+            smtp_address="test",
+            smtp_port="587",
+            receiver_emails="test@gmail.com",
+        )
+
+        assert a == b
+
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "emails, expected_email_list",
@@ -610,6 +627,14 @@ class TestV1ActionRun:
         }
 
         mock_pypd_event.assert_not_called()
+
+    @pytest.mark.unit
+    def test_SlackNotificationAction_equality(self):
+        """I kow, this one seems silly. But this was a bug."""
+        a = SlackNotificationAction(name="my_action", slack_webhook="test", notify_on="all")
+        b = SlackNotificationAction(name="my_action", slack_webhook="test", notify_on="all")
+
+        assert a == b
 
     @pytest.mark.unit
     def test_SlackNotificationAction_run(self, checkpoint_result: CheckpointResult):


### PR DESCRIPTION
This bug prevented running checkpoints with slack or email actions because their renderers didn't evaluate to being equal. Note: I'm only addressing the actions we support per https://greatexpectations.atlassian.net/wiki/spaces/DVRL/pages/744849422/Current+state+of+support+and+testing+for+GX+integrations

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
