### PR TITLE
[MAINTENANCE]: standardize _atomic_diagnostic_observed_value

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1055,12 +1055,29 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             result=result,
             runtime_configuration=runtime_configuration,
         )
+
         name = "observed_value"
+        param_types = sorted(
+            RendererValueType,
+            key=lambda x: (
+                # in order to infer type correctly
+                # object must be last in the list
+                # as it is permissive to any value
+                x.value == "object",
+                # and string must be second to last
+                # as it is permissive to string-able value
+                x.value == "string",
+                x.value,
+            ),
+        )
+        value = result.result.get(name) if result is not None else None
+        if value is None:
+            value = cls._get_observed_value_from_evr(result=result)
 
         renderer_configuration.add_param(
             name=name,
-            param_type=list(RendererValueType),
-            value=cls._get_observed_value_from_evr(result=result),
+            param_type=param_types,
+            value=value,
         )
 
         value_obj = renderedAtomicValueSchema.load(

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1050,14 +1050,27 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> RenderedAtomicContent:
-        observed_value: str = cls._get_observed_value_from_evr(result=result)
+        renderer_configuration: RendererConfiguration = RendererConfiguration(
+            configuration=configuration,
+            result=result,
+            runtime_configuration=runtime_configuration,
+        )
+        name = "observed_value"
+
+        renderer_configuration.add_param(
+            name=name,
+            param_type=list(RendererValueType),
+            value=cls._get_observed_value_from_evr(result=result),
+        )
+
         value_obj = renderedAtomicValueSchema.load(
             {
-                "template": observed_value,
-                "params": {},
+                "template": f"${name}",
+                "params": renderer_configuration.params.dict(),
                 "schema": {"type": "com.superconductive.rendered.string"},
             }
         )
+
         rendered = RenderedAtomicContent(
             name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
             value=value_obj,

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from numbers import Number
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Generic,
-    Iterable,
     List,
     Optional,
     Tuple,
@@ -19,7 +19,6 @@ from typing import (
 )
 
 import dateutil
-from dateutil.parser import ParserError
 from typing_extensions import TypeAlias, TypedDict
 
 from great_expectations.compatibility.pydantic import (
@@ -155,6 +154,66 @@ class CodeBlock(TypedDict):
     language: CodeBlockLanguage
 
 
+def make_exception_msg(v_type: RendererValueType, input: Any) -> str:
+    return f"Param type: <{v_type}> does not match value: <{input}>."
+
+
+def make_str_exception_msg(v_type: RendererValueType, input: Any) -> str:
+    message = f"Value was unable to be represented as a {v_type}"
+    try:
+        str(input)
+    except Exception as e:
+        message = f"{message}: {e}"
+    return message
+
+
+def safe_str(input: Any) -> bool:
+    try:
+        str(input)
+        return True
+    except Exception:
+        return False
+
+
+def safe_date(input: Any) -> bool:
+    try:
+        dateutil.parser.parse(input)
+        return True
+    except Exception:
+        return False
+
+
+PARAM_TYPE_TESTERS: Dict[
+    RendererValueType,
+    Tuple[
+        Callable[[Any], bool],
+        Callable[[RendererValueType, Any], str],
+    ],
+] = {
+    RendererValueType.ARRAY: (
+        lambda x: isinstance(x, (list, tuple, set)),
+        make_exception_msg,
+    ),
+    RendererValueType.BOOLEAN: (
+        lambda x: isinstance(x, bool),
+        make_exception_msg,
+    ),
+    RendererValueType.DATETIME: (
+        lambda x: isinstance(x, (date, datetime)) or safe_date(x),
+        make_exception_msg,
+    ),
+    RendererValueType.NUMBER: (
+        lambda x: isinstance(x, Number),
+        make_exception_msg,
+    ),
+    RendererValueType.OBJECT: (lambda x: True, make_exception_msg),
+    RendererValueType.STRING: (
+        lambda x: safe_str(x),
+        make_str_exception_msg,
+    ),
+}
+
+
 class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererParams]):
     """
     Configuration object built for each renderer. Operations to be performed strictly on this object at the renderer
@@ -225,42 +284,17 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
             allow_mutation = False
 
         @root_validator(pre=True)
-        def _validate_param_type_matches_value(  # noqa: C901
-            cls, values: dict
-        ) -> dict:
+        def _validate_param_type_matches_value(cls, values: dict) -> dict:
             """
             This root_validator ensures that a value can be parsed by its RendererValueType.
             If RendererValueType.OBJECT is passed, it is treated as valid for any value.
             """
             param_type: RendererValueType = values["schema"]["type"]
             value: Any = values["value"]
-            if param_type == RendererValueType.STRING:
-                try:
-                    str(value)
-                except Exception as e:
-                    raise RendererConfigurationError(  # noqa: TRY003
-                        f"Value was unable to be represented as a string: {e!s}"
-                    )
-            else:
-                renderer_configuration_error = RendererConfigurationError(
-                    f"Param type: <{param_type}> does " f"not match value: <{value}>."
-                )
-                if param_type == RendererValueType.NUMBER:
-                    if not isinstance(value, Number):
-                        raise renderer_configuration_error
-                elif param_type == RendererValueType.DATETIME:
-                    if not isinstance(value, datetime):
-                        try:
-                            dateutil.parser.parse(value)
-                        except ParserError:
-                            raise renderer_configuration_error
-                elif param_type == RendererValueType.BOOLEAN:
-                    if value is not True and value is not False:
-                        raise renderer_configuration_error
-                elif param_type == RendererValueType.ARRAY:
-                    if not isinstance(value, Iterable):
-                        raise renderer_configuration_error
 
+            (tester, error) = PARAM_TYPE_TESTERS[param_type]
+            if not tester(value):
+                raise RendererConfigurationError(error(param_type, value))
             return values
 
         @override

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -2092,9 +2092,9 @@ def test_atomic_diagnostic_observed_value_without_result(get_diagnostic_rendered
     assert res == {
         "name": "atomic.diagnostic.observed_value",
         "value": {
-            "params": {},
+            "params": {"observed_value": {"schema": {"type": "string"}, "value": "--"}},
             "schema": {"type": "com.superconductive.rendered.string"},
-            "template": "--",
+            "template": "$observed_value",
         },
         "value_type": "StringValueType",
     }
@@ -2121,9 +2121,9 @@ def test_atomic_diagnostic_observed_value_with_numeric_observed_value(
     assert res == {
         "name": "atomic.diagnostic.observed_value",
         "value": {
-            "params": {},
+            "params": {"observed_value": {"schema": {"type": "string"}, "value": "1,776"}},
             "schema": {"type": "com.superconductive.rendered.string"},
-            "template": "1,776",
+            "template": "$observed_value",
         },
         "value_type": "StringValueType",
     }
@@ -2148,9 +2148,9 @@ def test_atomic_diagnostic_observed_value_with_str_observed_value(get_diagnostic
     assert res == {
         "name": "atomic.diagnostic.observed_value",
         "value": {
-            "params": {},
+            "params": {"observed_value": {"schema": {"type": "string"}, "value": "foo"}},
             "schema": {"type": "com.superconductive.rendered.string"},
-            "template": "foo",
+            "template": "$observed_value",
         },
         "value_type": "StringValueType",
     }
@@ -2175,9 +2175,9 @@ def test_atomic_diagnostic_observed_value_with_unexpected_percent(get_diagnostic
     assert res == {
         "name": "atomic.diagnostic.observed_value",
         "value": {
-            "params": {},
+            "params": {"observed_value": {"schema": {"type": "string"}, "value": "10% unexpected"}},
             "schema": {"type": "com.superconductive.rendered.string"},
-            "template": "10% unexpected",
+            "template": "$observed_value",
         },
         "value_type": "StringValueType",
     }
@@ -2202,9 +2202,9 @@ def test_atomic_diagnostic_observed_value_with_empty_result(get_diagnostic_rende
     assert res == {
         "name": "atomic.diagnostic.observed_value",
         "value": {
-            "params": {},
+            "params": {"observed_value": {"schema": {"type": "string"}, "value": "--"}},
             "schema": {"type": "com.superconductive.rendered.string"},
-            "template": "--",
+            "template": "$observed_value",
         },
         "value_type": "StringValueType",
     }

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from pprint import pprint
 from typing import Callable, Dict, Union
 
@@ -2121,7 +2122,7 @@ def test_atomic_diagnostic_observed_value_with_numeric_observed_value(
     assert res == {
         "name": "atomic.diagnostic.observed_value",
         "value": {
-            "params": {"observed_value": {"schema": {"type": "string"}, "value": "1,776"}},
+            "params": {"observed_value": {"schema": {"type": "number"}, "value": 1776}},
             "schema": {"type": "com.superconductive.rendered.string"},
             "template": "$observed_value",
         },
@@ -2205,6 +2206,104 @@ def test_atomic_diagnostic_observed_value_with_empty_result(get_diagnostic_rende
             "params": {"observed_value": {"schema": {"type": "string"}, "value": "--"}},
             "schema": {"type": "com.superconductive.rendered.string"},
             "template": "$observed_value",
+        },
+        "value_type": "StringValueType",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "result, expected_template, expected_params",
+    [
+        (
+            {"observed_value": "foo"},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "string"}, "value": "foo"}},
+        ),
+        (
+            {"observed_value": False},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "boolean"}, "value": False}},
+        ),
+        (
+            {
+                "observed_value": datetime.strptime(
+                    "1999-12-31T23:59:59-00:00", "%Y-%m-%dT%H:%M:%S%z"
+                )
+            },
+            "$observed_value",
+            {
+                "observed_value": {
+                    "schema": {"type": "datetime"},
+                    "value": datetime.strptime("1999-12-31T23:59:59-00:00", "%Y-%m-%dT%H:%M:%S%z"),
+                }
+            },
+        ),
+        (
+            {"observed_value": "1999-12-31 23:59:59"},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "datetime"}, "value": "1999-12-31 23:59:59"}},
+        ),
+        (
+            {"observed_value": 1776},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "number"}, "value": 1776}},
+        ),
+        (
+            {"unexpected_percent": 10},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "string"}, "value": "10% unexpected"}},
+        ),
+        (
+            {"observed_value": ["%", "_"]},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "array"}, "value": ["%", "_"]}},
+        ),
+        (
+            {"observed_value": [1, 2, 3]},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "array"}, "value": [1, 2, 3]}},
+        ),
+        # when all value types are inferrable string will end up taking precendence over
+        # object otherwise object would overrride most other inference types as it
+        # is permissible to any value type
+        (
+            {"observed_value": {"foo": "bar"}},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "string"}, "value": {"foo": "bar"}}},
+        ),
+        (
+            {"observed_value": None},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "string"}, "value": "--"}},
+        ),
+        (
+            {},
+            "$observed_value",
+            {"observed_value": {"schema": {"type": "string"}, "value": "--"}},
+        ),
+    ],
+)
+def test_atomic_diagnostic_observed_param_type_inference(
+    get_diagnostic_rendered_content, result, expected_template, expected_params
+):
+    expectation_config = {
+        "type": "expect_table_row_count_to_equal",
+        "kwargs": {},
+    }
+    update_dict = {
+        "expectation_config": ExpectationConfiguration(**expectation_config),
+        "result": result,
+    }
+    rendered_content = get_diagnostic_rendered_content(update_dict)
+    res = rendered_content.to_json_dict()
+    pprint(res)
+    assert res == {
+        "name": "atomic.diagnostic.observed_value",
+        "value": {
+            "params": expected_params,
+            "schema": {"type": "com.superconductive.rendered.string"},
+            "template": expected_template,
         },
         "value_type": "StringValueType",
     }

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -59,9 +59,9 @@ def test_inline_renderer_instantiation_error_message(
                 {
                     "name": AtomicDiagnosticRendererType.OBSERVED_VALUE,
                     "value": {
-                        "params": {},
+                        "params": {"observed_value": {"schema": {"type": "number"}, "value": 3}},
                         "schema": {"type": "com.superconductive.rendered.string"},
-                        "template": "3",
+                        "template": "$observed_value",
                     },
                     "value_type": "StringValueType",
                 },
@@ -89,9 +89,9 @@ def test_inline_renderer_instantiation_error_message(
                 {
                     "name": AtomicDiagnosticRendererType.OBSERVED_VALUE,
                     "value": {
-                        "params": {},
+                        "params": {"observed_value": {"schema": {"type": "number"}, "value": 19}},
                         "schema": {"type": "com.superconductive.rendered.string"},
-                        "template": "19",
+                        "template": "$observed_value",
                     },
                     "value_type": "StringValueType",
                 },
@@ -227,9 +227,14 @@ def test_inline_renderer_instantiation_error_message(
                 {
                     "name": AtomicDiagnosticRendererType.OBSERVED_VALUE,
                     "value": {
-                        "params": {},
+                        "params": {
+                            "observed_value": {
+                                "schema": {"type": "string"},
+                                "value": "0% unexpected",
+                            }
+                        },
                         "schema": {"type": "com.superconductive.rendered.string"},
-                        "template": "0% unexpected",
+                        "template": "$observed_value",
                     },
                     "value_type": "StringValueType",
                 },

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -216,7 +216,9 @@ def test_renderer_configuration_add_param_validation(
         renderer_configuration.add_param(name="value", param_type=param_type)
 
     if param_type is RendererValueType.STRING:
-        exception_message = "Value was unable to be represented as a string: I'm not a string"
+        exception_message = (
+            f"Value was unable to be represented as a {RendererValueType.STRING}: I'm not a string"
+        )
     else:
         exception_message = f"Param type: <{param_type}> does not match value: <{value}>."
     assert any(


### PR DESCRIPTION
- Updates the Expectation class `_atomic_diagnostic_observed_value` method to use a template string and params like other atomic renderers
- Updates the ExpectationConfiguration class to better infer observed_value type
- Adds tests to assert proper type inference



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
