### PR TITLE
[DOCS] Community/issues board mentions

### DIFF
--- a/CONTRIBUTING_CODE.md
+++ b/CONTRIBUTING_CODE.md
@@ -521,9 +521,10 @@ Additionally, Great Expectations adds the following labels to indicate issue sta
 - `good first issue`: identifies issues that provide an introduction to the Great Expectations contribution process
 
 We also have labels to indicate the level of support you can expect for each issue. They are as follows:
-- `gx-supported`: related to a part of the code-base that is tested and actively maintained with new GX Core or GX Cloud releases
 - `community-supported`:  related to a part of the code-base that is not tested and actively maintained with new GX Core or GX Cloud releases; however, we actively welcome ongoing maintenance from the community
 - `not-supported`: an issue that we at GX will not be maintaining, and we will not support PRs or contributions from the community on the topic
+
+Issues without either a `community-supported` or `not-supported` label can be assumed to be **GX-supported**, which means they are related to a part of the code-base that is tested and actively maintained with new GX Core or GX Cloud releases. 
 
 ## Contributor license agreement (CLA)
 

--- a/CONTRIBUTING_CODE.md
+++ b/CONTRIBUTING_CODE.md
@@ -524,7 +524,7 @@ We also have labels to indicate the level of support you can expect for each iss
 - `community-supported`:  related to a part of the code-base that is not tested and actively maintained with new GX Core or GX Cloud releases; however, we actively welcome ongoing maintenance from the community
 - `not-supported`: an issue that we at GX will not be maintaining, and we will not support PRs or contributions from the community on the topic
 
-Issues without either a `community-supported` or `not-supported` label can be assumed to be **GX-supported**, which means they are related to a part of the code-base that is tested and actively maintained with new GX Core or GX Cloud releases. 
+Issues without either a `community-supported` or `not-supported` label can be assumed to be **GX-supported**, which means they are related to a part of the code-base that is tested and actively maintained with new GX Core or GX Cloud releases.
 
 ## Contributor license agreement (CLA)
 

--- a/docs/docusaurus/docs/core/introduction/community_resources.md
+++ b/docs/docusaurus/docs/core/introduction/community_resources.md
@@ -35,9 +35,9 @@ To contribute to GX documentation or code, see one of the following resources:
 - To submit a custom package to GX for consideration, see [CONTRIBUTING_PACKAGES](https://github.com/great-expectations/great_expectations/blob/develop/CONTRIBUTING_PACKAGES.md) in the `great_expectations` repository.
 -->
 
-If you're not sure where to start, or you want to learn what other contributors are doing, go to the [GX Slack community](https://greatexpectations.io/slack) and introduce yourself in the [#contributing channel](https://greatexpectationstalk.slack.com/archives/CV828B2UX).
+If you're not sure where to start, or you want to learn what other contributors are doing, check out the [community-supported tab in the GX Issues board](https://github.com/orgs/great-expectations/projects/2/views/1?pane=info) and/or check out the [GX Slack community](https://greatexpectations.io/slack) and introduce yourself in the [#contributing channel](https://greatexpectationstalk.slack.com/archives/CV828B2UX).
 
-If you're interested in helping out, review the [GitHub issues list](https://github.com/great-expectations/great_expectations/issues) and self-assign a help wanted issue. If you can't find an issue that interests you, and you want to add an improvement or change, create a new issue. If you're working on an existing or new issue, add a comment to introduce yourself and to let everyone know you’re working on the issue.
+If you're interested in helping out, pick out an issue with a community-supported label and either comment on an issue you’re interested in working on or assign it to yourself. If you can't find an issue that interests you, and you want to add an improvement or change, create a new issue and add a comment to introduce yourself and let everyone know you’re working on the issue. [Read more about the GX Issues board here](https://github.com/orgs/great-expectations/projects/2/views/3?pane=info).
 
 ## Connect with our community
 

--- a/docs/docusaurus/docs/core/introduction/community_resources.md
+++ b/docs/docusaurus/docs/core/introduction/community_resources.md
@@ -37,7 +37,7 @@ To contribute to GX documentation or code, see one of the following resources:
 
 If you're not sure where to start, or you want to learn what other contributors are doing, check out the [community-supported tab in the GX Issues board](https://github.com/orgs/great-expectations/projects/2/views/1?pane=info) and/or check out the [GX Slack community](https://greatexpectations.io/slack) and introduce yourself in the [#contributing channel](https://greatexpectationstalk.slack.com/archives/CV828B2UX).
 
-If you're interested in helping out, pick out an issue with a community-supported label and either comment on an issue you’re interested in working on or assign it to yourself. If you can't find an issue that interests you, and you want to add an improvement or change, create a new issue and add a comment to introduce yourself and let everyone know you’re working on the issue. [Read more about the GX Issues board here](https://github.com/orgs/great-expectations/projects/2/views/3?pane=info).
+If you're interested in helping out, pick out an issue with a `community-supported` label and either comment on an issue you’re interested in working on or assign it to yourself. If you can't find an issue that interests you, and you want to add an improvement or change, create a new issue and add a comment to introduce yourself and let everyone know you’re working on the issue. [Read more about the GX Issues board here](https://github.com/orgs/great-expectations/projects/2/views/3?pane=info).
 
 ## Connect with our community
 

--- a/docs/docusaurus/docs/resources/get_support.md
+++ b/docs/docusaurus/docs/resources/get_support.md
@@ -26,7 +26,7 @@ The order in which we are prioritizing support issues are as follows:
 
 **Your support question will be answered more quickly if you post in Discourse than if you post in Slack.** The reason: Discourse allows for better organization and searchability of support topics.
 
-For specific details on what is GX-supported (in either GX Core or GX Cloud), community-supported or not supported, you can reference our [integration and support policy](https://docs.greatexpectations.io/docs/application_integration_support/). For areas not covered by GX support, we encourage community-driven assistance. 
+For specific details on what is GX-supported (in either GX Core or GX Cloud), community-supported or not supported, you can reference our [integration and support policy](https://docs.greatexpectations.io/docs/application_integration_support/). For areas not covered by GX support, we encourage community-driven assistance. Check out the [GX Core Issues Board](https://github.com/orgs/great-expectations/projects/2?pane=info) for the latest status on GitHub Issues. 
 
 ## How to effectively get support
 


### PR DESCRIPTION
- added references to issues board in Get Support doc
- added references to issues board in community resources doc
- removed mention of the GX-supported label from contributing doc, since the decision was made not to use that label.
