### PR TITLE
[TEST PR PLZ IGNORE] sample test framework

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,11 +1,18 @@
 import enum
+import random
+import string
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Mapping
-from typing import Any, Callable, Optional, TypeVar
+from functools import cached_property
+from typing import Callable, Optional, TypeVar
 
+import pandas as pd
 import pytest
 
+import great_expectations as gx
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.data_context.data_context.abstract_data_context import AbstractDataContext
+from great_expectations.datasource.fluent.interfaces import Batch
 
 F = TypeVar("F", bound=Callable)
 
@@ -16,7 +23,7 @@ class DataSourceType(str, enum.Enum):
 
 
 def parameterize_batch_for_data_sources(
-    types: list[DataSourceType], data: list[int], description: Optional[str] = None
+    types: list[DataSourceType], data: pd.DataFrame, description: Optional[str] = None
 ) -> Callable[[F], F]:
     """Test decorator that parametrizes a test function with batches for various data sources.
 
@@ -53,7 +60,7 @@ def parameterize_batch_for_data_sources(
 
 
 @pytest.fixture
-def batch_for_datasource(request: pytest.FixtureRequest) -> Generator[Any, None, None]:
+def batch_for_datasource(request: pytest.FixtureRequest) -> Generator[Batch, None, None]:
     """Fixture that yields a batch for a specific data source type.
 
     This must be used in conjunction with `indirect=True` to defer execution
@@ -82,8 +89,7 @@ class BatchSetup(ABC):
         self.data = data
 
     @abstractmethod
-    def make_batch(self) -> list:  # TODO: return Batch
-        ...
+    def make_batch(self) -> Batch: ...
 
     @abstractmethod
     def setup(self) -> None: ...
@@ -93,10 +99,19 @@ class BatchSetup(ABC):
         pass
 
 
+_foo_cache: dict[int, pd.DataFrame] = {}
+
+
 class FooBatchSetup(BatchSetup):
     @override
-    def make_batch(self) -> list:
-        return [*self.data, 3]
+    def make_batch(self) -> Batch:
+        name = _random_resource_name()
+        return (
+            self._context.data_sources.add_pandas(name)
+            .add_dataframe_asset(name)
+            .add_batch_definition_whole_dataframe(name)
+            .get_batch(batch_parameters={"dataframe": self.data})
+        )
 
     @override
     def setup(self) -> None: ...
@@ -104,11 +119,15 @@ class FooBatchSetup(BatchSetup):
     @override
     def teardown(self) -> None: ...
 
+    @cached_property
+    def _context(self) -> AbstractDataContext:
+        return gx.get_context(mode="ephemeral")
+
 
 class BarBatchSetup(BatchSetup):
     @override
-    def make_batch(self) -> list:
-        return [*self.data, 3, 4]
+    def make_batch(self) -> Batch:
+        raise NotImplementedError
 
     @override
     def setup(self) -> None: ...
@@ -121,3 +140,7 @@ data_source_to_batch_setup: Mapping[DataSourceType, type[BatchSetup]] = {
     DataSourceType.FOO: FooBatchSetup,
     DataSourceType.BAR: BarBatchSetup,
 }
+
+
+def _random_resource_name() -> str:
+    return "".join(random.choices(string.ascii_lowercase, k=10))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,103 @@
+import enum
+from abc import ABC, abstractmethod
+from collections.abc import Generator, Mapping
+from typing import Any, Callable, Optional, TypeVar
+
+import pytest
+
+from great_expectations.compatibility.typing_extensions import override
+
+F = TypeVar("F", bound=Callable)
+
+
+class DataSourceType(str, enum.Enum):
+    FOO = "foo"
+    BAR = "bar"
+
+
+def parameterize_batch_for_data_sources(
+    types: list[DataSourceType], data: list[int], description: Optional[str] = None
+) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        pytest_params = [
+            pytest.param(
+                (data, t),
+                id=f"{description}-{t.value}" if description else t,
+                marks=[_data_source_type_to_mark(t)],
+            )
+            for t in types
+        ]
+        parameterize_decorator = pytest.mark.parametrize(
+            batch_for_datasource.__name__,
+            pytest_params,
+            indirect=True,
+        )
+        return parameterize_decorator(func)
+
+    return decorator
+
+
+@pytest.fixture
+def batch_for_datasource(request: pytest.FixtureRequest) -> Generator[Any, None, None]:
+    data, data_source_type = request.param
+    batch_setup_cls = data_source_to_batch_setup[data_source_type]
+    batch_setup = batch_setup_cls(data)
+
+    batch_setup.setup()
+    yield batch_setup.make_batch()
+    batch_setup.teardown()
+
+
+def _data_source_type_to_mark(type: DataSourceType) -> pytest.MarkDecorator:
+    if type in {DataSourceType.FOO}:
+        return pytest.mark.unit
+    elif type in {DataSourceType.BAR}:
+        return pytest.mark.cloud
+    else:
+        assert False
+
+
+class BatchSetup(ABC):
+    def __init__(self, data: list) -> None:
+        self.data = data
+
+    @abstractmethod
+    def make_batch(self) -> list:  # TODO: return Batch
+        ...
+
+    @abstractmethod
+    def setup(self) -> None: ...
+
+    @abstractmethod
+    def teardown(self) -> None:
+        pass
+
+
+class FooBatchSetup(BatchSetup):
+    @override
+    def make_batch(self) -> list:
+        return [*self.data, 3]
+
+    @override
+    def setup(self) -> None: ...
+
+    @override
+    def teardown(self) -> None: ...
+
+
+class BarBatchSetup(BatchSetup):
+    @override
+    def make_batch(self) -> list:
+        return [*self.data, 3, 4]
+
+    @override
+    def setup(self) -> None: ...
+
+    @override
+    def teardown(self) -> None: ...
+
+
+data_source_to_batch_setup: Mapping[DataSourceType, type[BatchSetup]] = {
+    DataSourceType.FOO: FooBatchSetup,
+    DataSourceType.BAR: BarBatchSetup,
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,21 @@ class DataSourceType(str, enum.Enum):
 def parameterize_batch_for_data_sources(
     types: list[DataSourceType], data: list[int], description: Optional[str] = None
 ) -> Callable[[F], F]:
+    """Test decorator that parametrizes a test function with batches for various data sources.
+
+    This injects a `batch_for_datasource` parameter into the test function for each data source
+    type.
+
+    example use:
+        @parameterize_batch_for_data_sources(
+            types=[DataSourceType.FOO, DataSourceType.BAR],
+            data=[1, 2],
+            # description="test_stuff",
+        )
+        def test_stuff(batch_for_datasource) -> None:
+            ...
+    """
+
     def decorator(func: F) -> F:
         pytest_params = [
             pytest.param(
@@ -39,6 +54,10 @@ def parameterize_batch_for_data_sources(
 
 @pytest.fixture
 def batch_for_datasource(request: pytest.FixtureRequest) -> Generator[Any, None, None]:
+    """Fixture that yields a batch for a specific data source type.
+
+    This must be used in conjunction with `indirect=True` to defer execution
+    """
     data, data_source_type = request.param
     batch_setup_cls = data_source_to_batch_setup[data_source_type]
     batch_setup = batch_setup_cls(data)
@@ -49,6 +68,7 @@ def batch_for_datasource(request: pytest.FixtureRequest) -> Generator[Any, None,
 
 
 def _data_source_type_to_mark(type: DataSourceType) -> pytest.MarkDecorator:
+    """Get the appropriate mark for a data source type."""
     if type in {DataSourceType.FOO}:
         return pytest.mark.unit
     elif type in {DataSourceType.BAR}:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,12 @@
-import enum
+from __future__ import annotations
+
 import random
 import string
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Mapping
+from dataclasses import dataclass
 from functools import cached_property
-from typing import Callable, Optional, TypeVar
+from typing import Any, Callable, Generic, Optional, Sequence, TypeVar
 
 import pandas as pd
 import pytest
@@ -14,17 +16,14 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.data_context.data_context.abstract_data_context import AbstractDataContext
 from great_expectations.datasource.fluent.interfaces import Batch
 
-F = TypeVar("F", bound=Callable)
-
-
-class DataSourceType(str, enum.Enum):
-    FOO = "foo"
-    BAR = "bar"
+_F = TypeVar("_F", bound=Callable)
 
 
 def parameterize_batch_for_data_sources(
-    types: list[DataSourceType], data: pd.DataFrame, description: Optional[str] = None
-) -> Callable[[F], F]:
+    data_source_configs: Sequence[DataSourceConfig],
+    data: pd.DataFrame,
+    description: Optional[str] = None,
+) -> Callable[[_F], _F]:
     """Test decorator that parametrizes a test function with batches for various data sources.
 
     This injects a `batch_for_datasource` parameter into the test function for each data source
@@ -32,7 +31,7 @@ def parameterize_batch_for_data_sources(
 
     example use:
         @parameterize_batch_for_data_sources(
-            types=[DataSourceType.FOO, DataSourceType.BAR],
+            data_source_configs=[DataSourceType.FOO, DataSourceType.BAR],
             data=[1, 2],
             # description="test_stuff",
         )
@@ -40,14 +39,14 @@ def parameterize_batch_for_data_sources(
             ...
     """
 
-    def decorator(func: F) -> F:
+    def decorator(func: _F) -> _F:
         pytest_params = [
             pytest.param(
                 (data, t),
-                id=f"{description}-{t.value}" if description else t,
-                marks=[_data_source_type_to_mark(t)],
+                id=t.get_test_id(description),
+                marks=[_data_source_config_to_mark(t)],
             )
-            for t in types
+            for t in data_source_configs
         ]
         parameterize_decorator = pytest.mark.parametrize(
             batch_for_datasource.__name__,
@@ -65,27 +64,111 @@ def batch_for_datasource(request: pytest.FixtureRequest) -> Generator[Batch, Non
 
     This must be used in conjunction with `indirect=True` to defer execution
     """
-    data, data_source_type = request.param
-    batch_setup_cls = data_source_to_batch_setup[data_source_type]
-    batch_setup = batch_setup_cls(data)
+    data, data_source_config = request.param
+    assert isinstance(data, pd.DataFrame)
+    assert isinstance(data_source_config, DataSourceConfig)
+
+    batch_setup = data_source_config.create_batch_setup(data)
 
     batch_setup.setup()
     yield batch_setup.make_batch()
     batch_setup.teardown()
 
 
-def _data_source_type_to_mark(type: DataSourceType) -> pytest.MarkDecorator:
+def _data_source_config_to_mark(data_source_config: DataSourceConfig) -> pytest.MarkDecorator:
     """Get the appropriate mark for a data source type."""
-    if type in {DataSourceType.FOO}:
+    if isinstance(data_source_config, PandasDataFrameDatasource):
         return pytest.mark.unit
-    elif type in {DataSourceType.BAR}:
-        return pytest.mark.cloud
+    elif isinstance(data_source_config, PandasFilesystemDatasource):
+        return pytest.mark.filesystem
+    elif isinstance(data_source_config, PostgresDataSource):
+        return pytest.mark.postgresql
+    elif isinstance(data_source_config, SnowflakeDataSource):
+        return pytest.mark.snowflake
     else:
         assert False
 
 
-class BatchSetup(ABC):
-    def __init__(self, data: list) -> None:
+# === DataSource config section ===
+@dataclass(frozen=True)
+class DataSourceConfig(ABC):
+    name: str | None = None
+
+    @property
+    @abstractmethod
+    def label(self) -> str:
+        """Label that will show up in test name."""
+        ...
+
+    @abstractmethod
+    def create_batch_setup(self, data: list) -> BatchSetup:
+        """Create a batch setup object for this data source."""
+
+    def get_test_id(self, test_description: str | None) -> str:
+        parts: list[Optional[str]] = [test_description, self.label, self.name]
+        non_null_parts = [p for p in parts if p is not None]
+
+        return "-".join(non_null_parts)
+
+
+@dataclass(frozen=True)
+class _SqlDataSourceConfig(DataSourceConfig):
+    columns: Mapping[str, Any] | None = None  # TODO: obvs lock down the value type here
+
+
+class PandasDataFrameDatasource(DataSourceConfig):
+    @property
+    @override
+    def label(self) -> str:
+        return "PandasDataFrameDatasource"
+
+    @override
+    def create_batch_setup(self, data: list) -> BatchSetup:
+        return PandasDataFrameBatchSetup(data=data, config=self)
+
+
+class PandasFilesystemDatasource(DataSourceConfig):
+    @property
+    @override
+    def label(self) -> str:
+        return "PandasFilesystemDatasource"
+
+    @override
+    def create_batch_setup(self, data: list) -> BatchSetup:
+        return NotImplemented
+
+
+class PostgresDataSource(_SqlDataSourceConfig):
+    @property
+    @override
+    def label(self) -> str:
+        return "PostgresDatasource"
+
+    @override
+    def create_batch_setup(self, data: list) -> BatchSetup:
+        return PostgresBatchSetup(data=data, config=self)
+
+
+class SnowflakeDataSource(_SqlDataSourceConfig):
+    @property
+    @override
+    def label(self) -> str:
+        return "SnowflakeDatasource"
+
+    @override
+    def create_batch_setup(self, data: list) -> BatchSetup:
+        return NotImplemented
+
+
+# === Batch Setup Classes section ===
+_ConfigT = TypeVar("_ConfigT", bound=DataSourceConfig)
+
+
+class BatchSetup(ABC, Generic[_ConfigT]):
+    """ABC for classes that set up and tear down batches."""
+
+    def __init__(self, config: _ConfigT, data: list) -> None:
+        self.config = config
         self.data = data
 
     @abstractmethod
@@ -98,14 +181,18 @@ class BatchSetup(ABC):
     def teardown(self) -> None:
         pass
 
+    @staticmethod
+    def _random_resource_name() -> str:
+        return "".join(random.choices(string.ascii_lowercase, k=10))
+
 
 _foo_cache: dict[int, pd.DataFrame] = {}
 
 
-class FooBatchSetup(BatchSetup):
+class PandasDataFrameBatchSetup(BatchSetup[PandasDataFrameDatasource]):
     @override
     def make_batch(self) -> Batch:
-        name = _random_resource_name()
+        name = self._random_resource_name()
         return (
             self._context.data_sources.add_pandas(name)
             .add_dataframe_asset(name)
@@ -124,9 +211,15 @@ class FooBatchSetup(BatchSetup):
         return gx.get_context(mode="ephemeral")
 
 
-class BarBatchSetup(BatchSetup):
+class PostgresBatchSetup(BatchSetup[PostgresDataSource]):
     @override
     def make_batch(self) -> Batch:
+        explicit_column_types = self.config.columns  # noqa: F841
+        inferred_column_types = self._inferred_column_types  # noqa: F841
+
+        # *waves hands* set schema based on ^
+        # *waves hands* load data
+
         raise NotImplementedError
 
     @override
@@ -135,12 +228,7 @@ class BarBatchSetup(BatchSetup):
     @override
     def teardown(self) -> None: ...
 
-
-data_source_to_batch_setup: Mapping[DataSourceType, type[BatchSetup]] = {
-    DataSourceType.FOO: FooBatchSetup,
-    DataSourceType.BAR: BarBatchSetup,
-}
-
-
-def _random_resource_name() -> str:
-    return "".join(random.choices(string.ascii_lowercase, k=10))
+    @property
+    def _inferred_column_types(self) -> Mapping[str, Any]:
+        # *waves hands* infers column types from data
+        return {}

--- a/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
@@ -1,16 +1,10 @@
-import pytest
-
 from tests.integration.conftest import DataSourceType, parameterize_batch_for_data_sources
 
 
-@pytest.mark.parametrize("even_more", [pytest.param("a", id="a"), pytest.param("b", id="b")])
 @parameterize_batch_for_data_sources(
     types=[DataSourceType.FOO, DataSourceType.BAR],
     data=[1, 2],
     # description="test_stuff",
 )
-@pytest.mark.parametrize("more", [pytest.param(1, id="one"), pytest.param(2, id="two")])
-def test_stuff(batch_for_datasource, more, even_more) -> None:
-    assert batch_for_datasource == [1, 2, 3]
-    assert more in (1, 2)
-    assert even_more in ("a, b")
+def test_stuff(batch_for_datasource) -> None:
+    assert batch_for_datasource == [1, 2, 3]  # this would actually be a Batch object

--- a/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
@@ -1,0 +1,16 @@
+import pytest
+
+from tests.integration.conftest import DataSourceType, parameterize_batch_for_data_sources
+
+
+@pytest.mark.parametrize("even_more", [pytest.param("a", id="a"), pytest.param("b", id="b")])
+@parameterize_batch_for_data_sources(
+    types=[DataSourceType.FOO, DataSourceType.BAR],
+    data=[1, 2],
+    # description="test_stuff",
+)
+@pytest.mark.parametrize("more", [pytest.param(1, id="one"), pytest.param(2, id="two")])
+def test_stuff(batch_for_datasource, more, even_more) -> None:
+    assert batch_for_datasource == [1, 2, 3]
+    assert more in (1, 2)
+    assert even_more in ("a, b")

--- a/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
@@ -1,22 +1,37 @@
 import pandas as pd
+import sqlalchemy as sa
 
-from great_expectations.datasource.fluent.interfaces import Batch
-from tests.integration.conftest import DataSourceType, parameterize_batch_for_data_sources
+import great_expectations.expectations as gxe
+from tests.integration.conftest import (
+    PandasDataFrameDatasource,
+    PostgresDataSource,
+    parameterize_batch_for_data_sources,
+)
 
 
 @parameterize_batch_for_data_sources(
-    types=[DataSourceType.FOO, DataSourceType.BAR],
-    data=pd.DataFrame([[1, 2]]),
-    # description="test_stuff",
+    data_source_configs=[
+        PostgresDataSource(),
+        PandasDataFrameDatasource(),
+    ],
+    data=pd.DataFrame({"a": [1, 2]}),
 )
-def test_stuff(batch_for_datasource) -> None:
-    assert isinstance(batch_for_datasource, Batch)
+def test_min(batch_for_datasource) -> None:
+    expectation = gxe.ExpectColumnMinToBeBetween(column="a", min_value=1, max_value=1)
+    result = batch_for_datasource.validate(expectation)
+    assert result.success
 
 
 @parameterize_batch_for_data_sources(
-    types=[DataSourceType.FOO, DataSourceType.BAR],
-    data=pd.DataFrame([[1, 2]]),
-    # description="test_stuff",
+    data_source_configs=[
+        PostgresDataSource(name="int", columns={"a": sa.INTEGER()}),
+        PostgresDataSource(name="float", columns={"a": sa.FLOAT()}),
+        PandasDataFrameDatasource(),
+    ],
+    data=pd.DataFrame({"a": [1, 2], "b": [3, 4]}),
+    description="max",
 )
-def test_more_stuff(batch_for_datasource) -> None:
-    assert isinstance(batch_for_datasource, Batch)
+def test_max(batch_for_datasource) -> None:
+    expectation = gxe.ExpectColumnMaxToBeBetween(column="a", min_value=2, max_value=2)
+    result = batch_for_datasource.validate(expectation)
+    assert result.success

--- a/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
@@ -1,10 +1,22 @@
+import pandas as pd
+
+from great_expectations.datasource.fluent.interfaces import Batch
 from tests.integration.conftest import DataSourceType, parameterize_batch_for_data_sources
 
 
 @parameterize_batch_for_data_sources(
     types=[DataSourceType.FOO, DataSourceType.BAR],
-    data=[1, 2],
+    data=pd.DataFrame([[1, 2]]),
     # description="test_stuff",
 )
 def test_stuff(batch_for_datasource) -> None:
-    assert batch_for_datasource == [1, 2, 3]  # this would actually be a Batch object
+    assert isinstance(batch_for_datasource, Batch)
+
+
+@parameterize_batch_for_data_sources(
+    types=[DataSourceType.FOO, DataSourceType.BAR],
+    data=pd.DataFrame([[1, 2]]),
+    # description="test_stuff",
+)
+def test_more_stuff(batch_for_datasource) -> None:
+    assert isinstance(batch_for_datasource, Batch)


### PR DESCRIPTION
This is intended to show how we can instrument the tests for CORE-436. I would recommend starting by looking at the new tests themselves, rather than the conftest.py stuff.

### About the tests
We want as little magic here as we can. Unfortunately, we were stuck with either having to create our own decorator, or use `request.getfixturevalue`, and the former seems more ergonomic. A few things to note in the test:
* `batch_for_datasource` is magically injected by `parameterize_batch_for_data_sources`. (sorry!)
* In some cases, we likely want to just let the tooling figure out the schema for our SQL types, but in other cases, we may want to be explicit on types (time vs datetime, etc), so we're allowing users to optionally specify the types, as shown in the second test
* Thinking about it now, I'm not sure we need the optional `description` param on `batch_for_datasource`.

### About the "framework" or whatever
The interface is hopefully clear from the sample tests, but here are the high level details on the various concepts:
* `BatchSetup`: these classes are responsible for setting up and tearing down data. They return batches in this example, but we could just as easily return checkpoints, validation definitions, dataclasses holding all of them, etc. I think batches are the simplest thing if we really are after testing expectations against datasources, as opposed to testing that e.g. checkpoints work
* `DataSourceConfig`: these classes are the public interface to be used by tests. They should be minimal, and for now essentially do 3 things:
  * Determine the pytest mark
  * Determine the label to show up when the test is run
  * Instantiate the `BatchSetup`
Ce could probably merge the 2 classes, or have a helper derive a `BatchSetup` from the `DataSourceConfig` - I don't have strong opinions here, but it seemed like a reasonable structure 


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
