### PR TITLE
[MAINTENANCE] Use the table name the test passes in

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,6 @@ from tests.integration.test_utils.data_source_config.base import (
     dict_to_tuple,
     hash_data_frame,
 )
-from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
 
 _F = TypeVar("_F", bound=Callable)
 
@@ -162,12 +161,3 @@ def batch_for_datasource(
     """
     set_context(_batch_setup_for_datasource.context)
     yield _batch_setup_for_datasource.make_batch()
-
-
-@pytest.fixture
-def extra_table_names_for_datasource(
-    _batch_setup_for_datasource: BatchTestSetup,
-) -> Generator[Mapping[str, str], None, None]:
-    """Fixture that yields extra table names"""
-    assert isinstance(_batch_setup_for_datasource, SQLBatchTestSetup)
-    yield {key: t.name for key, t in _batch_setup_for_datasource.extra_table_data.items()}

--- a/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Mapping, Sequence
+from typing import Sequence
 
 import pandas as pd
 
@@ -144,10 +144,8 @@ class TestExpectTableRowCountToEqualOtherTable:
     def test_success(
         self,
         batch_for_datasource: Batch,
-        extra_table_names_for_datasource: Mapping[str, str],
     ):
-        other_table_name = extra_table_names_for_datasource["other_table"]
-        expectation = gxe.ExpectTableRowCountToEqualOtherTable(other_table_name=other_table_name)
+        expectation = gxe.ExpectTableRowCountToEqualOtherTable(other_table_name="other_table")
         result = batch_for_datasource.validate(expectation)
         assert result.success
 
@@ -159,10 +157,8 @@ class TestExpectTableRowCountToEqualOtherTable:
     def test_different_counts(
         self,
         batch_for_datasource: Batch,
-        extra_table_names_for_datasource: Mapping[str, str],
     ):
-        other_table_name = extra_table_names_for_datasource["other_table"]
-        expectation = gxe.ExpectTableRowCountToEqualOtherTable(other_table_name=other_table_name)
+        expectation = gxe.ExpectTableRowCountToEqualOtherTable(other_table_name="other_table")
         result = batch_for_datasource.validate(expectation)
         assert not result.success
         assert result.result["observed_value"] == {

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -85,12 +85,12 @@ class SQLBatchTestSetup(BatchTestSetup, ABC, Generic[_ConfigT]):
     @cached_property
     def extra_table_data(self) -> Mapping[str, _TableData]:
         return {
-            label: self._create_table_data(
-                name=self._create_table_name(label),
+            name: self._create_table_data(
+                name=name,
                 df=df,
-                column_types=self.config.extra_column_types.get(label, {}),
+                column_types=self.config.extra_column_types.get(name, {}),
             )
-            for label, df in self.extra_data.items()
+            for name, df in self.extra_data.items()
         }
 
     @cached_property


### PR DESCRIPTION
Previously we randomized these to prevent collisions between tests, but we are now randomizing the schemas per test, so we can just use the name users pass in.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
