### PR TITLE
[MAINTENANCE] Patch `ge_releaser` installation pattern in released-related GH Actions

### DIFF
--- a/.github/workflows/ge_releaser-prep.yml
+++ b/.github/workflows/ge_releaser-prep.yml
@@ -16,7 +16,9 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
+      - name: Clone ge_releaser
+        run: git clone https://github.com/greatexpectationslabs/ge_releaser/ ..
       - name: Install ge_releaser
-        run: pip install git+https://github.com/greatexpectationslabs/ge_releaser/
+        run: pip install ../ge_releaser/
       - name: Run command
         run: ge_releaser prep

--- a/.github/workflows/ge_releaser-publish.yml
+++ b/.github/workflows/ge_releaser-publish.yml
@@ -16,7 +16,9 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
+      - name: Clone ge_releaser
+        run: git clone https://github.com/greatexpectationslabs/ge_releaser/ ..
       - name: Install ge_releaser
-        run: pip install git+https://github.com/greatexpectationslabs/ge_releaser/
+        run: pip install ../ge_releaser/
       - name: Run command
         run: ge_releaser publish

--- a/.github/workflows/ge_releaser-tag.yml
+++ b/.github/workflows/ge_releaser-tag.yml
@@ -27,7 +27,9 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
+      - name: Clone ge_releaser
+        run: git clone https://github.com/greatexpectationslabs/ge_releaser/ ..
       - name: Install ge_releaser
-        run: pip install git+https://github.com/greatexpectationslabs/ge_releaser/
+        run: pip install ../ge_releaser/
       - name: Run command
         run: ge_releaser tag ${{ github.event.inputs.hash }} ${{ github.event.inputs.version }} --stable


### PR DESCRIPTION
Need to local install - specifically putting it one directory up because `ge_releaser` doesn't like unstaged files in the repo root

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
