### PR TITLE
[BUGFIX] ExpectationSuiteValidationResult should contain checkpoint_name

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -356,6 +356,7 @@ class Checkpoint(BaseModel):
     ) -> CheckpointResult:
         for result in run_results.values():
             result.meta["checkpoint_id"] = self.id
+            result.meta["checkpoint_name"] = self.name
 
         return CheckpointResult(
             run_id=run_id,

--- a/great_expectations/core/validation_definition.py
+++ b/great_expectations/core/validation_definition.py
@@ -241,9 +241,10 @@ class ValidationDefinition(BaseModel):
         return batch_definition
 
     @public_api
-    def run(
+    def run(  # noqa: PLR0913
         self,
         *,
+        checkpoint_name: Optional[str] = None,
         checkpoint_id: Optional[str] = None,
         batch_parameters: Optional[BatchParameters] = None,
         expectation_parameters: Optional[SuiteParameterDict] = None,
@@ -289,6 +290,8 @@ class ValidationDefinition(BaseModel):
         results = validator.validate_expectation_suite(self.suite, expectation_parameters)
         results.meta["validation_id"] = self.id
         results.meta["checkpoint_id"] = checkpoint_id
+        if checkpoint_name:
+            results.meta["checkpoint_name"] = checkpoint_name
 
         # NOTE: We should promote this to a top-level field of the result.
         #       Meta should be reserved for user-defined information.

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -979,12 +979,14 @@ class TestCheckpointResult:
             "batch_parameters",
             "batch_spec",
             "checkpoint_id",
+            "checkpoint_name",
             "great_expectations_version",
             "run_id",
             "validation_id",
             "validation_time",
         ]
         assert meta["checkpoint_id"] == checkpoint.id
+        assert meta["checkpoint_name"] == checkpoint.name
         assert meta["validation_id"] == checkpoint.validation_definitions[0].id
 
     @pytest.mark.filesystem

--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -317,12 +317,14 @@ class TestValidationRun:
 
         output = dataframe_validation_definition.run(
             checkpoint_id=None,
+            checkpoint_name="checkpoint_name",
             batch_parameters={"dataframe": pd.DataFrame({"a": ["1", "2", "3", "4", "5"]})},
         )
 
         assert output.meta == {
             "validation_id": dataframe_validation_definition.id,
             "checkpoint_id": None,
+            "checkpoint_name": "checkpoint_name",
             "batch_parameters": {"dataframe": "<DATAFRAME>"},
             "batch_spec": ACTIVE_BATCH_SPEC,
             "batch_markers": BATCH_MARKERS,


### PR DESCRIPTION
In V1, a checkpoint cannot be looked up by ID and ran, instead you need to use the name. 

ExpectationSuiteValidationResultMeta shows that checkpoint_name should be available but it is not. This PR rectifies that.
https://github.com/great-expectations/great_expectations/blob/d4b8c189121dc565c4aeb50c6c58f5ce4345baa3/great_expectations/core/expectation_validation_result.py#L399-L405

A separate discussion needs to be had if checkpoint_id should be used for looking up and running checkpoints instead of checkpoint_name.

Here are some related PRs for context:
- https://github.com/great-expectations/great_expectations/pull/10169

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
