### PR TITLE
[BUGFIX] Parse spaces in row condition column name

### DIFF
--- a/great_expectations/expectations/row_conditions.py
+++ b/great_expectations/expectations/row_conditions.py
@@ -11,11 +11,11 @@ from pyparsing import (
     Combine,
     Literal,
     ParseException,
+    QuotedString,
     Regex,
     Suppress,
     Word,
     alphanums,
-    alphas,
 )
 
 import great_expectations.exceptions as gx_exceptions
@@ -34,11 +34,7 @@ def _set_notnull(s, l, t) -> None:  # noqa: E741 # ambiguous name `l`
 
 
 WHITESPACE_CHARS = " \t"
-column_name = Combine(
-    Suppress(Literal('col("'))
-    + Word(alphas, f"{alphanums}_-.").setResultsName("column")
-    + Suppress(Literal('")'))
-)
+column_name = Combine(Literal("col(") + QuotedString('"').setResultsName("column") + Literal(")"))
 gt = Literal(">")
 lt = Literal("<")
 ge = Literal(">=")

--- a/tests/expectations/test_row_conditions.py
+++ b/tests/expectations/test_row_conditions.py
@@ -43,6 +43,14 @@ def test_condition_parser_with_dash_in_column_name():
 
 
 @pytest.mark.unit
+def test_condition_parser_with_space_in_column_name():
+    res = _parse_great_expectations_condition('col("pk 2") == "Two"')
+    assert res["column"] == "pk 2"
+    assert res["op"] == "=="
+    assert res["condition_value"] == "Two"
+
+
+@pytest.mark.unit
 def test_condition_parser_with_space_in_condition_value():
     res = _parse_great_expectations_condition('col("pk_2") == "Two Two"')
     assert res["column"] == "pk_2"


### PR DESCRIPTION
Use `QuotedString` from pyparsing to parse column_name from submitted string to allow for spaces in column names.  Reported in [this thread on discourse](https://discourse.greatexpectations.io/t/expectations-with-the-row-condition-throws-an-exception-when-either-column-or-value-have-space/1247)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
