### PR TITLE
[DOCS] Go back to old search bar design

### DIFF
--- a/docs/docusaurus/src/css/searchBar.scss
+++ b/docs/docusaurus/src/css/searchBar.scss
@@ -1,22 +1,7 @@
+@import "sass_variables.scss";
+
 div .custom-search-bar {
   padding: var(--ifm-navbar-item-padding-vertical) 0;
-
-}
-
-.custom-search-bar .DocSearch-Button {
-  background: none;
-
-  &-Placeholder {
-    display: none;
-  }
-
-  &-Container svg path {
-    stroke-width: 3;
-  }
-
-  &-Keys {
-    display: none;
-  }
 }
 
 [data-theme='dark'] .custom-search-bar .DocSearch-Button:hover {
@@ -25,4 +10,22 @@ div .custom-search-bar {
 
 [data-theme='dark'] .DocSearch-Form {
   background: none;
+}
+
+@media (max-width: $mobile-breakpoint) {
+  .custom-search-bar .DocSearch-Button {
+    background: none;
+
+    &-Placeholder {
+      display: none;
+    }
+
+    &-Container svg path {
+      stroke-width: 3;
+    }
+
+    &-Keys {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
## Description
We discovered that searches have dropped significantly since we merged the change of the search bar design to be more minimalistic so we're reverting the change for desktop screens

## Screenshots


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
