### PR TITLE
[MAINTENANCE] Reduce test duration of flakey test

### DIFF
--- a/tests/expectations/core/test_expect_column_values_to_be_of_type.py
+++ b/tests/expectations/core/test_expect_column_values_to_be_of_type.py
@@ -109,11 +109,11 @@ def test_expect_column_values_to_be_in_set_render_performance():
     This test prevents a historical bug in which rendering took ~10 seconds to render 400 items.
     """
 
-    large_number = 400
+    large_number = 1500
 
     x = ExpectColumnValuesToBeInSet(
         column="foo_column_name", value_set=["foo" for _ in range(large_number)]
     )
 
     duration_s = timeit.timeit(x.render, number=1)
-    assert duration_s < 2, f"Rendering took {duration_s} seconds"
+    assert duration_s < 1, f"Rendering took {duration_s} seconds"

--- a/tests/expectations/core/test_expect_column_values_to_be_of_type.py
+++ b/tests/expectations/core/test_expect_column_values_to_be_of_type.py
@@ -109,7 +109,7 @@ def test_expect_column_values_to_be_in_set_render_performance():
     This test prevents a historical bug in which rendering took ~10 seconds to render 400 items.
     """
 
-    large_number = 1500
+    large_number = 150
 
     x = ExpectColumnValuesToBeInSet(
         column="foo_column_name", value_set=["foo" for _ in range(large_number)]


### PR DESCRIPTION
This test fails with some regularity in CI, but not in the way the test expects. See [this example](https://github.com/great-expectations/great_expectations/actions/runs/11824674689/job/32946716375). It fails with `Failed: Timeout >2.0s` because we currently invoke pytest with `--timeout=2`, so we would would never fail the assertion as written.

We could also throw a `mark.pytest.slow` on this instead of cutting the time in half, but I'm not sure if that matters.

The fix here:
* Reduce the expected time and `large_number` by half so we can see the expected error if appropriate. I'm assuming complexity is O(n) with `large_number`.
* Then reduce `large_number` by another 25% to avoid the flakiness.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
