### PR TITLE
[DOCS] actions not ready for contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ To ensure the long-term quality of the GX Core codebase, we're not yet ready to 
 
 | GX Component         | Readiness          | Notes |
 | -------------------- | ------------------ | ----- |
-| Action               | 🔴 Not ready       |       |
 | CredentialStore      | 🟢 Ready           |       |
 | BatchDefinition      | 🟡 Partially ready | Formerly known as splitters |
+| Action               | 🔴 Not ready       |       |
 | DataSource           | 🔴 Not ready       | Includes MetricProvider and ExecutionEngine |
 | DataContext          | 🔴 Not ready       | Also known as Configuration Stores |
 | DataAsset            | 🔴 Not ready       |       |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To ensure the long-term quality of the GX Core codebase, we're not yet ready to 
 
 | GX Component         | Readiness          | Notes |
 | -------------------- | ------------------ | ----- |
-| Action               | 🟢 Ready           |       |
+| Action               | 🔴 Not ready       |       |
 | CredentialStore      | 🟢 Ready           |       |
 | BatchDefinition      | 🟡 Partially ready | Formerly known as splitters |
 | DataSource           | 🔴 Not ready       | Includes MetricProvider and ExecutionEngine |


### PR DESCRIPTION
This issueless PR marks Actions as not ready for contributions while we work to restore custom Actions

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
