### PR TITLE
[BUGFIX] Ensure that Cloud-backed validation results get IDs

### DIFF
--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -317,6 +317,7 @@ class ValidationDefinition(BaseModel):
         )
 
         if isinstance(ref, GXCloudResourceRef):
+            results.id = ref.id
             results.result_url = self._validation_results_store.parse_result_url_from_gx_cloud_ref(
                 ref
             )

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -318,6 +318,7 @@ class ValidationDefinition(BaseModel):
 
         if isinstance(ref, GXCloudResourceRef):
             results.id = ref.id
+            # FIXME(cdkini): There is currently a bug in GX Cloud where the result_url is None
             results.result_url = self._validation_results_store.parse_result_url_from_gx_cloud_ref(
                 ref
             )

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -419,7 +419,7 @@ class TestValidationRun:
         return_value=GXCloudResourceRef(
             resource_type="validation_result",
             id="59b72ca5-4636-44be-a367-46b54ae51fe1",
-            url="https://api.greatexpectations.io/validation_result/59b72ca5-4636-44be-a367-46b54ae51fe1",
+            url="https://api.greatexpectations.io/api/v1/organizations/11111111-ba69-4295-8fe1-61eef96f12b4/validation-results",
             response_json={"data": {"result_url": "my_result_url"}},
         ),
     )

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -31,6 +31,7 @@ from great_expectations.data_context.data_context.ephemeral_data_context import 
     EphemeralDataContext,
 )
 from great_expectations.data_context.store.validation_results_store import ValidationResultsStore
+from great_expectations.data_context.types.refs import GXCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import (
     GXCloudIdentifier,
     ValidationResultIdentifier,
@@ -388,7 +389,16 @@ class TestValidationRun:
         assert key.batch_identifier == BATCH_ID
         assert value.success is True
 
-    @mock.patch.object(ValidationResultsStore, "set")
+    @mock.patch.object(
+        ValidationResultsStore,
+        "set",
+        return_value=GXCloudResourceRef(
+            resource_type="validation_result",
+            id="59b72ca5-4636-44be-a367-46b54ae51fe1",
+            url="url",
+            response_json={"data": {"result_url": "url"}},
+        ),
+    )
     @pytest.mark.unit
     def test_persists_validation_results_for_cloud(
         self,
@@ -403,7 +413,8 @@ class TestValidationRun:
             ExpectationValidationResult(success=True, expectation_config=expectation.configuration)
         ]
 
-        cloud_validation_definition.run()
+        result = cloud_validation_definition.run()
+        assert result.id == "59b72ca5-4636-44be-a367-46b54ae51fe1"
 
         # validate we are calling set on the store with data that's roughly the right shape
         [(_, kwargs)] = mock_validation_results_store_set.call_args_list


### PR DESCRIPTION
Validation results generated by Cloud should get their IDs as generated by the backend

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
