### PR TITLE
[BUGFIX] double-sided z score renderer

### DIFF
--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -240,7 +240,6 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
         add_param_args: AddParamArgs = (
             ("column", RendererValueType.STRING),
             ("threshold", RendererValueType.NUMBER),
-            ("double_sided", RendererValueType.BOOLEAN),
             ("mostly", RendererValueType.NUMBER),
         )
         for name, param_type in add_param_args:
@@ -253,10 +252,12 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
         else:
             template_str = "Value z-scores must be "
 
-        if params.double_sided.value is True:
+        if renderer_configuration.kwargs.get("double_sided") is True:
             inverse_threshold = params.threshold.value * -1
             renderer_configuration.add_param(
-                name="inverse_threshold", param_type=RendererValueType.NUMBER
+                name="inverse_threshold",
+                param_type=RendererValueType.NUMBER,
+                value=inverse_threshold,
             )
             if inverse_threshold < params.threshold.value:
                 template_str += "greater than $inverse_threshold and less than $threshold"

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -751,6 +751,29 @@ def test_inline_renderer_expectation_validation_result_serialization(
             ],
             id="row_condition",
         ),
+        pytest.param(
+            ExpectationConfiguration(
+                type="expect_column_value_z_scores_to_be_less_than",
+                kwargs={"column": "column_a", "threshold": 4, "double_sided": True},
+            ),
+            [
+                {
+                    "name": "atomic.prescriptive.summary",
+                    "value": {
+                        "params": {
+                            "column": {"schema": {"type": "string"}, "value": "column_a"},
+                            "threshold": {"schema": {"type": "number"}, "value": 4},
+                            "inverse_threshold": {"schema": {"type": "number"}, "value": -4},
+                        },
+                        "schema": {"type": "com.superconductive.rendered.string"},
+                        "template": "$column value z-scores must be greater "
+                        "than $inverse_threshold and less than $threshold.",
+                    },
+                    "value_type": "StringValueType",
+                }
+            ],
+            id="z_score_double_sided",
+        ),
     ],
 )
 def test_inline_renderer_expectation_configuration_serialization(


### PR DESCRIPTION
- We were missing the `inverse_threshold` param value assignment when `double_sided` is `True`
- Before: The literal string `"$inverse_threshold"` would appear in the expectation rendering
- After:  `$inverse_threshold` is substituted out for its numeric value