### PR TITLE
[MAINTENANCE] Return informative error when saving expectation suite

### DIFF
--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -235,7 +235,7 @@ class ExpectationsStore(Store):
             return result
         except gx_exceptions.StoreBackendError as exc:
             raise gx_exceptions.ExpectationSuiteError(  # noqa: TRY003
-                f"An ExpectationSuite named {value.name} already exists."
+                f"An error occurred while trying to save ExpectationSuite: {exc.message}"
             ) from exc
 
     def _update(self, key, value, **kwargs):  # type: ignore[explicit-override] # FIXME


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
