### PR TITLE
[BUGFIX] Missing renderer params when `row_condition` is used

### DIFF
--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -433,9 +433,9 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
         _params: Optional[Dict[str, Dict[str, Union[str, Dict[str, RendererValueType]]]]] = (
             values.get("_params")
         )
-        if not values["params"]:
-            values["params"] = _RendererValueBase()
-        if _params and _params != values["params"]:
+        # this logic loads the params that exist
+        # upon RendererConfiguration instantiation, e.g. row_condition
+        if _params and len(values["params"].__dict__) == 0:
             renderer_param_definitions: Dict[str, Any] = {}
             for name in _params:
                 renderer_param_type: Type[BaseModel] = (
@@ -445,14 +445,12 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
                     Optional[renderer_param_type],
                     ...,
                 )
-            existing_params = values["params"].__dict__
-            combined_params = {**existing_params, **_params}
             renderer_params: Type[BaseModel] = create_model(
                 "RendererParams",
                 **renderer_param_definitions,
                 __base__=_RendererValueBase,
             )
-            values["params"] = renderer_params(**combined_params)
+            values["params"] = renderer_params(**_params)
 
         return values
 
@@ -461,7 +459,7 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
         row_condition_str: str,
     ) -> List[str]:
         # divide the whole condition into smaller parts
-        row_conditions_list = re.split(r"AND|OR|NOT(?! in)|\(|\)", row_condition_str)
+        row_conditions_list = re.split(r"AND|OR|NOT(?! in)|col\(\"|\"\)", row_condition_str)
         row_conditions_list = [
             condition.strip() for condition in row_conditions_list if condition.strip()
         ]
@@ -479,7 +477,6 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
             .replace(" or ", " OR ")
             .replace("~", " NOT ")
             .replace(" not ", " NOT ")
-            .replace("==", " is ")
         )
         row_condition_str = " ".join(row_condition_str.split())
 

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -458,7 +458,7 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
     def _get_row_conditions_list_from_row_condition_str(
         row_condition_str: str,
     ) -> List[str]:
-        # divide the whole condition into smaller parts
+        # extract the variables to be substituted
         row_conditions_list = re.split(r"AND|OR|NOT(?! in)|col\(\"|\"\)", row_condition_str)
         row_conditions_list = [
             condition.strip() for condition in row_conditions_list if condition.strip()

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -718,6 +718,39 @@ def test_inline_renderer_expectation_validation_result_serialization(
             ],
             id="description",
         ),
+        pytest.param(
+            ExpectationConfiguration(
+                type="expect_column_values_to_be_between",
+                kwargs={
+                    "column": "column_a",
+                    "min_value": 0,
+                    "max_value": 10,
+                    "row_condition": 'col("column_b")==5',
+                    "condition_parser": "great_expectations",
+                },
+            ),
+            [
+                {
+                    "value_type": "StringValueType",
+                    "name": AtomicPrescriptiveRendererType.SUMMARY,
+                    "value": {
+                        "template": "If "
+                        'col("$row_condition__0")$row_condition__1, '
+                        "then $column values must be greater than or equal to "
+                        "$min_value and less than or equal to $max_value.",
+                        "schema": {"type": "com.superconductive.rendered.string"},
+                        "params": {
+                            "column": {"schema": {"type": "string"}, "value": "column_a"},
+                            "min_value": {"schema": {"type": "number"}, "value": 0},
+                            "max_value": {"schema": {"type": "number"}, "value": 10},
+                            "row_condition__0": {"schema": {"type": "string"}, "value": "column_b"},
+                            "row_condition__1": {"schema": {"type": "string"}, "value": "==5"},
+                        },
+                    },
+                }
+            ],
+            id="row_condition",
+        ),
     ],
 )
 def test_inline_renderer_expectation_configuration_serialization(

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -110,7 +110,7 @@ def test_successful_renderer_configuration_instantiation(
                 "condition_parser": "great_expectations",
                 "row_condition": 'PClass=="1st"',
             },
-            ['PClass is "1st"'],
+            ['PClass=="1st"'],
         ),
         (
             "expect_column_values_to_be_in_set",
@@ -120,7 +120,7 @@ def test_successful_renderer_configuration_instantiation(
                 "condition_parser": "great_expectations",
                 "row_condition": 'col("foo") > 5',
             },
-            ["col", '"foo"', "> 5"],
+            ["foo", "> 5"],
         ),
         (
             "expect_column_values_to_be_in_set",
@@ -130,7 +130,7 @@ def test_successful_renderer_configuration_instantiation(
                 "condition_parser": "great_expectations",
                 "row_condition": "foo == 1 | foo == 2",
             },
-            ["foo is 1", "foo is 2"],
+            ["foo == 1", "foo == 2"],
         ),
         (
             "expect_column_values_to_be_in_set",


### PR DESCRIPTION
- Fix regression where Expectation `kwargs` were not getting added as renderer `params`
- Revert logic changing "==" to "is" - this is a GX Cloud concern
---------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
