### PR TITLE
[MAINTENANCE] ruff 0.6.9 + mypy 0.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-ast
       - id: check-json
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
         exclude: tests/test_fixtures/database_key_test*|tests/datasource/fluent/test_snowflake_datasource\.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.6.8"
+    rev: "v0.6.9"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -1,6 +1,6 @@
 Click>=7.1.2         # CLI tooling
 cookiecutter==2.1.1  # Project templating
-mypy==1.11.2            # Type checker
+mypy==1.12.0            # Type checker
 pydantic>=1.0        # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
 ruff==0.6.9        # Linting / code style / formatting

--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -3,6 +3,6 @@ cookiecutter==2.1.1  # Project templating
 mypy==1.11.2            # Type checker
 pydantic>=1.0        # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
-ruff==0.6.8        # Linting / code style / formatting
+ruff==0.6.9        # Linting / code style / formatting
 twine==3.7.1         # Packaging
 wheel==0.38.1        # Packaging

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -427,7 +427,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     @property
     def ge_cloud_resource_type(self) -> GXCloudRESTResource:
-        return self._ge_cloud_resource_type  # type: ignore[return-value]
+        return self._ge_cloud_resource_type
 
     @property
     def ge_cloud_credentials(self) -> dict:

--- a/great_expectations/expectations/metrics/table_metrics/table_head.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_head.py
@@ -45,7 +45,7 @@ class TableHead(TableMetricProvider):
         if metric_value_kwargs.get("fetch_all", cls.default_kwarg_values["fetch_all"]):
             return df
         n_rows: int = (
-            metric_value_kwargs.get("n_rows")
+            metric_value_kwargs.get("n_rows")  # type: ignore[assignment] # FIXME expected 'int', got 'Any | None'
             if metric_value_kwargs.get("n_rows") is not None
             else cls.default_kwarg_values["n_rows"]
         )
@@ -65,7 +65,7 @@ class TableHead(TableMetricProvider):
         )
 
         n_rows: int = (
-            metric_value_kwargs.get("n_rows")
+            metric_value_kwargs.get("n_rows")  # type: ignore[assignment] # FIXME expected 'int', got 'Any | None'
             if metric_value_kwargs.get("n_rows") is not None
             else cls.default_kwarg_values["n_rows"]
         )
@@ -109,7 +109,7 @@ class TableHead(TableMetricProvider):
             rows = df.collect()
         else:
             n_rows: int = (
-                metric_value_kwargs.get("n_rows")
+                metric_value_kwargs.get("n_rows")  # type: ignore[assignment] # FIXME expected 'int', got 'Any | None'
                 if metric_value_kwargs.get("n_rows") is not None
                 else cls.default_kwarg_values["n_rows"]
             )

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -2,5 +2,5 @@ adr-tools-python==1.0.3
 invoke>=2.0.0
 mypy==1.11.2
 pre-commit>=2.21.0
-ruff==0.6.8
+ruff==0.6.9
 tomli>=2.0.1

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -1,6 +1,6 @@
 adr-tools-python==1.0.3
 invoke>=2.0.0
-mypy==1.11.2
+mypy==1.12.0
 pre-commit>=2.21.0
 ruff==0.6.9
 tomli>=2.0.1


### PR DESCRIPTION
Update static analysis package versions

- ruff `0.6.8` -> `0.6.9`
  - https://github.com/astral-sh/ruff/releases/tag/0.6.9 
- mypy `0.11.1` -> `0.12`
  - https://mypy-lang.blogspot.com/2024/10/mypy-112-released.html 
