### PR TITLE
[DOCS] Add `public_api` decorators to object factories

### DIFF
--- a/great_expectations/core/factory/checkpoint_factory.py
+++ b/great_expectations/core/factory/checkpoint_factory.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 
 
+@public_api
 class CheckpointFactory(Factory[Checkpoint]):
     def __init__(self, store: CheckpointStore):
         self._store = store

--- a/great_expectations/core/factory/suite_factory.py
+++ b/great_expectations/core/factory/suite_factory.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from great_expectations.data_context.store import ExpectationsStore
 
 
+@public_api
 class SuiteFactory(Factory[ExpectationSuite]):
     def __init__(self, store: ExpectationsStore):
         self._store = store

--- a/great_expectations/core/factory/validation_definition_factory.py
+++ b/great_expectations/core/factory/validation_definition_factory.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     )
 
 
+@public_api
 class ValidationDefinitionFactory(Factory[ValidationDefinition]):
     def __init__(self, store: ValidationDefinitionStore) -> None:
         self._store = store

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -426,6 +426,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     def datasource_store(self) -> DatasourceStore:
         return self._datasource_store
 
+    @public_api
     @property
     def suites(self) -> SuiteFactory:
         if not self._suites:

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -426,8 +426,8 @@ class AbstractDataContext(ConfigPeer, ABC):
     def datasource_store(self) -> DatasourceStore:
         return self._datasource_store
 
-    @public_api
     @property
+    @public_api
     def suites(self) -> SuiteFactory:
         if not self._suites:
             raise gx_exceptions.DataContextError(  # noqa: TRY003

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -436,6 +436,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         return self._suites
 
     @property
+    @public_api
     def checkpoints(self) -> CheckpointFactory:
         if not self._checkpoints:
             raise gx_exceptions.DataContextError(  # noqa: TRY003
@@ -444,6 +445,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         return self._checkpoints
 
     @property
+    @public_api
     def validation_definitions(self) -> ValidationDefinitionFactory:
         if not self._validation_definitions:
             raise gx_exceptions.DataContextError(  # noqa: TRY003


### PR DESCRIPTION
Please build docs locally and confirm that this updates the public API.
<img width="395" alt="Screenshot 2024-10-11 at 11 55 23 AM" src="https://github.com/user-attachments/assets/fe6f4386-01e1-4b91-9922-64ee25865df3">
<img width="800" alt="Screenshot 2024-10-11 at 11 55 43 AM" src="https://github.com/user-attachments/assets/3aa9c180-5108-4964-a1c7-97855ffe0fc1">
<img width="783" alt="Screenshot 2024-10-11 at 11 56 12 AM" src="https://github.com/user-attachments/assets/8082e876-95c2-45e6-b443-8e657492d2ec">


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
