### PR TITLE
[BUGFIX] Handle DatabricksSQL attribute error and update dependency

### DIFF
--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -68,7 +68,7 @@ except ImportError:
 
 try:
     import databricks.sqlalchemy as sqla_databricks
-except ImportError:
+except (ImportError, AttributeError):
     sqla_databricks = None  # type: ignore[assignment]
 
 _BIGQUERY_MODULE_NAME = "sqlalchemy_bigquery"

--- a/reqs/requirements-dev-databricks.txt
+++ b/reqs/requirements-dev-databricks.txt
@@ -1,2 +1,1 @@
-databricks-sql-connector>=2.0.0; python_version < "3.12"
-databricks-sql-connector[sqlalchemy]>=3.0.0; python_version >= "3.12"
+databricks-sql-connector[sqlalchemy]>=3.0.0


### PR DESCRIPTION
Depending on the version and extra depenencies the `databricks` package may not always have a `.sqlalchemy` sub-module.

This PR handles the potential `AttributeError` and bumps the minimum version of `databricks-sql-connector`