### PR TITLE
[DOCS] Remove install instructions for redshift and trino

### DIFF
--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql_dialect_installation_commands.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql_dialect_installation_commands.md
@@ -8,6 +8,5 @@ The following table lists the installation commands used to install GX Core depe
 | BigQuery | `pip install 'great_expectations[bigquery]'` |
 | MSSQL | `pip install 'great_expectations[mssql]'` |
 | PostgreSQL | `pip install 'great_expectations[postgresql]'` |
-| Redshift | `pip install 'great_expectations[redshift]'` |
 | Snowflake | `pip install 'great_expectations[snowflake]'` |
 | Trino | `pip install 'great_expectations[trino]'` |

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql_dialect_installation_commands.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql_dialect_installation_commands.md
@@ -9,4 +9,3 @@ The following table lists the installation commands used to install GX Core depe
 | MSSQL | `pip install 'great_expectations[mssql]'` |
 | PostgreSQL | `pip install 'great_expectations[postgresql]'` |
 | Snowflake | `pip install 'great_expectations[snowflake]'` |
-| Trino | `pip install 'great_expectations[trino]'` |


### PR DESCRIPTION
We no longer officially support redshift, so it shouldn't be referenced in our docs..

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
