### PR TITLE
[BUGFIX] Remove `row_condition` from Expectations for which it does not apply

### DIFF
--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -172,7 +172,6 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    condition_parser: Union[str, None] = "pandas"
     threshold: Union[float, SuiteParameterDict] = pydantic.Field(description=THRESHOLD_DESCRIPTION)
     double_sided: Union[bool, SuiteParameterDict] = pydantic.Field(
         description=DOUBLE_SIDED_DESCRIPTION

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -205,7 +205,6 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    condition_parser: Union[str, None] = "pandas"
     type_list: Union[List[str], SuiteParameterDict, None] = pydantic.Field(
         description=TYPE_LIST_DESCRIPTION
     )

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -170,7 +170,6 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
                 }}
     """  # noqa: E501
 
-    condition_parser: Union[None, str] = "pandas"
     domain_keys: ClassVar[Tuple[str, ...]] = (
         "column",
         "row_condition",

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -12,6 +12,7 @@ from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
 )
+from great_expectations.expectations.model_field_types import ConditionParser  # noqa: TCH001
 from great_expectations.render import LegacyRendererType, RenderedStringTemplateContent
 from great_expectations.render.renderer.renderer import renderer
 from great_expectations.render.renderer_configuration import (
@@ -161,7 +162,7 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
         default=None, description=MAX_VALUE_DESCRIPTION
     )
     row_condition: Union[str, None] = None
-    condition_parser: Union[str, None] = None
+    condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -160,6 +160,8 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
     max_value: Union[int, SuiteParameterDict, datetime, None] = pydantic.Field(
         default=None, description=MAX_VALUE_DESCRIPTION
     )
+    row_condition: Union[str, None] = None
+    condition_parser: Union[str, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -11,6 +11,7 @@ from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
 )
+from great_expectations.expectations.model_field_types import ConditionParser  # noqa: TCH001
 from great_expectations.render import LegacyRendererType, RenderedStringTemplateContent
 from great_expectations.render.renderer.renderer import renderer
 from great_expectations.render.renderer_configuration import (
@@ -140,7 +141,7 @@ class ExpectTableRowCountToEqual(BatchExpectation):
 
     value: Union[int, SuiteParameterDict] = pydantic.Field(description=VALUE_DESCRIPTION)
     row_condition: Union[str, None] = None
-    condition_parser: Union[str, None] = None
+    condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -139,6 +139,8 @@ class ExpectTableRowCountToEqual(BatchExpectation):
     """  # noqa: E501
 
     value: Union[int, SuiteParameterDict] = pydantic.Field(description=VALUE_DESCRIPTION)
+    row_condition: Union[str, None] = None
+    condition_parser: Union[str, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -147,6 +147,8 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
     """  # noqa: E501
 
     other_table_name: str = pydantic.Field(description=OTHER_TABLE_NAME_DESCRIPTION)
+    row_condition: Union[str, None] = None
+    condition_parser: Union[str, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -9,6 +9,7 @@ from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
 )
+from great_expectations.expectations.model_field_types import ConditionParser  # noqa: TCH001
 from great_expectations.render import (
     LegacyDiagnosticRendererType,
     LegacyRendererType,
@@ -148,7 +149,7 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
 
     other_table_name: str = pydantic.Field(description=OTHER_TABLE_NAME_DESCRIPTION)
     row_condition: Union[str, None] = None
-    condition_parser: Union[str, None] = None
+    condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
         "maturity": "production",

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value_set": {
             "title": "Value Set",
@@ -281,6 +280,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value_set": {
             "title": "Value Set",
@@ -281,6 +280,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value_set": {
             "title": "Value Set",
@@ -281,6 +280,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "partition_object": {
             "title": "Partition Object",
@@ -283,6 +282,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -262,6 +261,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -262,6 +261,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -262,6 +261,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -262,6 +261,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value_set": {
             "title": "Value Set",
@@ -286,6 +285,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_A": {
             "title": "Column A",
             "description": "The first column name.",
@@ -94,6 +86,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "or_equal": {
             "title": "Or Equal",
@@ -241,6 +240,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_A": {
             "title": "Column A",
             "description": "The first column name.",
@@ -94,6 +86,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "ignore_row_if": {
             "title": "Ignore Row If",
@@ -237,6 +236,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_A": {
             "title": "Column A",
             "description": "The first column name.",
@@ -94,6 +86,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value_pairs_set": {
             "title": "Value Pairs Set",
@@ -250,6 +249,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -279,6 +278,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "quantile_ranges": {
             "title": "Quantile Ranges",
@@ -231,6 +230,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         },
         "QuantileRange": {
             "title": "QuantileRange",

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -262,6 +261,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -261,6 +260,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -66,19 +66,18 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
             "minLength": 1,
             "type": "string"
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -279,6 +278,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -263,6 +262,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value": {
             "title": "Value",
@@ -232,6 +231,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -86,9 +86,7 @@
             "type": "string"
         },
         "condition_parser": {
-            "title": "Condition Parser",
-            "default": "pandas",
-            "type": "string"
+            "$ref": "#/definitions/ConditionParser"
         },
         "threshold": {
             "title": "Threshold",
@@ -246,6 +244,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -66,15 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "default": "pandas",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -89,6 +80,15 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "title": "Condition Parser",
+            "default": "pandas",
+            "type": "string"
         },
         "threshold": {
             "title": "Threshold",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "min_value": {
             "title": "Min Value",
@@ -270,6 +269,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value_set": {
             "title": "Value Set",
@@ -290,6 +289,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -66,15 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "default": "pandas",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -89,6 +80,15 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "title": "Condition Parser",
+            "default": "pandas",
+            "type": "string"
         },
         "type_list": {
             "title": "Type List",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -86,9 +86,7 @@
             "type": "string"
         },
         "condition_parser": {
-            "title": "Condition Parser",
-            "default": "pandas",
-            "type": "string"
+            "$ref": "#/definitions/ConditionParser"
         },
         "type_list": {
             "title": "Type List",
@@ -235,6 +233,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -66,15 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "default": "pandas",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -89,6 +80,15 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "title": "Condition Parser",
+            "default": "pandas",
+            "type": "string"
         },
         "metadata": {
             "type": "object",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -86,9 +86,7 @@
             "type": "string"
         },
         "condition_parser": {
-            "title": "Condition Parser",
-            "default": "pandas",
-            "type": "string"
+            "$ref": "#/definitions/ConditionParser"
         },
         "metadata": {
             "type": "object",
@@ -220,6 +218,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "type_": {
             "title": "Type ",
@@ -225,6 +224,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "metadata": {
             "type": "object",
@@ -218,6 +217,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "like_pattern": {
             "title": "Like Pattern",
@@ -228,6 +227,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "like_pattern_list": {
             "title": "Like Pattern List",
@@ -241,6 +240,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "regex": {
             "title": "Regex",
@@ -228,6 +227,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "regex_list": {
             "title": "Regex List",
@@ -241,6 +240,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "value_set": {
             "title": "Value Set",
@@ -290,6 +289,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "metadata": {
             "type": "object",
@@ -219,6 +218,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "like_pattern": {
             "title": "Like Pattern",
@@ -228,6 +227,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "like_pattern_list": {
             "title": "Like Pattern List",
@@ -231,6 +230,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "regex": {
             "title": "Regex",
@@ -228,6 +227,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column": {
             "title": "Column",
             "description": "The column name.",
@@ -88,6 +80,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "regex_list": {
             "title": "Regex List",
@@ -231,6 +230,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_list": {
             "title": "Column List",
             "description": "Set of columns to be checked.",
@@ -90,6 +82,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "ignore_row_if": {
             "title": "Ignore Row If",
@@ -231,6 +230,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_list": {
             "title": "Column List",
             "description": "Set of columns to be checked.",
@@ -90,6 +82,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "ignore_row_if": {
             "title": "Ignore Row If",
@@ -238,6 +237,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_list": {
             "title": "Column List",
             "description": "The column names to evaluate.",
@@ -90,6 +82,13 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "multipleOf": 0.01
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "$ref": "#/definitions/ConditionParser"
         },
         "ignore_row_if": {
             "title": "Ignore Row If",
@@ -227,6 +226,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "min_value": {
             "title": "Min Value",
             "description": "The minimum number of columns, inclusive.",

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "value": {
             "title": "Value",
             "description": "The expected number of columns.",

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_list": {
             "title": "Column List",
             "description": "The column names, in the correct order.",

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "column_set": {
             "title": "Column Set",
             "description": "The column names, in any order.",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "min_value": {
             "title": "Min Value",
             "description": "The minimum number of rows, inclusive.",
@@ -105,6 +97,14 @@
                     "format": "date-time"
                 }
             ]
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "title": "Condition Parser",
+            "type": "string"
         },
         "metadata": {
             "type": "object",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -103,8 +103,7 @@
             "type": "string"
         },
         "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
+            "$ref": "#/definitions/ConditionParser"
         },
         "metadata": {
             "type": "object",
@@ -233,6 +232,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -83,8 +83,7 @@
             "type": "string"
         },
         "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
+            "$ref": "#/definitions/ConditionParser"
         },
         "metadata": {
             "type": "object",
@@ -216,6 +215,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "value": {
             "title": "Value",
             "description": "The expected number of rows.",
@@ -85,6 +77,14 @@
                     "type": "object"
                 }
             ]
+        },
+        "row_condition": {
+            "title": "Row Condition",
+            "type": "string"
+        },
+        "condition_parser": {
+            "title": "Condition Parser",
+            "type": "string"
         },
         "metadata": {
             "type": "object",

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -66,17 +66,17 @@
             "title": "Batch Id",
             "type": "string"
         },
+        "other_table_name": {
+            "title": "Other Table Name",
+            "description": "The name of the other table. Other table must be located within the same database.",
+            "type": "string"
+        },
         "row_condition": {
             "title": "Row Condition",
             "type": "string"
         },
         "condition_parser": {
             "title": "Condition Parser",
-            "type": "string"
-        },
-        "other_table_name": {
-            "title": "Other Table Name",
-            "description": "The name of the other table. Other table must be located within the same database.",
             "type": "string"
         },
         "metadata": {

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -76,8 +76,7 @@
             "type": "string"
         },
         "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
+            "$ref": "#/definitions/ConditionParser"
         },
         "metadata": {
             "type": "object",
@@ -206,6 +205,16 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "ConditionParser": {
+            "title": "ConditionParser",
+            "description": "Type of parser to be used to interpret a Row Condition.",
+            "enum": [
+                "great_expectations__experimental__",
+                "pandas",
+                "spark"
+            ],
+            "type": "string"
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
+++ b/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
@@ -66,14 +66,6 @@
             "title": "Batch Id",
             "type": "string"
         },
-        "row_condition": {
-            "title": "Row Condition",
-            "type": "string"
-        },
-        "condition_parser": {
-            "title": "Condition Parser",
-            "type": "string"
-        },
         "unexpected_rows_query": {
             "title": "Unexpected Rows Query",
             "description": "A SQL or Spark-SQL query to be executed for validation.",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -66,6 +66,7 @@ from great_expectations.expectations.model_field_descriptions import (
     WINDOWS_DESCRIPTION,
 )
 from great_expectations.expectations.model_field_types import (
+    ConditionParser,
     Mostly,
 )
 from great_expectations.expectations.registry import (
@@ -1530,14 +1531,10 @@ class BatchExpectation(Expectation, ABC):
     """  # noqa: E501
 
     batch_id: Union[str, None] = None
-    row_condition: Union[str, None] = None
-    condition_parser: Union[str, None] = None
 
     domain_keys: ClassVar[Tuple[str, ...]] = (
         "batch_id",
         "table",
-        "row_condition",
-        "condition_parser",
     )
     metric_dependencies: ClassVar[Tuple[str, ...]] = ()
     domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.TABLE
@@ -1691,11 +1688,7 @@ class QueryExpectation(BatchExpectation, ABC):
         - https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations
     """  # noqa: E501
 
-    domain_keys: ClassVar[Tuple] = (
-        "batch_id",
-        "row_condition",
-        "condition_parser",
-    )
+    domain_keys: ClassVar[Tuple] = ("batch_id",)
 
     @override
     def validate_configuration(
@@ -1708,16 +1701,13 @@ class QueryExpectation(BatchExpectation, ABC):
 
         Raises:
               InvalidExpectationConfigurationError: If no `query` is specified
-              UserWarning: If query is not parameterized, and/or row_condition is passed.
+              UserWarning: If query is not parameterized
         """
         super().validate_configuration(configuration=configuration)
         if not configuration:
             configuration = self.configuration
 
         query: Optional[Any] = configuration.kwargs.get("query") or self._get_default_value("query")
-        row_condition: Optional[Any] = configuration.kwargs.get(
-            "row_condition"
-        ) or self._get_default_value("row_condition")
 
         try:
             assert (
@@ -1745,13 +1735,6 @@ class QueryExpectation(BatchExpectation, ABC):
             )
         except (TypeError, AssertionError) as e:
             warnings.warn(str(e), UserWarning)
-        try:
-            assert row_condition is None, (
-                "`row_condition` is an experimental feature. "
-                "Combining this functionality with QueryExpectations may result in unexpected behavior."  # noqa: E501
-            )
-        except AssertionError as e:
-            warnings.warn(str(e), UserWarning)
 
 
 class ColumnAggregateExpectation(BatchExpectation, ABC):
@@ -1776,6 +1759,8 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
     """  # noqa: E501
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
+    row_condition: Union[str, None] = None
+    condition_parser: Union[ConditionParser, None] = None
 
     domain_keys: ClassVar[Tuple[str, ...]] = (
         "batch_id",
@@ -1827,6 +1812,8 @@ class ColumnMapExpectation(BatchExpectation, ABC):
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
     mostly: Mostly = 1.0  # type: ignore[assignment] # TODO: Fix in CORE-412
+    row_condition: Union[str, None] = None
+    condition_parser: Union[ConditionParser, None] = None
 
     catch_exceptions: bool = True
 
@@ -2093,6 +2080,8 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
     column_A: StrictStr = Field(min_length=1, description=COLUMN_A_DESCRIPTION)
     column_B: StrictStr = Field(min_length=1, description=COLUMN_B_DESCRIPTION)
     mostly: Mostly = 1.0  # type: ignore[assignment] # TODO: Fix in CORE-412
+    row_condition: Union[str, None] = None
+    condition_parser: Union[ConditionParser, None] = None
 
     catch_exceptions: bool = True
 
@@ -2347,7 +2336,8 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
 
     column_list: List[StrictStr] = pydantic.Field(description=COLUMN_LIST_DESCRIPTION)
     mostly: Mostly = pydantic.Field(default=1.0, description=MOSTLY_DESCRIPTION)
-
+    row_condition: Union[str, None] = None
+    condition_parser: Union[ConditionParser, None] = None
     ignore_row_if: Literal["all_values_are_missing", "any_value_is_missing", "never"] = (
         "all_values_are_missing"
     )

--- a/great_expectations/expectations/model_field_types.py
+++ b/great_expectations/expectations/model_field_types.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from numbers import Number
 from typing import Any, Callable, Dict, Generator, Iterable, Union
 
@@ -111,3 +112,11 @@ class _ValueSet(Iterable):
 
 
 ValueSet = Annotated[_ValueSet, Union[list, set]]
+
+
+class ConditionParser(str, Enum):
+    """Type of parser to be used to interpret a Row Condition."""
+
+    GX = "great_expectations__experimental__"
+    PANDAS = "pandas"
+    SPARK = "spark"

--- a/tests/expectations/core/test_expectation_serialization.py
+++ b/tests/expectations/core/test_expectation_serialization.py
@@ -20,9 +20,9 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": false, "rendered_content": null, '
-                '"windows": null, "batch_id": null, "row_condition": null, "condition_parser": '
-                'null, "column": "test_column", "min_value": 1.0, "max_value": null, '
-                '"strict_min": false, "strict_max": false}'
+                '"windows": null, "batch_id": null, "column": "test_column", '
+                '"row_condition": null, "condition_parser": null, "min_value": 1.0, '
+                '"max_value": null, "strict_min": false, "strict_max": false}'
             ),
         ),
         (
@@ -33,8 +33,8 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
-                '"windows": null, "batch_id": null, "row_condition": null, "condition_parser": '
-                'null, "column": "test_column", "mostly": 0.82}'
+                '"windows": null, "batch_id": null, "column": "test_column", "mostly": 0.82, '
+                '"row_condition": null, "condition_parser": null}'
             ),
         ),
         (
@@ -45,8 +45,8 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": "Data shouldn\'t be bad.", "catch_exceptions": false, '
-                '"rendered_content": null, "windows": null, "batch_id": null, "row_condition": '
-                'null, "condition_parser": null, "unexpected_rows_query": "SELECT * FROM '
+                '"rendered_content": null, "windows": null, "batch_id": null, '
+                '"unexpected_rows_query": "SELECT * FROM '
                 "my_table WHERE data='bad'\"}"
             ),
         ),
@@ -68,8 +68,8 @@ from great_expectations.expectations.window import Offset, Window
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
                 '"windows": [{"constraint_fn": "a", "parameter_name": "b", "range": 5, '
                 '"offset": {"positive": 0.2, "negative": 0.2}}], "batch_id": null, '
-                '"row_condition": null, "condition_parser": null, "column": "test_column", '
-                '"mostly": 0.82}'
+                '"column": "test_column", "mostly": 0.82, '
+                '"row_condition": null, "condition_parser": null}'
             ),
         ),
     ],

--- a/tests/test_definitions/column_map_expectations/expect_column_value_lengths_to_be_between.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_value_lengths_to_be_between.json
@@ -206,7 +206,7 @@
         "condition_parser": "bad_parser"
       },
       "out" : {
-        "traceback_substring": "must be 'python' or 'pandas'"
+        "traceback_substring": "not a valid enumeration member"
       }
     }]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_value_lengths_to_equal.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_value_lengths_to_equal.json
@@ -129,7 +129,7 @@
         "condition_parser": "bad_parser"
       },
       "out" : {
-        "traceback_substring": "must be 'python' or 'pandas'"
+        "traceback_substring": "not a valid enumeration member"
       }
     }]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_between.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_between.json
@@ -776,7 +776,7 @@
             "condition_parser": "bad_parser"
           },
           "out": {
-            "traceback_substring": "must be 'python' or 'pandas'"
+            "traceback_substring": "not a valid enumeration member"
           }
         }
       ]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_between_tz_naive.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_between_tz_naive.json
@@ -572,7 +572,7 @@
           "condition_parser": "bad_parser"
         },
         "out": {
-          "traceback_substring": "must be 'python' or 'pandas'"
+          "traceback_substring": "not a valid enumeration member"
         }
       }
     ]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_set.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_set.json
@@ -177,7 +177,7 @@
         "condition_parser": "bad_parser"
       },
       "out": {
-        "traceback_substring": "condition_parser is required"
+        "traceback_substring": "not a valid enumeration member"
       }
     }
     ]},


### PR DESCRIPTION
- Remove `row_condition` from Expectations for which it does not apply: `ExpectColumnToExist`, `ExpectTableColumnCountToBeBetween`, `ExpectTableColumnCountToEqual`, `ExpectTableColumnsToMatchOrderedList`, `ExpectTableColumnsToMatchSet`, and `UnexpectedRowsExpectation`
- Add enum for `condition_parser`
- Remove `pandas` as default `condition_parser` for 3 Expectations - these do not need a special case
----------------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated