### PR TITLE
[MAINTENANCE] Use random schema in integration tests

### DIFF
--- a/tests/integration/test_utils/data_source_config/mssql.py
+++ b/tests/integration/test_utils/data_source_config/mssql.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Union
+from typing import Mapping
 
 import pandas as pd
 import pytest
@@ -45,8 +45,8 @@ class MSSQLBatchTestSetup(SQLBatchTestSetup[MSSQLDatasourceTestConfig]):
 
     @property
     @override
-    def schema(self) -> Union[str, None]:
-        return None
+    def use_schema(self) -> bool:
+        return False
 
     @override
     def make_batch(self) -> Batch:

--- a/tests/integration/test_utils/data_source_config/mysql.py
+++ b/tests/integration/test_utils/data_source_config/mysql.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping, Type, Union
+from typing import Dict, Mapping, Type
 
 import pandas as pd
 import pytest
@@ -46,8 +46,8 @@ class MySQLBatchTestSetup(SQLBatchTestSetup[MySQLDatasourceTestConfig]):
 
     @property
     @override
-    def schema(self) -> Union[str, None]:
-        return None
+    def use_schema(self) -> bool:
+        return False
 
     @property
     @override

--- a/tests/integration/test_utils/data_source_config/postgres.py
+++ b/tests/integration/test_utils/data_source_config/postgres.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Union
+from typing import Mapping
 
 import pandas as pd
 import pytest
@@ -43,10 +43,10 @@ class PostgresBatchTestSetup(SQLBatchTestSetup[PostgreSQLDatasourceTestConfig]):
     def connection_string(self) -> str:
         return "postgresql+psycopg2://postgres@localhost:5432/test_ci"
 
-    @override
     @property
-    def schema(self) -> Union[str, None]:
-        return "public"
+    @override
+    def use_schema(self) -> bool:
+        return False
 
     @override
     def make_batch(self) -> Batch:

--- a/tests/integration/test_utils/data_source_config/snowflake.py
+++ b/tests/integration/test_utils/data_source_config/snowflake.py
@@ -48,15 +48,13 @@ class SnowflakeConnectionConfig(BaseSettings):
     SNOWFLAKE_PW: str
     SNOWFLAKE_ACCOUNT: str
     SNOWFLAKE_DATABASE: str
-    SNOWFLAKE_SCHEMA: str
     SNOWFLAKE_WAREHOUSE: str
     SNOWFLAKE_ROLE: str = "PUBLIC"
 
-    @property
-    def connection_string(self) -> str:
+    def connection_string(self, schema: str) -> str:
         return (
             f"snowflake://{self.SNOWFLAKE_USER}:{self.SNOWFLAKE_PW}"
-            f"@{self.SNOWFLAKE_ACCOUNT}/{self.SNOWFLAKE_DATABASE}/{self.SNOWFLAKE_SCHEMA}"
+            f"@{self.SNOWFLAKE_ACCOUNT}/{self.SNOWFLAKE_DATABASE}/{schema}"
             f"?warehouse={self.SNOWFLAKE_WAREHOUSE}&role={self.SNOWFLAKE_ROLE}"
         )
 
@@ -65,7 +63,9 @@ class SnowflakeBatchTestSetup(SQLBatchTestSetup[SnowflakeDatasourceTestConfig]):
     @property
     @override
     def connection_string(self) -> str:
-        return self.snowflake_connection_config.connection_string
+        schema = self.schema
+        assert schema
+        return self.snowflake_connection_config.connection_string(schema)
 
     @property
     @override
@@ -84,6 +84,8 @@ class SnowflakeBatchTestSetup(SQLBatchTestSetup[SnowflakeDatasourceTestConfig]):
     @override
     def make_batch(self) -> Batch:
         name = self._random_resource_name()
+        schema = self.schema
+        assert schema
         return (
             self.context.data_sources.add_snowflake(
                 name=name,
@@ -91,7 +93,7 @@ class SnowflakeBatchTestSetup(SQLBatchTestSetup[SnowflakeDatasourceTestConfig]):
                 user=self.snowflake_connection_config.SNOWFLAKE_USER,
                 password=self.snowflake_connection_config.SNOWFLAKE_PW,
                 database=self.snowflake_connection_config.SNOWFLAKE_DATABASE,
-                schema=self.snowflake_connection_config.SNOWFLAKE_SCHEMA,
+                schema=schema,
                 warehouse=self.snowflake_connection_config.SNOWFLAKE_WAREHOUSE,
                 role=self.snowflake_connection_config.SNOWFLAKE_ROLE,
             )

--- a/tests/integration/test_utils/data_source_config/snowflake.py
+++ b/tests/integration/test_utils/data_source_config/snowflake.py
@@ -51,10 +51,11 @@ class SnowflakeConnectionConfig(BaseSettings):
     SNOWFLAKE_WAREHOUSE: str
     SNOWFLAKE_ROLE: str = "PUBLIC"
 
-    def connection_string(self, schema: str) -> str:
+    @property
+    def connection_string(self) -> str:
         return (
             f"snowflake://{self.SNOWFLAKE_USER}:{self.SNOWFLAKE_PW}"
-            f"@{self.SNOWFLAKE_ACCOUNT}/{self.SNOWFLAKE_DATABASE}/{schema}"
+            f"@{self.SNOWFLAKE_ACCOUNT}/{self.SNOWFLAKE_DATABASE}"
             f"?warehouse={self.SNOWFLAKE_WAREHOUSE}&role={self.SNOWFLAKE_ROLE}"
         )
 
@@ -65,7 +66,7 @@ class SnowflakeBatchTestSetup(SQLBatchTestSetup[SnowflakeDatasourceTestConfig]):
     def connection_string(self) -> str:
         schema = self.schema
         assert schema
-        return self.snowflake_connection_config.connection_string(schema)
+        return self.snowflake_connection_config.connection_string
 
     @property
     @override

--- a/tests/integration/test_utils/data_source_config/snowflake.py
+++ b/tests/integration/test_utils/data_source_config/snowflake.py
@@ -66,8 +66,6 @@ class SnowflakeBatchTestSetup(SQLBatchTestSetup[SnowflakeDatasourceTestConfig]):
     @property
     @override
     def connection_string(self) -> str:
-        schema = self.schema
-        assert schema
         return self.snowflake_connection_config.connection_string
 
     @property

--- a/tests/integration/test_utils/data_source_config/snowflake.py
+++ b/tests/integration/test_utils/data_source_config/snowflake.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Union
+from typing import Mapping
 
 import pandas as pd
 import pytest
@@ -62,15 +62,15 @@ class SnowflakeConnectionConfig(BaseSettings):
 
 
 class SnowflakeBatchTestSetup(SQLBatchTestSetup[SnowflakeDatasourceTestConfig]):
-    @override
     @property
+    @override
     def connection_string(self) -> str:
         return self.snowflake_connection_config.connection_string
 
-    @override
     @property
-    def schema(self) -> Union[str, None]:
-        return self.snowflake_connection_config.SNOWFLAKE_SCHEMA
+    @override
+    def use_schema(self) -> bool:
+        return True
 
     def __init__(
         self,

--- a/tests/integration/test_utils/data_source_config/snowflake.py
+++ b/tests/integration/test_utils/data_source_config/snowflake.py
@@ -53,6 +53,8 @@ class SnowflakeConnectionConfig(BaseSettings):
 
     @property
     def connection_string(self) -> str:
+        # Note: we don't specify the schema here because it will be created dynamically, and we pass
+        # it into the `data_sources.add_snowflake` call.
         return (
             f"snowflake://{self.SNOWFLAKE_USER}:{self.SNOWFLAKE_PW}"
             f"@{self.SNOWFLAKE_ACCOUNT}/{self.SNOWFLAKE_DATABASE}"

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -104,16 +104,18 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
 
     @override
     def setup(self) -> None:
-        # create tables
-        all_table_data = self._ensure_all_table_data_created()
-        self.metadata.create_all(self.engine)
-
-        # insert data
         with self.engine.connect() as conn, conn.begin():
+            # create schema if needed
             if self.use_schema:
                 schema = self.schema
                 assert schema
                 conn.execute(TextClause(f"CREATE SCHEMA {schema}"))
+
+            # create tables
+            all_table_data = self._ensure_all_table_data_created()
+            self.metadata.create_all(self.engine)
+
+            # insert data
             for table_data in all_table_data:
                 # pd.DataFrame(...).to_dict("index") returns a dictionary where the keys are the row
                 # index and the values are a dict of column names mapped to column values.
@@ -135,8 +137,7 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
                 conn.execute(TextClause(f"DROP SCHEMA {schema}"))
 
     def _create_table_name(self, label: Optional[str] = None) -> str:
-        schema = f"{self.schema}." if self.use_schema else None
-        parts = [schema, "expectation_test_table", label, self._random_resource_name()]
+        parts = ["expectation_test_table", label, self._random_resource_name()]
         return "_".join([part for part in parts if part])
 
     def _ensure_all_table_data_created(self) -> Sequence[_TableData]:

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -135,7 +135,8 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
                 conn.execute(TextClause(f"DROP SCHEMA {schema}"))
 
     def _create_table_name(self, label: Optional[str] = None) -> str:
-        parts = ["expectation_test_table", label, self._random_resource_name()]
+        schema = f"{self.schema}." if self.use_schema else None
+        parts = [schema, "expectation_test_table", label, self._random_resource_name()]
         return "_".join([part for part in parts if part])
 
     def _ensure_all_table_data_created(self) -> Sequence[_TableData]:

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -106,10 +106,9 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
     def setup(self) -> None:
         with self.engine.connect() as conn, conn.begin():
             # create schema if needed
-            if self.use_schema:
-                schema = self.schema
-                assert schema
-                conn.execute(TextClause(f"CREATE SCHEMA {schema}"))
+
+            if self.schema:
+                conn.execute(TextClause(f"CREATE SCHEMA {self.schema}"))
 
             # create tables
             all_table_data = self._ensure_all_table_data_created()
@@ -131,10 +130,8 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
         for table in self.tables:
             table.drop(self.engine)
         with self.engine.connect() as conn, conn.begin():
-            if self.use_schema:
-                schema = self.schema
-                assert schema
-                conn.execute(TextClause(f"DROP SCHEMA {schema}"))
+            if self.schema:
+                conn.execute(TextClause(f"DROP SCHEMA {self.schema}"))
 
     def _create_table_name(self, label: Optional[str] = None) -> str:
         parts = ["expectation_test_table", label, self._random_resource_name()]

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Dict, Generic, Mapping, Optional, Sequence, Type, Union
 
+from sqlalchemy import TextClause
 from typing_extensions import override
 
 from great_expectations.compatibility.sqlalchemy import (
@@ -38,8 +39,11 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
 
     @property
     @abstractmethod
-    def schema(self) -> Union[str, None]:
-        """Schema -- if any -- to use when connecting to SQL backend."""
+    def use_schema(self) -> bool:
+        """Whether to use a schema when connecting to SQL backend.
+
+        If `True`, a schema will be automatically created.
+        """
 
     @property
     def inferrable_types_lookup(self) -> Dict[Type, TypeEngine]:
@@ -91,6 +95,13 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
         extra_tables = [td.table for td in self.extra_table_data.values()]
         return [self.main_table_data.table, *extra_tables]
 
+    @cached_property
+    def schema(self) -> Union[str, None]:
+        if self.use_schema:
+            return self._random_resource_name()
+        else:
+            return None
+
     @override
     def setup(self) -> None:
         # create tables
@@ -99,6 +110,10 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
 
         # insert data
         with self.engine.connect() as conn, conn.begin():
+            if self.use_schema:
+                schema = self.schema
+                assert schema
+                conn.execute(TextClause(f"CREATE SCHEMA IF NOT EXISTS {schema}"))
             for table_data in all_table_data:
                 # pd.DataFrame(...).to_dict("index") returns a dictionary where the keys are the row
                 # index and the values are a dict of column names mapped to column values.

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Dict, Generic, Mapping, Optional, Sequence, Type, Union
 
-from sqlalchemy import TextClause
 from typing_extensions import override
 
 from great_expectations.compatibility.sqlalchemy import (
     Column,
     MetaData,
     Table,
+    TextClause,
     create_engine,
     insert,
     sqltypes,

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -129,8 +129,8 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
     def teardown(self) -> None:
         for table in self.tables:
             table.drop(self.engine)
-        with self.engine.connect() as conn, conn.begin():
-            if self.schema:
+        if self.schema:
+            with self.engine.connect() as conn, conn.begin():
                 conn.execute(TextClause(f"DROP SCHEMA {self.schema}"))
 
     def _create_table_name(self, label: Optional[str] = None) -> str:

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -113,7 +113,7 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
             if self.use_schema:
                 schema = self.schema
                 assert schema
-                conn.execute(TextClause(f"CREATE SCHEMA IF NOT EXISTS {schema}"))
+                conn.execute(TextClause(f"CREATE SCHEMA {schema}"))
             for table_data in all_table_data:
                 # pd.DataFrame(...).to_dict("index") returns a dictionary where the keys are the row
                 # index and the values are a dict of column names mapped to column values.
@@ -128,6 +128,11 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
     def teardown(self) -> None:
         for table in self.tables:
             table.drop(self.engine)
+        with self.engine.connect() as conn, conn.begin():
+            if self.use_schema:
+                schema = self.schema
+                assert schema
+                conn.execute(TextClause(f"DROP SCHEMA {schema}"))
 
     def _create_table_name(self, label: Optional[str] = None) -> str:
         parts = ["expectation_test_table", label, self._random_resource_name()]

--- a/tests/integration/test_utils/data_source_config/sqlite.py
+++ b/tests/integration/test_utils/data_source_config/sqlite.py
@@ -60,8 +60,8 @@ class SqliteBatchTestSetup(SQLBatchTestSetup[SqliteDatasourceTestConfig]):
 
     @property
     @override
-    def schema(self) -> None:
-        return None
+    def use_schema(self) -> bool:
+        return False
 
     @property
     def db_file_path(self) -> pathlib.Path:


### PR DESCRIPTION
* replaces the abstract `schema` with an abstract bool `use_schema`
* implements a new `schema` at the parent class to randomize the schema name
* If `use_schema` is `True`, creates a random schema
NOTE: This allows us to basically revert a lot of https://github.com/great-expectations/great_expectations/pull/10630. I'll get that in a follow-up PR.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
