### PR TITLE
[MAINTENANCE] ruff `0.5.3` -> `0.6.8`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
         exclude: tests/test_fixtures/database_key_test*|tests/datasource/fluent/test_snowflake_datasource\.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.3"
+    rev: "v0.6.8"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -3,6 +3,6 @@ cookiecutter==2.1.1  # Project templating
 mypy==1.11.2            # Type checker
 pydantic>=1.0        # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
-ruff==0.5.3        # Linting / code style / formatting
+ruff==0.6.8        # Linting / code style / formatting
 twine==3.7.1         # Packaging
 wheel==0.38.1        # Packaging

--- a/docs/docusaurus/docs/components/reference_notebooks/_fluent_datasources_assumed_code_for_guides.ipynb
+++ b/docs/docusaurus/docs/components/reference_notebooks/_fluent_datasources_assumed_code_for_guides.ipynb
@@ -44,6 +44,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -94,7 +95,7 @@
    "outputs": [],
    "source": [
     "### Add specific files to the Datasource as individual Data Assets\n",
-    "csv_file_name_as_regex = \"taxi_data\\.csv\"\n",
+    "csv_file_name_as_regex = r\"taxi_data\\.csv\"\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name_as_regex\n",
     ")"
@@ -111,6 +112,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -161,7 +163,7 @@
    "outputs": [],
    "source": [
     "### Add specific files as individual Data Assets\n",
-    "csv_file_name_as_regex = \"taxi_data\\.csv\"\n",
+    "csv_file_name_as_regex = r\"taxi_data\\.csv\"\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name.as_regex\n",
     ")"
@@ -189,6 +191,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -262,6 +265,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -348,6 +352,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -408,7 +413,7 @@
    "outputs": [],
    "source": [
     "### Add specific files to the Datasource as individual Data Assets\n",
-    "csv_file_name_as_regex = \"taxi_data\\.csv\"\n",
+    "csv_file_name_as_regex = r\"taxi_data\\.csv\"\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name_as_regex\n",
     ")"
@@ -425,6 +430,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -485,7 +491,7 @@
    "outputs": [],
    "source": [
     "### Add specific files to the Datasource as individual Data Assets\n",
-    "csv_file_name_as_regex = \"taxi_data\\.csv\"\n",
+    "csv_file_name_as_regex = r\"taxi_data\\.csv\"\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name_as_regex\n",
     ")"
@@ -502,6 +508,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -556,18 +563,17 @@
    "outputs": [],
    "source": [
     "### Create Datasource\n",
-    "datasource_name=\"MyS3Datasource\"\n",
-    "bucket_path=\"YourBucketPath\"\n",
-    "datasource = context.datasources.add_pandas_s3(name=datasource_name,\n",
-    "                                               bucket=bucket_path)\n",
+    "datasource_name = \"MyS3Datasource\"\n",
+    "bucket_path = \"YourBucketPath\"\n",
+    "datasource = context.datasources.add_pandas_s3(name=datasource_name, bucket=bucket_path)\n",
     "### Optional\n",
     "boto3_options = {\n",
-    "    \"endpoint_url\": \"${S3_ENDPOINT}\", # Uses the S3_ENDPOINT environment variable to determine which endpoint to use.\n",
-    "    \"region_name\": \"<your_aws_region_name>\"\n",
+    "    \"endpoint_url\": \"${S3_ENDPOINT}\",  # Uses the S3_ENDPOINT environment variable to determine which endpoint to use.\n",
+    "    \"region_name\": \"<your_aws_region_name>\",\n",
     "}\n",
-    "datasource = context.datasource.add_pandas_s3(name=datasource_name,\n",
-    "                                             bucket=bucket_path,\n",
-    "                                             boto3_options=boto3_options)"
+    "datasource = context.datasource.add_pandas_s3(\n",
+    "    name=datasource_name, bucket=bucket_path, boto3_options=boto3_options\n",
+    ")"
    ]
   },
   {
@@ -578,7 +584,7 @@
    "outputs": [],
    "source": [
     "### Add specific files to the Datasource as individual Data Assets\n",
-    "csv_file_name_as_regex = \"taxi_data\\.csv\"\n",
+    "csv_file_name_as_regex = r\"taxi_data\\.csv\"\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name_as_regex\n",
     ")"
@@ -595,6 +601,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -649,18 +656,17 @@
    "outputs": [],
    "source": [
     "### Create Datasource\n",
-    "datasource_name=\"MyS3Datasource\"\n",
-    "bucket_path=\"YourBucketPath\"\n",
-    "datasource = context.datasources.add_spark_s3(name=datasource_name,\n",
-    "                                               bucket=bucket_path)\n",
+    "datasource_name = \"MyS3Datasource\"\n",
+    "bucket_path = \"YourBucketPath\"\n",
+    "datasource = context.datasources.add_spark_s3(name=datasource_name, bucket=bucket_path)\n",
     "### Optional  (Do we need this? Should it be taken care of when setting up credentials with the AWS CLI?)\n",
     "boto3_options = {\n",
-    "    \"endpoint_url\": \"${S3_ENDPOINT}\", # Uses the S3_ENDPOINT environment variable to determine which endpoint to use.\n",
-    "    \"region_name\": \"<your_aws_region_name>\"\n",
+    "    \"endpoint_url\": \"${S3_ENDPOINT}\",  # Uses the S3_ENDPOINT environment variable to determine which endpoint to use.\n",
+    "    \"region_name\": \"<your_aws_region_name>\",\n",
     "}\n",
-    "datasource = context.datasource.add_spark_s3(name=datasource_name,\n",
-    "                                             bucket=bucket_path,\n",
-    "                                             boto3_options=boto3_options)"
+    "datasource = context.datasource.add_spark_s3(\n",
+    "    name=datasource_name, bucket=bucket_path, boto3_options=boto3_options\n",
+    ")"
    ]
   },
   {
@@ -671,7 +677,7 @@
    "outputs": [],
    "source": [
     "### Add specific files to the Datasource as individual Data Assets\n",
-    "csv_file_name_as_regex = \"taxi_data\\.csv\"\n",
+    "csv_file_name_as_regex = r\"taxi_data\\.csv\"\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name_as_regex\n",
     ")"
@@ -688,6 +694,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -766,6 +773,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -855,6 +863,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -961,6 +970,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -1219,6 +1229,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -1266,7 +1277,7 @@
    "source": [
     "### Add all files matching a regex to a Datasource as a single Data Asset grouped by year and month\n",
     "all_csv_files_as_month_year_regex = (\n",
-    "    \"yellow_tripdata_sample_(?P<year>\\d{4})-(?P<month>\\d{2}).csv\"\n",
+    "    r\"yellow_tripdata_sample_(?P<year>\\d{4})-(?P<month>\\d{2}).csv\"\n",
     ")\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=all_csv_files_as_month_year_regex\n",
@@ -1283,6 +1294,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
    "metadata": {
     "collapsed": false,
     "pycharm": {

--- a/docs/docusaurus/docs/components/reference_notebooks/_fluent_datasources_assumed_code_for_guides.ipynb
+++ b/docs/docusaurus/docs/components/reference_notebooks/_fluent_datasources_assumed_code_for_guides.ipynb
@@ -566,7 +566,7 @@
     "    \"region_name\": \"<your_aws_region_name>\"\n",
     "}\n",
     "datasource = context.datasource.add_pandas_s3(name=datasource_name,\n",
-    "                                             bucket=bucket_path\n",
+    "                                             bucket=bucket_path,\n",
     "                                             boto3_options=boto3_options)"
    ]
   },
@@ -659,7 +659,7 @@
     "    \"region_name\": \"<your_aws_region_name>\"\n",
     "}\n",
     "datasource = context.datasource.add_spark_s3(name=datasource_name,\n",
-    "                                             bucket=bucket_path\n",
+    "                                             bucket=bucket_path,\n",
     "                                             boto3_options=boto3_options)"
    ]
   },

--- a/docs/docusaurus/docs/components/reference_notebooks/_fluent_datasources_assumed_code_for_guides.ipynb
+++ b/docs/docusaurus/docs/components/reference_notebooks/_fluent_datasources_assumed_code_for_guides.ipynb
@@ -165,7 +165,7 @@
     "### Add specific files as individual Data Assets\n",
     "csv_file_name_as_regex = r\"taxi_data\\.csv\"\n",
     "data_asset = datasource.add_csv_asset(\n",
-    "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name.as_regex\n",
+    "    asset_name=\"MyTaxiDataAsset\", batching_regex=csv_file_name_as_regex\n",
     ")"
    ]
   },

--- a/docs/docusaurus/docs/components/reference_notebooks/_fluent_zero_entry_pool_datasources_03062023_as11.ipynb
+++ b/docs/docusaurus/docs/components/reference_notebooks/_fluent_zero_entry_pool_datasources_03062023_as11.ipynb
@@ -60,7 +60,6 @@
    "outputs": [],
    "source": [
     "import findspark\n",
-    "import pyspark\n",
     "from pyspark.sql import SparkSession\n",
     "\n",
     "findspark.init()"
@@ -2459,7 +2458,7 @@
    "source": [
     "### Add all files matching a regex to a Datasource as a single Data Asset grouped by year and month\n",
     "all_csv_files_as_month_year_regex = (\n",
-    "    \"yellow_tripdata_sample_(?P<year>\\d{4})-(?P<month>\\d{2}).csv\"\n",
+    "    r\"yellow_tripdata_sample_(?P<year>\\d{4})-(?P<month>\\d{2}).csv\"\n",
     ")\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=all_csv_files_as_month_year_regex\n",

--- a/docs/docusaurus/docs/components/reference_notebooks/fluent_zero_entry_pool_datasources_03062023_as11.ipynb
+++ b/docs/docusaurus/docs/components/reference_notebooks/fluent_zero_entry_pool_datasources_03062023_as11.ipynb
@@ -60,7 +60,6 @@
    "outputs": [],
    "source": [
     "import findspark\n",
-    "import pyspark\n",
     "from pyspark.sql import SparkSession\n",
     "\n",
     "findspark.init()"
@@ -2900,7 +2899,7 @@
    "source": [
     "### Add all files matching a regex to a Datasource as a single Data Asset grouped by year and month\n",
     "all_csv_files_as_month_year_regex = (\n",
-    "    \"yellow_tripdata_sample_(?P<year>\\d{4})-(?P<month>\\d{2}).csv\"\n",
+    "    r\"yellow_tripdata_sample_(?P<year>\\d{4})-(?P<month>\\d{2}).csv\"\n",
     ")\n",
     "data_asset = datasource.add_csv_asset(\n",
     "    asset_name=\"MyTaxiDataAsset\", batching_regex=all_csv_files_as_month_year_regex\n",

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -208,7 +208,7 @@ class SphinxInvokeDocsBuilder:
         Returns:
             Content suitable for use in a docusaurus mdx file.
         """
-        from bs4 import (  # noqa: I001
+        from bs4 import (
             BeautifulSoup,
         )  # Importing here since it is not a library requirement
 

--- a/great_expectations/_version.py
+++ b/great_expectations/_version.py
@@ -68,7 +68,7 @@ def register_vcs_handler(vcs, method):  # decorator
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):  # noqa: C901 - too complex
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
 
@@ -97,8 +97,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             print(f"unable to find command, tried {commands}")
         return None, None
     stdout = p.communicate()[0].strip()
-    if sys.version_info[0] >= 3:
-        stdout = stdout.decode()
+    stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:
             print(f"unable to run {dispcmd} (error)")

--- a/great_expectations/_version.py
+++ b/great_expectations/_version.py
@@ -343,12 +343,12 @@ def render_pep440(pieces):
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
-            rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
+            rendered += "%d.g%s" % (pieces["distance"], pieces["short"])  # noqa: UP031
             if pieces["dirty"]:
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])  # noqa: UP031
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -363,10 +363,10 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += ".post.dev%d" % pieces["distance"]
+            rendered += ".post.dev%d" % pieces["distance"]  # noqa: UP031
     else:
         # exception #1
-        rendered = "0.post.dev%d" % pieces["distance"]
+        rendered = "0.post.dev%d" % pieces["distance"]  # noqa: UP031
     return rendered
 
 
@@ -383,14 +383,14 @@ def render_pep440_post(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += ".post%d" % pieces["distance"]
+            rendered += ".post%d" % pieces["distance"]  # noqa: UP031
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
             rendered += f"g{pieces['short']}"
     else:
         # exception #1
-        rendered = "0.post%d" % pieces["distance"]
+        rendered = "0.post%d" % pieces["distance"]  # noqa: UP031
         if pieces["dirty"]:
             rendered += ".dev0"
         rendered += f"+g{pieces['short']}"
@@ -408,12 +408,12 @@ def render_pep440_old(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += ".post%d" % pieces["distance"]
+            rendered += ".post%d" % pieces["distance"]  # noqa: UP031
             if pieces["dirty"]:
                 rendered += ".dev0"
     else:
         # exception #1
-        rendered = "0.post%d" % pieces["distance"]
+        rendered = "0.post%d" % pieces["distance"]  # noqa: UP031
         if pieces["dirty"]:
             rendered += ".dev0"
     return rendered
@@ -430,7 +430,7 @@ def render_git_describe(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+            rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])  # noqa: UP031
     else:
         # exception #1
         rendered = pieces["short"]
@@ -450,7 +450,7 @@ def render_git_describe_long(pieces):
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
-        rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+        rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])  # noqa: UP031
     else:
         # exception #1
         rendered = pieces["short"]

--- a/great_expectations/datasource/fluent/data_asset/path/path_data_asset.py
+++ b/great_expectations/datasource/fluent/data_asset/path/path_data_asset.py
@@ -53,7 +53,7 @@ class PathDataAsset(DataAsset, Generic[DatasourceT, PartitionerT], ABC):
         "batch_metadata",
         "batching_regex",  # file_path argument
         "kwargs",  # kwargs need to be unpacked and passed separately
-        "batch_metadata",  # noqa: PLW0130
+        "batch_metadata",  # noqa: B033
         "connect_options",
         "id",
     }

--- a/great_expectations/datasource/fluent/data_asset/path/path_data_asset.py
+++ b/great_expectations/datasource/fluent/data_asset/path/path_data_asset.py
@@ -53,7 +53,6 @@ class PathDataAsset(DataAsset, Generic[DatasourceT, PartitionerT], ABC):
         "batch_metadata",
         "batching_regex",  # file_path argument
         "kwargs",  # kwargs need to be unpacked and passed separately
-        "batch_metadata",  # noqa: B033
         "connect_options",
         "id",
     }

--- a/great_expectations/execution_engine/partition_and_sample/sqlalchemy_data_sampler.py
+++ b/great_expectations/execution_engine/partition_and_sample/sqlalchemy_data_sampler.py
@@ -69,7 +69,7 @@ class SqlAlchemyDataSampler(DataSampler):
                     compile_kwargs={"literal_binds": True},
                 )
             )
-            query += "\nAND ROWNUM <= %d" % batch_spec["sampling_kwargs"]["n"]
+            query += "\nAND ROWNUM <= %d" % batch_spec["sampling_kwargs"]["n"]  # noqa: UP031
             return query
         elif dialect_name == GXSqlDialect.MSSQL:
             # Note that this code path exists because the limit parameter is not getting rendered

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -385,8 +385,7 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
             return None
         else:
             chart_pixel_width = (len(values) / 60.0) * 500
-            if chart_pixel_width < 250:  # noqa: PLR2004
-                chart_pixel_width = 250
+            chart_pixel_width = max(chart_pixel_width, 250)
             chart_container_col_width = round((len(values) / 60.0) * 6)
             if chart_container_col_width < 4:  # noqa: PLR2004
                 chart_container_col_width = 4

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -902,7 +902,7 @@ class ExpectColumnKLDivergenceToBeLessThan(ColumnAggregateExpectation):
         return return_obj
 
     @classmethod
-    def _get_kl_divergence_chart(  # noqa: PLR0912,C901 - 13
+    def _get_kl_divergence_chart(  # noqa: C901 - 13
         cls, partition_object, header=None
     ):
         weights = partition_object["weights"]
@@ -913,8 +913,7 @@ class ExpectColumnKLDivergenceToBeLessThan(ColumnAggregateExpectation):
             )
         else:
             chart_pixel_width = (len(weights) / 60.0) * 500
-            if chart_pixel_width < 250:  # noqa: PLR2004
-                chart_pixel_width = 250
+            chart_pixel_width = max(chart_pixel_width, 250)
             chart_container_col_width = round((len(weights) / 60.0) * 6)
             if chart_container_col_width < 4:  # noqa: PLR2004
                 chart_container_col_width = 4
@@ -1008,12 +1007,11 @@ class ExpectColumnKLDivergenceToBeLessThan(ColumnAggregateExpectation):
         return expected_distribution
 
     @classmethod
-    def _atomic_kl_divergence_chart_template(cls, partition_object: dict) -> tuple:  # noqa: C901 - too complex
+    def _atomic_kl_divergence_chart_template(cls, partition_object: dict) -> tuple:
         weights = partition_object.get("weights", [])
 
         chart_pixel_width = (len(weights) / 60.0) * 500
-        if chart_pixel_width < 250:  # noqa: PLR2004
-            chart_pixel_width = 250
+        chart_pixel_width = max(chart_pixel_width, 250)
         chart_container_col_width = round((len(weights) / 60.0) * 6)
         if chart_container_col_width < 4:  # noqa: PLR2004
             chart_container_col_width = 4

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -2,5 +2,5 @@ adr-tools-python==1.0.3
 invoke>=2.0.0
 mypy==1.11.2
 pre-commit>=2.21.0
-ruff==0.5.3
+ruff==0.6.8
 tomli>=2.0.1


### PR DESCRIPTION
Ruff linter updates

### Note

This change includes formatting and linting of jupyter (`.ipynb`) files.


https://github.com/astral-sh/ruff/releases/tag/0.6.8
https://github.com/astral-sh/ruff/releases/tag/0.6.7
https://github.com/astral-sh/ruff/releases/tag/0.6.6
https://github.com/astral-sh/ruff/releases/tag/0.6.5
https://github.com/astral-sh/ruff/releases/tag/0.6.4
https://github.com/astral-sh/ruff/releases/tag/0.6.3
https://github.com/astral-sh/ruff/releases/tag/0.6.2
https://github.com/astral-sh/ruff/releases/tag/0.6.1
https://github.com/astral-sh/ruff/releases/tag/0.6.0