### PR TITLE
[MAINTENANCE] update docs link for configuring credentials

### DIFF
--- a/great_expectations/core/config_substitutor.py
+++ b/great_expectations/core/config_substitutor.py
@@ -130,7 +130,7 @@ class _ConfigurationSubstitutor:
                 raise gx_exceptions.MissingConfigVariableError(  # noqa: TRY003
                     f"""\n\nUnable to find a match for config substitution variable: `{config_variable_name}`.
     Please add this missing variable to your `uncommitted/config_variables.yml` file or your environment variables.
-    See https://docs.greatexpectations.io/docs/guides/setup/configuring_data_contexts/how_to_configure_credentials""",  # noqa: E501
+    See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials""",  # noqa: E501
                     missing_config_variable=config_variable_name,
                 )
 

--- a/tests/data_context/test_data_context_on_teams.py
+++ b/tests/data_context/test_data_context_on_teams.py
@@ -29,6 +29,6 @@ def test_incomplete_uncommitted(tmp_path):
         "`secret_validation_results_store_name`." in exc.value.message
     )
     assert (
-        "See https://docs.greatexpectations.io/docs/guides/setup/configuring_data_contexts/how_to_configure_credentials"
+        "See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials"
         in exc.value.message
     )


### PR DESCRIPTION
This issueless PR updates a docs link that was getting redirected to the 0.18 version of content. This PR makes the link point at the current equivalent of the content in the Core docs. 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
