### PR TITLE
[FEATURE] Descriptive error if open_data_docs called with no data docs

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -27,6 +27,7 @@ from typing import (
 
 from marshmallow import ValidationError
 
+import great_expectations as gx
 import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import (
     new_argument,
@@ -1574,17 +1575,20 @@ class AbstractDataContext(ConfigPeer, ABC):
         site_name: Optional[str] = None,
         only_if_exists: bool = True,
     ) -> None:
-        data_docs_urls: List[Dict[str, str]] = self.get_docs_sites_urls(
+        data_docs_urls = self.get_docs_sites_urls(
             resource_identifier=resource_identifier,
             site_name=site_name,
             only_if_exists=only_if_exists,
         )
-        urls_to_open: List[str] = [site["site_url"] for site in data_docs_urls]
+        nullable_urls = [site["site_url"] for site in data_docs_urls]
+        urls_to_open = [url for url in nullable_urls if url is not None]
+
+        if not urls_to_open:
+            raise gx.exceptions.NoDataDocsError
 
         for url in urls_to_open:
-            if url is not None:
-                logger.debug(f"Opening Data Docs found here: {url}")
-                self._open_url_in_browser(url)
+            logger.debug(f"Opening Data Docs found here: {url}")
+            self._open_url_in_browser(url)
 
     @staticmethod
     def _open_url_in_browser(url: str) -> None:
@@ -1599,7 +1603,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         site_name: Optional[str] = None,
         only_if_exists: bool = True,
         site_names: Optional[List[str]] = None,
-    ) -> List[Dict[str, str]]:
+    ) -> List[Dict[str, Optional[str]]]:
         """
         Get URLs for a resource for all data docs sites.
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1650,7 +1650,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             )
             return [{"site_name": site_name, "site_url": url}]
 
-        site_urls = []
+        site_urls: List[Dict[str, Optional[str]]] = []
         for _site_name, site_config in sites.items():
             site_builder = self._load_site_builder_from_site_config(site_config)
             url = site_builder.get_resource_url(

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     Literal,
     Mapping,
+    Optional,
     Type,
     overload,
 )
@@ -134,7 +135,7 @@ class ProjectManager:
         site_name: str | None = None,
         only_if_exists: bool = True,
         site_names: list[str] | None = None,
-    ) -> list[dict[str, str]]:
+    ) -> list[dict[str, Optional[str]]]:
         return self._project.get_docs_sites_urls(
             resource_identifier=resource_identifier,
             site_name=site_name,

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -185,7 +185,7 @@ class StoreBackend(metaclass=ABCMeta):
         # https://docs.python.org/3/library/urllib.parse.html#url-quoting
         return urllib.parse.quote(path)
 
-    def get_url_for_key(self, key, protocol=None) -> None:
+    def get_url_for_key(self, key, protocol=None) -> str:
         raise StoreError(
             "Store backend of type {:s} does not have an implementation of get_url_for_key".format(  # noqa: UP032
                 type(self).__name__

--- a/great_expectations/data_context/store/database_store_backend.py
+++ b/great_expectations/data_context/store/database_store_backend.py
@@ -285,7 +285,8 @@ class DatabaseStoreBackend(StoreBackend):
     def _move(self) -> None:  # type: ignore[override]
         raise NotImplementedError
 
-    def get_url_for_key(self, key):  # type: ignore[explicit-override] # FIXME
+    @override
+    def get_url_for_key(self, key) -> str:
         url = self._convert_engine_and_key_to_url(key)
         return url
 

--- a/great_expectations/data_context/store/database_store_backend.py
+++ b/great_expectations/data_context/store/database_store_backend.py
@@ -286,7 +286,7 @@ class DatabaseStoreBackend(StoreBackend):
         raise NotImplementedError
 
     @override
-    def get_url_for_key(self, key) -> str:
+    def get_url_for_key(self, key, protocol=None) -> str:
         url = self._convert_engine_and_key_to_url(key)
         return url
 

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -467,7 +467,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ) from e
 
     @override
-    def get_url_for_key(  # type: ignore[override]
+    def get_url_for_key(
         self,
         key: Tuple[GXCloudRESTResource, str | None, str | None],
         protocol: Optional[Any] = None,

--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 import tempfile
 from mimetypes import guess_type
+from typing import Optional
 from zipfile import ZipFile, is_zipfile
 
 from great_expectations.core.data_context_key import DataContextKey
@@ -266,7 +267,7 @@ class HtmlSiteStore:
             content_type="text/html; charset=utf-8",
         )
 
-    def get_url_for_resource(self, resource_identifier=None, only_if_exists=True):
+    def get_url_for_resource(self, resource_identifier=None, only_if_exists=True) -> Optional[str]:
         """
         Return the URL of the HTML document that renders a resource
         (e.g., an expectation suite or a validation result).

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -407,7 +407,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
             return True
         return False
 
-    def get_url_for_key(self, key, protocol=None):  # type: ignore[explicit-override] # FIXME
+    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
         path = self._convert_key_to_filepath(key)
         escaped_path = self._url_path_escape_special_characters(path=path)
         full_path = os.path.join(self.full_base_directory, escaped_path)  # noqa: PTH118
@@ -647,7 +647,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
                 key_list.append(key)
         return key_list
 
-    def get_url_for_key(self, key, protocol=None):  # type: ignore[explicit-override] # FIXME
+    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
         location = None
         if self.boto3_options.get("endpoint_url"):
             location = self.boto3_options.get("endpoint_url")
@@ -920,7 +920,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
                 key_list.append(key)
         return key_list
 
-    def get_url_for_key(self, key, protocol=None):  # type: ignore[explicit-override] # FIXME
+    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
         path = self._convert_key_to_filepath(key)
 
         if self._public_urls:
@@ -1123,7 +1123,7 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
             key_list.append(key)
         return key_list
 
-    def get_url_for_key(self, key, protocol=None):  # type: ignore[explicit-override] # FIXME
+    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
         az_blob_key = self._convert_key_to_filepath(key)
         az_blob_path = os.path.join(  # noqa: PTH118
             self.container, self.prefix, az_blob_key

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -407,7 +407,8 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
             return True
         return False
 
-    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
+    @override
+    def get_url_for_key(self, key, protocol=None) -> str:
         path = self._convert_key_to_filepath(key)
         escaped_path = self._url_path_escape_special_characters(path=path)
         full_path = os.path.join(self.full_base_directory, escaped_path)  # noqa: PTH118
@@ -647,7 +648,8 @@ class TupleS3StoreBackend(TupleStoreBackend):
                 key_list.append(key)
         return key_list
 
-    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
+    @override
+    def get_url_for_key(self, key, protocol=None) -> str:
         location = None
         if self.boto3_options.get("endpoint_url"):
             location = self.boto3_options.get("endpoint_url")
@@ -920,7 +922,8 @@ class TupleGCSStoreBackend(TupleStoreBackend):
                 key_list.append(key)
         return key_list
 
-    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
+    @override
+    def get_url_for_key(self, key, protocol=None) -> str:
         path = self._convert_key_to_filepath(key)
 
         if self._public_urls:
@@ -1123,7 +1126,8 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
             key_list.append(key)
         return key_list
 
-    def get_url_for_key(self, key, protocol=None) -> str:  # type: ignore[explicit-override] # FIXME
+    @override
+    def get_url_for_key(self, key, protocol=None) -> str:
         az_blob_key = self._convert_key_to_filepath(key)
         az_blob_path = os.path.join(  # noqa: PTH118
             self.container, self.prefix, az_blob_key

--- a/great_expectations/exceptions/__init__.py
+++ b/great_expectations/exceptions/__init__.py
@@ -46,6 +46,7 @@ from .exceptions import (
     MetricResolutionError,
     MissingConfigVariableError,
     MissingDataContextError,
+    NoDataDocsError,
     PluginClassNotFoundError,
     PluginModuleNotFoundError,
     RenderingError,

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -56,6 +56,14 @@ class ValidationDefinitionError(DataContextError):
     pass
 
 
+class NoDataDocsError(DataContextError):
+    def __init__(self) -> None:
+        super().__init__(
+            "No Data Docs found. Please check that you have run a checkpoint, "
+            "and that the checkpoint has a UpdateDataDocsAction in its actions."
+        )
+
+
 class ValidationDefinitionNotFoundError(ValidationDefinitionError):
     def __init__(self, name: str) -> None:
         super().__init__(

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -322,7 +322,7 @@ class SiteBuilder:
             index_links_dict,
         )
 
-    def get_resource_url(self, resource_identifier=None, only_if_exists=True):
+    def get_resource_url(self, resource_identifier=None, only_if_exists=True) -> Optional[str]:
         """
         Return the URL of the HTML document that renders a resource
         (e.g., an expectation suite or a validation result).

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -1,12 +1,16 @@
 import os
 from unittest import mock
 
+import pandas as pd
 import pytest
 import pytest_mock
 
+import great_expectations as gx
+from great_expectations.checkpoint.actions import UpdateDataDocsAction
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.core.expectation_validation_result import ExpectationSuiteValidationResult
 from great_expectations.data_context import get_context
+from great_expectations.data_context.data_context.abstract_data_context import AbstractDataContext
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
 )
@@ -16,14 +20,71 @@ from great_expectations.data_context.types.resource_identifiers import (
 )
 from great_expectations.exceptions import DataContextError
 
+CHECKPOINT_NAME = "my_checkpoint"
+COLUMN_NAME = "my-column"
+
+
+@pytest.fixture
+def data_context_with_checkpoint(empty_data_context: AbstractDataContext) -> AbstractDataContext:
+    context = empty_data_context
+    bd = (
+        context.data_sources.add_pandas(name="my-ds")
+        .add_dataframe_asset(name="my-asset")
+        .add_batch_definition_whole_dataframe(name="my-bd")
+    )
+    suite = context.suites.add(
+        gx.ExpectationSuite(
+            name="my-suite",
+            expectations=[gx.expectations.ExpectColumnValuesToNotBeNull(column="my-column")],
+        )
+    )
+    vd = context.validation_definitions.add(
+        gx.ValidationDefinition(name="my-validation_def", data=bd, suite=suite)
+    )
+    context.checkpoints.add(gx.Checkpoint(name=CHECKPOINT_NAME, validation_definitions=[vd]))
+    return context
+
 
 @pytest.mark.unit
-@mock.patch("webbrowser.open", return_value=True, side_effect=None)
-def test_open_docs_with_no_site(mock_webbrowser, context_with_no_sites):
-    context = context_with_no_sites
+@mock.patch("webbrowser.open")
+def test_open_docs_with_no_run_checkpoints(
+    mock_webbrowser, empty_data_context: AbstractDataContext
+) -> None:
+    context = empty_data_context
+
+    with pytest.raises(gx.exceptions.NoDataDocsError):
+        context.open_data_docs()
+    assert mock_webbrowser.call_count == 0
+
+
+@pytest.mark.unit
+@mock.patch("webbrowser.open")
+def test_open_data_docs_with_checkpoint_run_with_no_data_docs_action(
+    mock_webbrowser, data_context_with_checkpoint: AbstractDataContext
+):
+    context = data_context_with_checkpoint
+    checkpoint = context.checkpoints.get(CHECKPOINT_NAME)
+    checkpoint.run(batch_parameters={"dataframe": pd.DataFrame({COLUMN_NAME: [1, 2, 3]})})
+
+    with pytest.raises(gx.exceptions.NoDataDocsError):
+        context.open_data_docs()
+    assert mock_webbrowser.call_count == 0
+
+
+@pytest.mark.unit
+@mock.patch("webbrowser.open")
+def test_open_data_docs_with_checkpoint_run_with_data_docs_action(
+    mock_webbrowser, data_context_with_checkpoint: AbstractDataContext
+):
+    context = data_context_with_checkpoint
+    checkpoint = context.checkpoints.get(CHECKPOINT_NAME)
+    checkpoint.actions.append(UpdateDataDocsAction(name="store_result"))
+    checkpoint.save()
+
+    checkpoint.run(batch_parameters={"dataframe": pd.DataFrame({COLUMN_NAME: [1, 2, 3]})})
 
     context.open_data_docs()
-    assert mock_webbrowser.call_count == 0
+    assert mock_webbrowser.call_count == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Specifically raises the new `NoDataDocsError` if we don't have any data docs built.

Also cleans up some signatures of methods that are called by open_data_docs. We had some missing return types, and some return types that lied a bit.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
