### PR TITLE
[MAINTENANCE] Standardize result object from Checkpoint action runs

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -151,7 +151,7 @@ class ValidationAction(BaseModel):
             data_docs_results = action_context.filter_results(class_=UpdateDataDocsAction)
             data_docs_pages = {}
             for result in data_docs_results:
-                data_docs_pages.update(result)
+                data_docs_pages.update(result.run_info)
             return data_docs_pages
 
         return None

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -86,7 +86,7 @@ def _build_renderer(config: dict) -> Renderer:
 
 
 class ValidationActionResult(BaseModel):
-    success: bool | None
+    success: bool | None # None if not run at all but could be an enum
     run_info: dict
 
 

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -319,7 +319,9 @@ class SlackNotificationAction(DataDocsAction):
             if response is not None
             else ValidationActionRunStatus.FAILURE
         )
-        return ValidationActionResult(status=status, result={"slack_notification_result": response})
+        return ValidationActionResult(
+            status=status, run_info={"slack_notification_result": response}
+        )
 
     def _render_validation_result(
         self,
@@ -523,13 +525,13 @@ class MicrosoftTeamsNotificationAction(ValidationAction):
             )
         )
 
-        success = (
+        status = (
             ValidationActionRunStatus.SUCCESS
             if teams_notif_result is not None
             else ValidationActionRunStatus.FAILURE
         )
-        return ValidationActionRunStatus(
-            success=success, run_info={"microsoft_teams_notification_result": teams_notif_result}
+        return ValidationActionResult(
+            status=status, run_info={"microsoft_teams_notification_result": teams_notif_result}
         )
 
 
@@ -609,7 +611,7 @@ class OpsgenieAlertAction(ValidationAction):
                 else ValidationActionRunStatus.FAILURE
             )
             return ValidationActionResult(
-                status=status, run_info={"opsgenie_alert_result": "No alert sent"}
+                status=status, run_info={"opsgenie_alert_result": alert_result}
             )
         else:
             return ValidationActionResult(

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -86,7 +86,7 @@ def _build_renderer(config: dict) -> Renderer:
 
 
 class ValidationActionResult(BaseModel):
-    success: bool | None # None if not run at all but could be an enum
+    success: bool | None  # None if not run at all but could be an enum
     run_info: dict
 
 

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -93,6 +93,14 @@ class ValidationActionRunStatus(enum.Enum):
 
 
 class ValidationActionResult(BaseModel):
+    """
+    The result of running a ValidationAction.
+
+    Args:
+        status: The status of the action run. If the action was not run, the status is "not_run".
+        run_info: A dictionary containing information about the run.
+    """
+
     status: ValidationActionRunStatus
     run_info: dict
 

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -299,10 +299,7 @@ class Checkpoint(BaseModel):
         )
 
         checkpoint_result = self._construct_result(run_id=run_id, run_results=run_results)
-        action_results = self._run_actions(checkpoint_result=checkpoint_result)
-
-        # Do something with action results and/or add to checkpoint result payload
-        # checkpoint_result.run_info or something?
+        checkpoint_result.action_info = self._run_actions(checkpoint_result=checkpoint_result)
 
         self._submit_analytics_event()
 

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -299,7 +299,7 @@ class Checkpoint(BaseModel):
         )
 
         checkpoint_result = self._construct_result(run_id=run_id, run_results=run_results)
-        checkpoint_result.action_info = self._run_actions(checkpoint_result=checkpoint_result)
+        self._run_actions(checkpoint_result=checkpoint_result)
 
         self._submit_analytics_event()
 

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -24,8 +24,6 @@ from great_expectations.checkpoint.actions import (
     ActionContext,
     CheckpointAction,
     UpdateDataDocsAction,
-    ValidationAction,
-    ValidationActionResult,
 )
 from great_expectations.compatibility.pydantic import (
     BaseModel,
@@ -368,7 +366,7 @@ class Checkpoint(BaseModel):
     def _run_actions(
         self,
         checkpoint_result: CheckpointResult,
-    ) -> list[tuple[ValidationAction, ValidationActionResult]]:
+    ) -> None:
         action_context = ActionContext()
         sorted_actions = self._sort_actions()
         for action in sorted_actions:
@@ -377,8 +375,6 @@ class Checkpoint(BaseModel):
                 action_context=action_context,
             )
             action_context.update(action=action, action_result=action_result)
-
-        return action_context.data
 
     def _sort_actions(self) -> List[CheckpointAction]:
         """

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -370,7 +370,7 @@ class Checkpoint(BaseModel):
     def _run_actions(
         self,
         checkpoint_result: CheckpointResult,
-    ) -> dict[str, ValidationActionResult]:
+    ) -> Dict[str, ValidationActionResult]:
         action_context = ActionContext()
         sorted_actions = self._sort_actions()
         for action in sorted_actions:

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -24,6 +24,8 @@ from great_expectations.checkpoint.actions import (
     ActionContext,
     CheckpointAction,
     UpdateDataDocsAction,
+    ValidationAction,
+    ValidationActionResult,
 )
 from great_expectations.compatibility.pydantic import (
     BaseModel,
@@ -297,7 +299,10 @@ class Checkpoint(BaseModel):
         )
 
         checkpoint_result = self._construct_result(run_id=run_id, run_results=run_results)
-        self._run_actions(checkpoint_result=checkpoint_result)
+        action_results = self._run_actions(checkpoint_result=checkpoint_result)
+
+        # Do something with action results and/or add to checkpoint result payload
+        # checkpoint_result.run_info or something?
 
         self._submit_analytics_event()
 
@@ -366,7 +371,7 @@ class Checkpoint(BaseModel):
     def _run_actions(
         self,
         checkpoint_result: CheckpointResult,
-    ) -> None:
+    ) -> list[tuple[ValidationAction, ValidationActionResult]]:
         action_context = ActionContext()
         sorted_actions = self._sort_actions()
         for action in sorted_actions:
@@ -375,6 +380,8 @@ class Checkpoint(BaseModel):
                 action_context=action_context,
             )
             action_context.update(action=action, action_result=action_result)
+
+        return action_context.data
 
     def _sort_actions(self) -> List[CheckpointAction]:
         """

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -129,7 +129,7 @@ def send_email(  # noqa: C901, PLR0913
     receiver_emails_list,
     use_tls,
     use_ssl,
-):
+) -> str | None:
     msg = MIMEMultipart()
     msg["From"] = sender_alias
     msg["To"] = ", ".join(receiver_emails_list)
@@ -168,7 +168,7 @@ def send_email(  # noqa: C901, PLR0913
 
 def send_sns_notification(
     sns_topic_arn: str, sns_subject: str, validation_results: str, **kwargs
-) -> str:
+) -> tuple[bool, str]:
     """
     Send JSON results to an SNS topic with a schema of:
 
@@ -182,7 +182,7 @@ def send_sns_notification(
     """
     if not aws.boto3:
         logger.warning("boto3 is not installed")
-        return "boto3 is not installed"
+        return False, "boto3 is not installed"
 
     message_dict = {
         "TopicArn": sns_topic_arn,
@@ -200,6 +200,9 @@ def send_sns_notification(
     except sns.exceptions.InvalidParameterException:
         error_msg = f"Received invalid for message: {validation_results}"
         logger.error(error_msg)  # noqa: TRY400
-        return error_msg
+        return False, error_msg
     else:
-        return f"Successfully posted results to {response['MessageId']} with Subject {sns_subject}"
+        return (
+            True,
+            f"Successfully posted results to {response['MessageId']} with Subject {sns_subject}",
+        )

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -129,7 +129,7 @@ def send_email(  # noqa: C901, PLR0913
     receiver_emails_list,
     use_tls,
     use_ssl,
-) -> str | None:
+):
     msg = MIMEMultipart()
     msg["From"] = sender_alias
     msg["To"] = ", ".join(receiver_emails_list)
@@ -164,6 +164,7 @@ def send_email(  # noqa: C901, PLR0913
         logger.error(str(e))  # noqa: TRY400
     else:
         return "success"
+    return None
 
 
 def send_sns_notification(

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from types import ModuleType
@@ -431,6 +432,9 @@ class TestMicrosoftTeamsNotificationAction:
         self,
         checkpoint_result: CheckpointResult,
     ):
+        if not os.environ.get("GX_MS_TEAMS_WEBHOOK"):
+            pytest.skip("GX_MS_TEAMS_WEBHOOK environment variable not set; skipping test.")
+
         # Necessary to retrieve config provider
         gx.get_context(mode="ephemeral")
 
@@ -459,7 +463,10 @@ class TestMicrosoftTeamsNotificationAction:
         with caplog.at_level(logging.WARNING):
             result = action.run(checkpoint_result=checkpoint_result)
 
-        assert result == {"microsoft_teams_notification_result": None}
+        assert result == ValidationActionResult(
+            status=ValidationActionRunStatus.FAILURE,
+            run_info={"microsoft_teams_notification_result": None},
+        )
         assert caplog.records[-1].message.startswith("Failed to connect to Microsoft Teams webhook")
 
 

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -433,7 +433,7 @@ class TestMicrosoftTeamsNotificationAction:
         checkpoint_result: CheckpointResult,
     ):
         if not os.environ.get("GX_MS_TEAMS_WEBHOOK"):
-            pytest.skip("GX_MS_TEAMS_WEBHOOK environment variable not set; skipping test.")
+            pytest.xfail("GX_MS_TEAMS_WEBHOOK environment variable must be set.")
 
         # Necessary to retrieve config provider
         gx.get_context(mode="ephemeral")

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -800,15 +800,18 @@ class TestV1ActionRun:
         action_context = ActionContext()
         action_context.update(
             action=UpdateDataDocsAction(name="docs_action"),
-            action_result={
-                ValidationResultIdentifier(
-                    expectation_suite_identifier=ExpectationSuiteIdentifier(name="my_suite"),
-                    run_id=RunIdentifier(run_name="prod_20240401"),
-                    batch_identifier="my_datasource-my_first_asset",
-                ): {
-                    "local_site": site_path,
-                }
-            },
+            action_result=ValidationActionResult(
+                status=ValidationActionRunStatus.SUCCESS,
+                run_info={
+                    ValidationResultIdentifier(
+                        expectation_suite_identifier=ExpectationSuiteIdentifier(name="my_suite"),
+                        run_id=RunIdentifier(run_name="prod_20240401"),
+                        batch_identifier="my_datasource-my_first_asset",
+                    ): {
+                        "local_site": site_path,
+                    }
+                },
+            ),
         )
         with mock.patch.object(Session, "post") as mock_post:
             output = action.run(

--- a/tests/actions/test_sns_action.py
+++ b/tests/actions/test_sns_action.py
@@ -19,8 +19,9 @@ def test_send_sns_notification(sns, aws_credentials):
     result = ExpectationSuiteValidationResult(**results)
     topic = "test"
     created = sns.create_topic(Name=topic)
-    response = send_sns_notification(
+    success, response = send_sns_notification(
         created.get("TopicArn"), str(result.success), str(result.results)
     )
 
+    assert success
     assert response.startswith("Successfully")


### PR DESCRIPTION
We should have a consistent API for `ValidationAction.run` - this new model is a lightweight wrapper around a status and the existing payload but should allow us to be better prepared for extensibility that users want.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
