### PR TITLE
[DOCS] Edit API reference internal links to prevent 404s

### DIFF
--- a/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
@@ -15,7 +15,6 @@ import OverviewCard from '@site/src/components/OverviewCard';
 
 
 <LinkCardGrid>
-  
   <LinkCard 
       topIcon 
       label="Metadata Stores"

--- a/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
@@ -13,9 +13,7 @@ import OverviewCard from '@site/src/components/OverviewCard';
       {frontMatter.description}
 </OverviewCard>
 
-
 <LinkCardGrid>
-
   <LinkCard 
       topIcon 
       label="Metadata Stores"

--- a/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
@@ -9,6 +9,7 @@ import LinkCardGrid from '@site/src/components/LinkCardGrid';
 import LinkCard from '@site/src/components/LinkCard';
 import OverviewCard from '@site/src/components/OverviewCard';
 
+
 <OverviewCard title={frontMatter.title}>
       {frontMatter.description}
 </OverviewCard>

--- a/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_project_settings.md
@@ -9,13 +9,13 @@ import LinkCardGrid from '@site/src/components/LinkCardGrid';
 import LinkCard from '@site/src/components/LinkCard';
 import OverviewCard from '@site/src/components/OverviewCard';
 
-
 <OverviewCard title={frontMatter.title}>
       {frontMatter.description}
 </OverviewCard>
 
 
 <LinkCardGrid>
+
   <LinkCard 
       topIcon 
       label="Metadata Stores"

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -279,9 +279,8 @@ class SphinxInvokeDocsBuilder:
             else:
                 link_sidebar_entry = self._get_sidebar_entry(html_file_path=href_path)
 
-            relative_link = self._relative_path_between_documents(
-                sidebar_entry.mdx_relpath, link_sidebar_entry.mdx_relpath
-            )
+            relative_link = link_sidebar_entry.mdx_relpath
+
             without_extension = str(relative_link).replace(".mdx", "")
             if not without_extension.endswith("_class"):
                 raise Exception(  # noqa: TRY002, TRY003

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -286,7 +286,7 @@ class SphinxInvokeDocsBuilder:
                 raise Exception(  # noqa: TRY002, TRY003
                     f"Expected class mdx file path to end with _class; this could indicate a method link that will break: {without_extension}"
                 )
-            internal_ref["href"] = str(without_extension)
+            internal_ref["href"] = "/docs/reference/api/" + str(without_extension)
 
         doc_str = str(doc)
 

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -286,7 +286,7 @@ class SphinxInvokeDocsBuilder:
                 raise Exception(  # noqa: TRY002, TRY003
                     f"Expected class mdx file path to end with _class; this could indicate a method link that will break: {without_extension}"
                 )
-            internal_ref["href"] = "/docs/reference/api/" + str(without_extension)
+            internal_ref["href"] = str(without_extension)
 
         doc_str = str(doc)
 


### PR DESCRIPTION
## Description
Relative paths in href are inconsistently handled by browsers and this is causing some links to have a flaky behavior in which they sometimes resolve the URL incorrectly and throw a 404 error.
The purpose of this PR is to use URLS relative to the root path instead so they don't have the current ambiguity.

## Videos
### Production (with relative links)
[Grabación de pantalla desde 24-10-24 03:07:55.webm](https://github.com/user-attachments/assets/d384fbca-afee-46fb-a54c-b9332a09e776)

### Preview app (with relative to the root links)
[Grabación de pantalla desde 24-10-24 03:06:52.webm](https://github.com/user-attachments/assets/50b1ad45-0d9a-42ea-839c-e8bf4f8e1a7f)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
