### PR TITLE
[BUGFIX] 0.18.x Ignore unsupported INTERVAL type as part of CDM

### DIFF
--- a/great_expectations/experimental/metric_repository/metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_retriever.py
@@ -137,7 +137,7 @@ class MetricRetriever(abc.ABC):
         Excludes columns that are unsupported or missing type metadata
         """
         columns_to_skip: List[str] = []
-        UNSUPPORTED_COLUMN_TYPES = ["TIME"]
+        UNSUPPORTED_COLUMN_TYPES = ["TIME", "INTERVAL"]
         for column_type in table_column_types.value:
             if not column_type.get("type"):
                 columns_to_skip.append(column_type["name"])


### PR DESCRIPTION
Currently CDM and Schema introspection fails for any Databricks SQL table asset that has an `INTERVAL` column.

This change should prevent the presence of an `INTERVAL` column from breaking CDM for all other columns.

https://docs.databricks.com/en/sql/language-manual/data-types/interval-type.html

- See also #10412 