### PR TITLE
[DOCS] Replace terms.json urls in v0.18

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.18/reference/learn/term_tags/terms.json
+++ b/docs/docusaurus/versioned_docs/version-0.18/reference/learn/term_tags/terms.json
@@ -2,171 +2,171 @@
   "batch": {
     "term": "Batch",
     "definition": "A selection of records from a Data Asset.",
-    "url": "/docs/reference/learn/terms/batch"
+    "url": "/docs/0.18/reference/learn/terms/batch"
   },
   "batch_request": {
     "term": "Batch Request",
     "definition": "Provided to a Data Source in order to create a Batch.",
-    "url": "/docs/reference/learn/terms/batch_request"
+    "url": "/docs/0.18/reference/learn/terms/batch_request"
   },
   "catalog_asset": {
     "term": "Catalog Asset",
     "definition": "A collection of records within a Data Source which is usually named based on the underlying data system and sliced in different ways to correspond to multiple desired specifications.",
-    "url": "/docs/reference/learn/terms/catalog_asset"
+    "url": "/docs/0.18/reference/learn/terms/catalog_asset"
   },
   "checkpoint": {
     "term": "Checkpoint",
     "definition": "The primary means for validating data in a production deployment of Great Expectations.",
-    "url": "/docs/reference/learn/terms/checkpoint"
+    "url": "/docs/0.18/reference/learn/terms/checkpoint"
   },
   "checkpoint_store": {
     "term": "Checkpoint Store",
     "definition": "A connector to store and retrieve information about means for validating data in a production deployment of Great Expectations.",
-    "url": "/docs/reference/learn/terms/checkpoint_store"
+    "url": "/docs/0.18/reference/learn/terms/checkpoint_store"
   },
   "custom_expectation": {
     "term": "Custom Expectation",
     "definition": "An extension of the `Expectation` class, developed outside of the Great Expectations library.",
-    "url": "/docs/reference/learn/terms/custom_expectation"
+    "url": "/docs/0.18/reference/learn/terms/custom_expectation"
   },
   "data_asset": {
     "term": "Data Asset",
     "definition": "A collection of records within a Data Source which is usually named based on the underlying data system and sliced to correspond to a desired specification.",
-    "url": "/docs/reference/learn/terms/data_asset"
+    "url": "/docs/0.18/reference/learn/terms/data_asset"
   },
   "data_assistant": {
     "term": "Data Assistant",
     "definition": "A utility that asks questions about your data, gathering information to describe what is observed, and then presents Metrics and proposes Expectations based on the answers.",
-    "url": "/docs/reference/learn/terms/data_assistant"
+    "url": "/docs/0.18/reference/learn/terms/data_assistant"
   },
   "data_connector": {
     "term": "Data Connector",
     "definition": "Provides the configuration details a Data Source needs to define Data Assets.",
-    "url": "/docs/reference/learn/terms/data_connector"
+    "url": "/docs/0.18/reference/learn/terms/data_connector"
   },
   "data_context": {
     "term": "Data Context",
     "definition": "The primary entry point for a Great Expectations deployment, with configurations and methods for all supporting components.",
-    "url": "/docs/reference/learn/terms/data_context"
+    "url": "/docs/0.18/reference/learn/terms/data_context"
   },
   "data_docs": {
     "term": "Data Docs",
     "definition": "Human readable documentation generated from Great Expectations metadata detailing Expectations, Validation Results, etc.",
-    "url": "/docs/reference/learn/terms/data_docs"
+    "url": "/docs/0.18/reference/learn/terms/data_docs"
   },
   "data_docs_store": {
     "term": "Data Docs Store",
     "definition": "A connector to store and retrieve information pertaining to Human readable documentation generated from Great Expectations metadata detailing Expectations, Validation Results, etc.",
-    "url": "/docs/reference/learn/terms/data_docs_store"
+    "url": "/docs/0.18/reference/learn/terms/data_docs_store"
   },
   "datasource": {
     "term": "Data Source",
     "definition": "Provides a standard API for accessing and interacting with data from a wide variety of source systems.",
-    "url": "/docs/reference/learn/terms/datasource"
+    "url": "/docs/0.18/reference/learn/terms/datasource"
   },
   "evaluation_parameter": {
     "term": "Evaluation Parameter",
     "definition": "A dynamic value used during Validation of an Expectation which is populated by evaluating simple expressions or by referencing previously generated metrics.",
-    "url": "/docs/reference/learn/terms/evaluation_parameter"
+    "url": "/docs/0.18/reference/learn/terms/evaluation_parameter"
   },
   "evaluation_parameter_store": {
     "term": "Evaluation Parameter Store",
     "definition": "A connector to store and retrieve information about parameters used during Validation of an Expectation which reference simple expressions or previously generated metrics.",
-    "url": "/docs/reference/learn/terms/evaluation_parameter_store"
+    "url": "/docs/0.18/reference/learn/terms/evaluation_parameter_store"
   },
   "execution_engine": {
     "term": "Execution Engine",
     "definition": "A system capable of processing data to compute Metrics.",
-    "url": "/docs/reference/learn/terms/execution_engine"
+    "url": "/docs/0.18/reference/learn/terms/execution_engine"
   },
   "expectation": {
     "term": "Expectation",
     "definition": "A verifiable assertion about data.",
-    "url": "/docs/reference/learn/terms/expectation"
+    "url": "/docs/0.18/reference/learn/terms/expectation"
   },
   "expectation_suite": {
     "term": "Expectation Suite",
     "definition": "A collection of verifiable assertions about data.",
-    "url": "/docs/reference/learn/terms/expectation_suite"
+    "url": "/docs/0.18/reference/learn/terms/expectation_suite"
   },
   "expectation_store": {
     "term": "Expectation Store",
     "definition": "A connector to store and retrieve information about collections of verifiable assertions about data.",
-    "url": "/docs/reference/learn/terms/expectation_store"
+    "url": "/docs/0.18/reference/learn/terms/expectation_store"
   },
   "metric": {
     "term": "Metric",
     "definition": "A computed attribute of data such as the mean of a column.",
-    "url": "/docs/reference/learn/terms/metric"
+    "url": "/docs/0.18/reference/learn/terms/metric"
   },
   "metric_store": {
     "term": "Metric Store",
     "definition": "A connector to store and retrieve information about computed attributes of data, such as the mean of a column.",
-    "url": "/docs/reference/learn/terms/metric_store"
+    "url": "/docs/0.18/reference/learn/terms/metric_store"
   },
   "profiler": {
     "term": "Profiler",
     "definition": "Generates Metrics and candidate Expectations from data.",
-    "url": "/docs/reference/learn/terms/profiler"
+    "url": "/docs/0.18/reference/learn/terms/profiler"
   },
   "profile": {
     "term": "Profile",
     "definition": "The act of generating Metrics and candidate Expectations from data.",
-    "url": "/docs/reference/learn/terms/profiler"
+    "url": "/docs/0.18/reference/learn/terms/profiler"
   },
   "profiling": {
     "term": "Profiling",
     "definition": "The act of generating Metrics and candidate Expectations from data.",
-    "url": "/docs/reference/learn/terms/profiler"
+    "url": "/docs/0.18/reference/learn/terms/profiler"
   },
   "renderer": {
     "term": "Renderer",
     "definition": "A method for converting Expectations, Validation Results, etc. into Data Docs or other output such as email notifications or slack messages.",
-    "url": "/docs/reference/learn/terms/renderer"
+    "url": "/docs/0.18/reference/learn/terms/renderer"
   },
   "store": {
     "term": "Store",
     "definition": "A connector to store and retrieve information about metadata in Great Expectations.",
-    "url": "/docs/reference/learn/terms/store"
+    "url": "/docs/0.18/reference/learn/terms/store"
   },
   "supporting_resource": {
     "term": "Supporting Resource",
     "definition": "A resource external to the Great Expectations code base which Great Expectations utilizes.",
-    "url": "/docs/reference/learn/terms/supporting_resource"
+    "url": "/docs/0.18/reference/learn/terms/supporting_resource"
   },
   "validation": {
     "term": "Validation",
     "definition": "The act of applying an Expectation Suite to a Batch.",
-    "url": "/docs/oss/guides/validation/validate_data_overview"
+    "url": "/docs/0.18/oss/guides/validation/validate_data_overview"
   },
   "validate": {
     "term": "Validate",
     "definition": "The act of applying an Expectation Suite to a Batch.",
-    "url": "/docs/oss/guides/validation/validate_data_overview"
+    "url": "/docs/0.18/oss/guides/validation/validate_data_overview"
   },
   "action": {
     "term": "Action",
     "definition": "A Python class with a run method that takes a Validation Result and does something with it",
-    "url": "/docs/reference/learn/terms/action"
+    "url": "/docs/0.18/reference/learn/terms/action"
   },
   "validation_result": {
     "term": "Validation Result",
     "definition": "Generated when data is Validated against an Expectation or Expectation Suite.",
-    "url": "/docs/reference/learn/terms/validation_result"
+    "url": "/docs/0.18/reference/learn/terms/validation_result"
   },
   "validation_result_store": {
     "term": "Validation Result Store",
     "definition": "A connector to store and retrieve information about objects generated when data is Validated against an Expectation Suite.",
-    "url": "/docs/reference/learn/terms/validation_result_store"
+    "url": "/docs/0.18/reference/learn/terms/validation_result_store"
   },
   "validator": {
     "term": "Validator",
     "definition": "Used to run an Expectation Suite against data.",
-    "url": "/docs/reference/learn/terms/validator"
+    "url": "/docs/0.18/reference/learn/terms/validator"
   },
   "plugin": {
     "term": "Plugin",
     "definition": "Extends Great Expectations' components and/or functionality.",
-    "url": "/docs/reference/learn/terms/plugin"
+    "url": "/docs/0.18/reference/learn/terms/plugin"
   }
 }


### PR DESCRIPTION
[Shown example in Deploy Preview](https://deploy-preview-10479.docs.greatexpectations.io/docs/0.18/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/instantiate_data_context/)

[Jira Ticket](https://greatexpectations.atlassian.net/jira/software/c/projects/DSB/boards/79?assignee=712020%3A309fac2a-9c8e-412d-aa31-c2bbd94510b0&assignee=5b3bc63c7954ee2e97ae760a&selectedIssue=DSB-1158)

# Description 

In version 0.18, the "Learn" tab has a dropdown Glossary (in version 1.0, the glossary is only a markdown file). 
The different Glossary pages in v0.18 are generated by the terms.json file, which was left outdated when we added a new version since its links were broken (the url should be /docs/0.18/reference/learn/terms/... instead of /docs/reference/learn/terms/...)
 
This fixes some 404 captured by the Algolia crawler such as: 

### Broken example 

[broken_terms_v18.webm](https://github.com/user-attachments/assets/103601cd-a073-4c53-ba4e-b7fad5b4ab4d)

### Fixed example

[fixed_terms_v18.webm](https://github.com/user-attachments/assets/ba133b92-f98b-4a6b-af41-2dd1fdeea899)



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
