### PR TITLE
[DOCS] Fix typo in overview docs

### DIFF
--- a/docs/docusaurus/docs/cloud/overview/gx_cloud_overview.md
+++ b/docs/docusaurus/docs/cloud/overview/gx_cloud_overview.md
@@ -63,6 +63,6 @@ GX Cloud architecture comprises a frontend web UI, storage for entity configurat
 
 * **GX Cloud data storage**. Stores the configurations for your organization's Data Sources, Data Assets, Expectations, and Validations alongside your organization's Validation Result histories and Data Asset descriptive metrics.
 
-* **GX Cloud backend application**. Contains the necessary logic and compute to connect to data and run queries. The specifics of how the GX Cloud backend connects to your data is described in [GX Cloud deployment pattern](/cloud/deploy/deployment_patterns.md).
+* **GX Cloud backend application**. Contains the necessary logic and compute to connect to data and run queries. The specifics of how the GX Cloud backend connects to your data is described in [GX Cloud deployment patterns](/cloud/deploy/deployment_patterns.md).
 
 * **GX Core Python client**. Enables you to interact programmatically with the GX Cloud backend application. The [GX Core Python client](/core/introduction/introduction.mdx) can complement and extend your web UI-created workflows.

--- a/docs/docusaurus/docs/cloud/overview/gx_cloud_overview.md
+++ b/docs/docusaurus/docs/cloud/overview/gx_cloud_overview.md
@@ -63,6 +63,6 @@ GX Cloud architecture comprises a frontend web UI, storage for entity configurat
 
 * **GX Cloud data storage**. Stores the configurations for your organization's Data Sources, Data Assets, Expectations, and Validations alongside your organization's Validation Result histories and Data Asset descriptive metrics.
 
-* **GX Cloud backend application**. Contains the necessary logic and compute to connect to data and run queries. The specifics of how the GX Cloud backend connects to your data is described in [GX Cloud deployment patterns](/cloud/deploy/deployment_patterns.md).
+* **GX Cloud backend application**. Contains the necessary logic and compute to connect to data and run queries. The specifics of how the GX Cloud backend connects to your data is described in [Deployment patterns](/cloud/deploy/deployment_patterns.md).
 
 * **GX Core Python client**. Enables you to interact programmatically with the GX Cloud backend application. The [GX Core Python client](/core/introduction/introduction.mdx) can complement and extend your web UI-created workflows.


### PR DESCRIPTION
Fix some small typos overlooked in the release of the new GX Cloud Overview & deployment pattern docs.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
