### PR TITLE
[MAINTENANCE] Validate Expectation JSON Schema follows meta-schema specification

### DIFF
--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -85,7 +85,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -85,7 +85,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -85,7 +85,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -79,7 +79,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -81,7 +81,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -81,7 +81,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -81,7 +81,7 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "type": "number",
-            "multiple_of": 0.01
+            "multipleOf": 0.01
         },
         "row_condition": {
             "title": "Row Condition",

--- a/great_expectations/expectations/core/schemas/README.md
+++ b/great_expectations/expectations/core/schemas/README.md
@@ -1,7 +1,7 @@
 # Expectation JSON Schemas
 
 ## Specification
-Expectation JSON schemas follow should conform to the [JsonSchema7 interface](https://jsonforms.io/api/core/interfaces/jsonschema7). We ensure this by validating each schema using the python [jsonschema](https://python-jsonschema.readthedocs.io/en/stable/) library (e.g. using `Draft7Validator.check_schema()`).
+Expectation JSON schemas should conform to the [JsonSchema7 interface](https://jsonforms.io/api/core/interfaces/jsonschema7). We ensure this by validating each schema using the python [jsonschema](https://python-jsonschema.readthedocs.io/en/stable/) library (e.g. using `Draft7Validator.check_schema()`).
 
 ## Metadata Property
 Properties on the Expectation schemas represent class instance variable definitions except for one special property: `metadata`

--- a/great_expectations/expectations/core/schemas/README.md
+++ b/great_expectations/expectations/core/schemas/README.md
@@ -1,0 +1,9 @@
+# Expectation JSON Schemas
+
+## Specification
+Expectation JSON schemas follow should conform to the [JsonSchema7 interface](https://jsonforms.io/api/core/interfaces/jsonschema7). We ensure this by validating each schema using the python [jsonschema](https://python-jsonschema.readthedocs.io/en/stable/) library (e.g. using `Draft7Validator.check_schema()`).
+
+## Metadata Property
+Properties on the Expectation schemas represent class instance variable definitions except for one special property: `metadata`
+
+The `metadata` property is itself an `object` containing many `properties`. The `metadata` `properties` are all defined by a `const` which does not change from one Expectation instance to another.

--- a/great_expectations/expectations/model_field_types.py
+++ b/great_expectations/expectations/model_field_types.py
@@ -18,7 +18,7 @@ MostlyField = Annotated[
         ge=0.0,
         le=1.0,
         # This is just for the schema, it should not be validated on input
-        schema_overrides={"multiple_of": 0.01},
+        schema_overrides={"multipleOf": 0.01},
     ),
 ]
 

--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -3,7 +3,6 @@ coverage[toml]>=7.5.1
 flaky>=3.7.0 # for docs-integration tests that access cloud-resources that access cloud-resources
 flask>=1.0.0 # for s3 test only (with moto)
 freezegun>=0.3.15
-jsonschema>=4.23.0
 moto[sns,s3]>=4.2.13,<5.0
 pact-python>=2.0.1
 pyfakefs>=4.5.1

--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -3,6 +3,7 @@ coverage[toml]>=7.5.1
 flaky>=3.7.0 # for docs-integration tests that access cloud-resources that access cloud-resources
 flask>=1.0.0 # for s3 test only (with moto)
 freezegun>=0.3.15
+jsonschema>=4.23.0
 moto[sns,s3]>=4.2.13,<5.0
 pact-python>=2.0.1
 pyfakefs>=4.5.1

--- a/tests/expectations/core/test_core_model_schemas.py
+++ b/tests/expectations/core/test_core_model_schemas.py
@@ -1,7 +1,9 @@
 import json
 from pathlib import Path
 
+import jsonschema
 import pytest
+from jsonschema import Draft7Validator
 
 from great_expectations.expectations import core
 from great_expectations.expectations.core import schemas
@@ -37,3 +39,15 @@ def test_schemas_updated():
         new_schema = json.loads(all_models[cls_name].schema_json())
         old_schema = json.loads(schema)
         assert new_schema == old_schema, "json schemas not updated, run `invoke schemas --sync`"
+
+
+@pytest.mark.unit
+def test_schemas_valid_spec():
+    schema_file_paths = Path(schemas.__file__).parent.glob("*.json")
+    for file_path in schema_file_paths:
+        with open(file_path) as schema_file:
+            schema = json.load(schema_file)
+            try:
+                Draft7Validator.check_schema(schema)
+            except jsonschema.exceptions.ValidationError as e:
+                raise f"Schema is invalid according to Draft 7: {e.message}" from e

--- a/tests/expectations/core/test_core_model_schemas.py
+++ b/tests/expectations/core/test_core_model_schemas.py
@@ -44,7 +44,7 @@ def safer_draft_7_validator():
     validator = Draft7Validator
     validator.META_SCHEMA = {
         **Draft7Validator.META_SCHEMA,
-        # this ensures that only specified properties are used
+        # this ensures that only specified properties are used (e.g. multipleOf, not multiple_of)
         # otherwise, the spec says unspecified properties should be ignored
         "additionalProperties": False,
     }

--- a/tests/expectations/core/test_core_model_schemas.py
+++ b/tests/expectations/core/test_core_model_schemas.py
@@ -55,6 +55,8 @@ def test_schemas_updated():
 
 @pytest.mark.unit
 def test_schemas_valid_spec(safer_draft_7_validator: type[Draft7Validator]):
+    # https://json-schema.org/draft-07
+    # https://jsonforms.io/api/core/interfaces/jsonschema7
     schema_file_paths = Path(schemas.__file__).parent.glob("*.json")
     for file_path in schema_file_paths:
         with open(file_path) as schema_file:

--- a/tests/expectations/core/test_core_model_schemas.py
+++ b/tests/expectations/core/test_core_model_schemas.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import jsonschema
 import pytest
 from jsonschema import Draft7Validator
 
@@ -9,6 +10,18 @@ from great_expectations.expectations.core import schemas
 from great_expectations.expectations.expectation import MetaExpectation
 
 expectation_dictionary = dict(core.__dict__)
+
+
+@pytest.fixture
+def safer_draft_7_validator() -> type[Draft7Validator]:
+    validator = Draft7Validator
+    validator.META_SCHEMA = {
+        **Draft7Validator.META_SCHEMA,
+        # this ensures that only specified properties are used (e.g. multipleOf, not multiple_of)
+        # otherwise, the spec says unspecified properties should be ignored
+        "additionalProperties": False,
+    }
+    return validator
 
 
 @pytest.mark.unit
@@ -40,20 +53,14 @@ def test_schemas_updated():
         assert new_schema == old_schema, "json schemas not updated, run `invoke schemas --sync`"
 
 
-def safer_draft_7_validator():
-    validator = Draft7Validator
-    validator.META_SCHEMA = {
-        **Draft7Validator.META_SCHEMA,
-        # this ensures that only specified properties are used (e.g. multipleOf, not multiple_of)
-        # otherwise, the spec says unspecified properties should be ignored
-        "additionalProperties": False,
-    }
-    return validator
-
-
 @pytest.mark.unit
-def test_schemas_valid_spec():
+def test_schemas_valid_spec(safer_draft_7_validator: type[Draft7Validator]):
     schema_file_paths = Path(schemas.__file__).parent.glob("*.json")
     for file_path in schema_file_paths:
         with open(file_path) as schema_file:
-            safer_draft_7_validator().check_schema(json.load(schema_file))
+            try:
+                safer_draft_7_validator.check_schema(json.load(schema_file))
+            except jsonschema.exceptions.SchemaError as e:
+                raise AssertionError(
+                    f"Invalid json schema for `{file_path.name}`: {e.message}"
+                ) from e

--- a/tests/expectations/core/test_core_model_schemas.py
+++ b/tests/expectations/core/test_core_model_schemas.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-import jsonschema
 import pytest
 from jsonschema import Draft7Validator
 
@@ -41,13 +40,20 @@ def test_schemas_updated():
         assert new_schema == old_schema, "json schemas not updated, run `invoke schemas --sync`"
 
 
+def safer_draft_7_validator():
+    validator = Draft7Validator
+    validator.META_SCHEMA = {
+        **Draft7Validator.META_SCHEMA,
+        # this ensures that only specified properties are used
+        # otherwise, the spec says unspecified properties should be ignored
+        "additionalProperties": False,
+    }
+    return validator
+
+
 @pytest.mark.unit
 def test_schemas_valid_spec():
     schema_file_paths = Path(schemas.__file__).parent.glob("*.json")
     for file_path in schema_file_paths:
         with open(file_path) as schema_file:
-            schema = json.load(schema_file)
-            try:
-                Draft7Validator.check_schema(schema)
-            except jsonschema.exceptions.ValidationError as e:
-                raise f"Schema is invalid according to Draft 7: {e.message}" from e
+            safer_draft_7_validator().check_schema(json.load(schema_file))


### PR DESCRIPTION
The Expectation schemas need to satisfy the [JSONSchema7 interface](https://jsonforms.io/api/core/interfaces/jsonschema7). This can be achieved by following the [Draft-7 spec](https://json-schema.org/draft-07). We can verify the schemas follow the meta-schema spec using the [jsonschema](https://python-jsonschema.readthedocs.io/en/stable/) library.
- Replace use of `multiple_of` with specified key `multipleOf`
- Add regression test
- Add `README` for Expectation schemas
---------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
