### PR TITLE
[MAINTENANCE] Sqlite integration testing

### DIFF
--- a/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
@@ -15,6 +15,7 @@ from tests.integration.test_utils.data_source_config import (
     PandasFilesystemCsvDatasourceTestConfig,
     PostgreSQLDatasourceTestConfig,
     SnowflakeDatasourceTestConfig,
+    SqliteDatasourceTestConfig,
 )
 
 ALL_DATA_SOURCES: Sequence[DataSourceTestConfig] = [
@@ -24,6 +25,7 @@ ALL_DATA_SOURCES: Sequence[DataSourceTestConfig] = [
     PandasFilesystemCsvDatasourceTestConfig(),
     PostgreSQLDatasourceTestConfig(),
     SnowflakeDatasourceTestConfig(),
+    SqliteDatasourceTestConfig(),
 ]
 
 
@@ -45,6 +47,7 @@ def test_expect_column_min_to_be_between(batch_for_datasource) -> None:
         PandasFilesystemCsvDatasourceTestConfig(),
         PostgreSQLDatasourceTestConfig(column_types={"date": sqltypes.DATE}),
         SnowflakeDatasourceTestConfig(column_types={"date": sqltypes.DATE}),
+        SqliteDatasourceTestConfig(column_types={"date": sqltypes.DATE}),
     ],
     data=pd.DataFrame(
         {
@@ -74,6 +77,7 @@ def test_expect_column_min_to_be_between__date(batch_for_datasource) -> None:
         PandasFilesystemCsvDatasourceTestConfig(),
         PostgreSQLDatasourceTestConfig(column_types={"date": sqltypes.DATE}),
         SnowflakeDatasourceTestConfig(column_types={"date": sqltypes.DATE}),
+        SqliteDatasourceTestConfig(column_types={"date": sqltypes.DATE}),
     ],
     data=pd.DataFrame(
         {
@@ -142,6 +146,7 @@ class TestExpectTableRowCountToEqualOtherTable:
             MySQLDatasourceTestConfig(),
             PostgreSQLDatasourceTestConfig(),
             SnowflakeDatasourceTestConfig(),
+            SqliteDatasourceTestConfig(),
         ],
         data=pd.DataFrame({"a": [1, 2, 3, 4]}),
         extra_data={"other_table": pd.DataFrame({"col_b": ["a", "b", "c", "d"]})},
@@ -164,6 +169,7 @@ class TestExpectTableRowCountToEqualOtherTable:
                 extra_column_types={"other_table": {"col_b": sqltypes.VARCHAR}}
             ),
             SnowflakeDatasourceTestConfig(),
+            SqliteDatasourceTestConfig(),
         ],
         data=pd.DataFrame({"a": [1, 2, 3, 4]}),
         extra_data={"other_table": pd.DataFrame({"col_b": ["just_this_one!"]})},
@@ -188,6 +194,7 @@ class TestExpectTableRowCountToEqualOtherTable:
             MySQLDatasourceTestConfig(),
             PostgreSQLDatasourceTestConfig(),
             SnowflakeDatasourceTestConfig(),
+            SqliteDatasourceTestConfig(),
         ],
         data=pd.DataFrame({"a": [1, 2, 3, 4]}),
     )

--- a/tests/integration/test_utils/data_source_config/__init__.py
+++ b/tests/integration/test_utils/data_source_config/__init__.py
@@ -5,3 +5,4 @@ from .pandas_data_frame import PandasDataFrameDatasourceTestConfig
 from .pandas_filesystem_csv import PandasFilesystemCsvDatasourceTestConfig
 from .postgres import PostgreSQLDatasourceTestConfig
 from .snowflake import SnowflakeDatasourceTestConfig
+from .sqlite import SqliteDatasourceTestConfig

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -115,7 +115,7 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
             table.drop(self.engine)
 
     def _create_table_name(self, label: Optional[str] = None) -> str:
-        parts = [self.config.label, "expectation_test_table", label, self._random_resource_name()]
+        parts = ["expectation_test_table", label, self._random_resource_name()]
         return "_".join([part for part in parts if part])
 
     def _ensure_all_table_data_created(self) -> Sequence[_TableData]:

--- a/tests/integration/test_utils/data_source_config/sqlite.py
+++ b/tests/integration/test_utils/data_source_config/sqlite.py
@@ -1,0 +1,78 @@
+import pathlib
+from typing import Mapping
+
+import pandas as pd
+import pytest
+
+from great_expectations.compatibility.typing_extensions import override
+from great_expectations.datasource.fluent.interfaces import Batch
+from tests.integration.test_utils.data_source_config.base import (
+    BatchTestSetup,
+    DataSourceTestConfig,
+)
+
+
+class SqliteDatasourceTestConfig(DataSourceTestConfig):
+    @property
+    @override
+    def label(self) -> str:
+        return "sqlite"
+
+    @property
+    @override
+    def pytest_mark(self) -> pytest.MarkDecorator:
+        return pytest.mark.sqlite
+
+    @override
+    def create_batch_setup(
+        self,
+        request: pytest.FixtureRequest,
+        data: pd.DataFrame,
+        extra_data: Mapping[str, pd.DataFrame],
+    ) -> BatchTestSetup:
+        tmp_path = request.getfixturevalue("tmp_path")
+        assert isinstance(tmp_path, pathlib.Path)
+
+        return SqliteBatchTestSetup(
+            data=data,
+            config=self,
+            base_dir=tmp_path,
+            extra_data=extra_data,
+        )
+
+
+class SqliteBatchTestSetup(BatchTestSetup[SqliteDatasourceTestConfig]):
+    def __init__(
+        self,
+        config: SqliteDatasourceTestConfig,
+        data: pd.DataFrame,
+        base_dir: pathlib.Path,
+        extra_data: Mapping[str, pd.DataFrame],
+    ) -> None:
+        super().__init__(config=config, data=data)
+        self._base_dir = base_dir
+        self._extra_data = extra_data
+
+    @override
+    def make_batch(self) -> Batch:
+        name = self._random_resource_name()
+        path = self._base_dir
+
+        return (
+            self.context.data_sources.add_pandas_filesystem(name=name, base_directory=path)
+            .add_csv_asset(name=name)
+            .add_batch_definition_path(name=name, path=self.csv_path)
+            .get_batch()
+        )
+
+    @override
+    def setup(self) -> None:
+        file_path = self._base_dir / self.csv_path
+        self.data.to_csv(file_path, index=False)
+
+    @override
+    def teardown(self) -> None: ...
+
+    @property
+    def csv_path(self) -> pathlib.Path:
+        return pathlib.Path("data.csv")

--- a/tests/integration/test_utils/data_source_config/sqlite.py
+++ b/tests/integration/test_utils/data_source_config/sqlite.py
@@ -10,13 +10,14 @@ from tests.integration.test_utils.data_source_config.base import (
     BatchTestSetup,
     DataSourceTestConfig,
 )
+from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
 
 
 class SqliteDatasourceTestConfig(DataSourceTestConfig):
     @property
     @override
     def label(self) -> str:
-        return "sqlite"
+        return "_sqlite"
 
     @property
     @override
@@ -41,7 +42,7 @@ class SqliteDatasourceTestConfig(DataSourceTestConfig):
         )
 
 
-class SqliteBatchTestSetup(BatchTestSetup[SqliteDatasourceTestConfig]):
+class SqliteBatchTestSetup(SQLBatchTestSetup[SqliteDatasourceTestConfig]):
     def __init__(
         self,
         config: SqliteDatasourceTestConfig,
@@ -49,30 +50,33 @@ class SqliteBatchTestSetup(BatchTestSetup[SqliteDatasourceTestConfig]):
         base_dir: pathlib.Path,
         extra_data: Mapping[str, pd.DataFrame],
     ) -> None:
-        super().__init__(config=config, data=data)
         self._base_dir = base_dir
-        self._extra_data = extra_data
+        super().__init__(config=config, data=data, extra_data=extra_data)
+
+    @property
+    @override
+    def connection_string(self) -> str:
+        return f"sqlite:///{self.db_file_path}"
+
+    @property
+    @override
+    def schema(self) -> None:
+        return None
+
+    @property
+    def db_file_path(self) -> pathlib.Path:
+        return self._base_dir / "database.db"
 
     @override
     def make_batch(self) -> Batch:
         name = self._random_resource_name()
-        path = self._base_dir
 
         return (
-            self.context.data_sources.add_pandas_filesystem(name=name, base_directory=path)
-            .add_csv_asset(name=name)
-            .add_batch_definition_path(name=name, path=self.csv_path)
+            self.context.data_sources.add_sqlite(
+                name=name,
+                connection_string=self.connection_string,
+            )
+            .add_table_asset(name=name, table_name=self.table_name)
+            .add_batch_definition_whole_table(name=name)
             .get_batch()
         )
-
-    @override
-    def setup(self) -> None:
-        file_path = self._base_dir / self.csv_path
-        self.data.to_csv(file_path, index=False)
-
-    @override
-    def teardown(self) -> None: ...
-
-    @property
-    def csv_path(self) -> pathlib.Path:
-        return pathlib.Path("data.csv")

--- a/tests/integration/test_utils/data_source_config/sqlite.py
+++ b/tests/integration/test_utils/data_source_config/sqlite.py
@@ -17,7 +17,7 @@ class SqliteDatasourceTestConfig(DataSourceTestConfig):
     @property
     @override
     def label(self) -> str:
-        return "_sqlite"
+        return "sqlite"
 
     @property
     @override


### PR DESCRIPTION
NOTE: sqlite won't let us prefix table names with `sqlite` (we previously prefixed table names with the config's label, i.e. the datasource type). The datasource type didn't seem add any extra data (like if I'm looking at a table in snowflake, I probably know it's a snowflake table), so I just removed that from the table name.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
