### PR TITLE
[BUGFIX] Mask conn_str in configs

### DIFF
--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -163,7 +163,7 @@ class PasswordMasker:
     MASKED_PASSWORD_STRING = "***"
 
     # values with the following keys will be processed with cls.mask_db_url:
-    URL_KEYS = {"connection_string", "url"}
+    URL_KEYS = {"conn_str", "connection_string", "url"}
 
     # values with these keys will be directly replaced with cls.MASKED_PASSWORD_STRING:
     PASSWORD_KEYS = {"access_token", "password"}

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -379,17 +379,20 @@ def test_sanitize_config_with_url_field(conn_string_with_embedded_password, conn
     assert PasswordMasker.MASKED_PASSWORD_STRING in res["credentials"]["url"]
 
 
+@pytest.mark.parametrize("key", ["connection_string", "conn_str"])
 @pytest.mark.unit
 def test_sanitize_config_with_nested_url_field(
-    conn_string_password, conn_string_with_embedded_password
+    conn_string_password,
+    conn_string_with_embedded_password,
+    key: str,
 ):
     # this case has a connection string in an execution_engine dict
-    config = {"execution_engine": {"connection_string": conn_string_with_embedded_password}}
+    config = {"execution_engine": {key: conn_string_with_embedded_password}}
     config_copy = safe_deep_copy(config)
     res = PasswordMasker.sanitize_config(config_copy)
     assert res != config
-    assert conn_string_password not in res["execution_engine"]["connection_string"]
-    assert PasswordMasker.MASKED_PASSWORD_STRING in res["execution_engine"]["connection_string"]
+    assert conn_string_password not in res["execution_engine"][key]
+    assert PasswordMasker.MASKED_PASSWORD_STRING in res["execution_engine"][key]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
This is a field used by ABS DataSources

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
