### PR TITLE
[MAINTENANCE] Enable mostly as an expectation parameter

### DIFF
--- a/great_expectations/expectations/model_field_types.py
+++ b/great_expectations/expectations/model_field_types.py
@@ -12,7 +12,7 @@ from great_expectations.expectations.model_field_descriptions import (
 )
 
 MostlyField = Annotated[
-    float,
+    Union[float, SuiteParameterDict],
     pydantic.Field(
         description=MOSTLY_DESCRIPTION,
         ge=0.0,


### PR DESCRIPTION
Add SuiteParameterDict to MostlyField


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
