### PR TITLE
[DOCS] Add databricks to supported datasources in corresponding expectations

### DIFF
--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -55,6 +55,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Sets"]
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -46,6 +46,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Sets"]
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -46,6 +46,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Sets"]
 

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -65,6 +65,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Numerical data"]
 

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -57,6 +57,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Numerical data"]
 

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -53,6 +53,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Numerical data"]
 

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -58,6 +58,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Numerical data"]
 

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -52,6 +52,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Sets"]
 

--- a/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
@@ -45,6 +45,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Distribution"]
 

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -45,6 +45,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Data integrity"]
 

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -60,6 +60,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Cardinality"]
 

--- a/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
@@ -53,6 +53,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Distribution"]
 

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -48,6 +48,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Distribution"]
 

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -45,6 +45,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -56,6 +56,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Cardinality"]
 

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -71,6 +71,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 
 

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
@@ -50,6 +50,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 
 

--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -45,6 +45,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -54,6 +54,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -57,6 +57,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Sets"]
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -71,6 +71,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -57,6 +57,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Missingness"]
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -90,6 +90,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -44,6 +44,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Cardinality"]
 

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
@@ -40,7 +40,7 @@ EXPECTATION_SHORT_DESCRIPTION = (
 )
 LIKE_PATTERN_DESCRIPTION = "The SQL like pattern expression the column entries should match."
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToMatchLikePattern(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -46,7 +46,7 @@ MATCH_ON_DESCRIPTION = (
     "Use 'all' if it should match each like pattern in the list."
 )
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -40,7 +40,7 @@ EXPECTATION_SHORT_DESCRIPTION = (
 )
 REGEX_DESCRIPTION = "The regular expression the column entries should match."
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -47,7 +47,7 @@ MATCH_ON_DESCRIPTION = (
     "Use 'all' if it should match each regular expression in the list."
 )
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -51,6 +51,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 
 

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -56,6 +56,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Missingness"]
 

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -36,7 +36,7 @@ EXPECTATION_SHORT_DESCRIPTION = (
 )
 LIKE_PATTERN_DESCRIPTION = "The SQL like pattern expression the column entries should NOT match."
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -41,7 +41,7 @@ LIKE_PATTERN_LIST_DESCRIPTION = (
     "The list of SQL like pattern expressions the column entries should NOT match."
 )
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -49,7 +49,7 @@ EXPECTATION_SHORT_DESCRIPTION = (
 )
 REGEX_DESCRIPTION = "The regular expression the column entries should NOT match."
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -43,7 +43,7 @@ REGEX_LIST_DESCRIPTION = (
     "The list of regular expressions which the column entries should not match."
 )
 DATA_QUALITY_ISSUES = ["Pattern matching"]
-SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["Pandas", "Spark", "PostgreSQL", "MySQL", "Redshift", "Databricks (SQL)"]
 
 
 class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -43,6 +43,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Cardinality"]
 

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -43,7 +43,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Cardinality"]
 

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -50,6 +50,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Data integrity"]
 

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -50,7 +50,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Data integrity"]
 

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -47,6 +47,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Cardinality"]
 

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -47,7 +47,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Cardinality"]
 

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -43,7 +43,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -43,6 +43,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -40,7 +40,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -40,6 +40,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -41,7 +41,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -41,6 +41,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -45,7 +45,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -45,6 +45,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Schema"]
 

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -47,6 +47,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Volume"]
 

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -47,7 +47,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Volume"]
 

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -41,7 +41,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
-    "Databricks (SQL)"
+    "Databricks (SQL)",
 ]
 DATA_QUALITY_ISSUES = ["Volume"]
 

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -41,6 +41,7 @@ SUPPORTED_DATA_SOURCES = [
     "Redshift",
     "BigQuery",
     "Snowflake",
+    "Databricks (SQL)"
 ]
 DATA_QUALITY_ISSUES = ["Volume"]
 

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -41,7 +41,7 @@ EXPECTATION_SHORT_DESCRIPTION = (
 OTHER_TABLE_NAME_DESCRIPTION = (
     "The name of the other table. Other table must be located within the same database."
 )
-SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift"]
+SUPPORTED_DATA_SOURCES = ["SQLite", "PostgreSQL", "MySQL", "MSSQL", "Redshift", "Databricks (SQL)"]
 DATA_QUALITY_ISSUES = ["Volume"]
 
 

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -217,7 +217,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -217,7 +217,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -217,7 +217,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -198,7 +198,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -198,7 +198,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -198,7 +198,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -198,7 +198,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -222,7 +222,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -176,7 +176,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -172,7 +172,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -215,7 +215,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -198,7 +198,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -197,7 +197,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -144,7 +144,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -215,7 +215,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -199,7 +199,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -167,7 +167,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -179,7 +179,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -206,7 +206,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -226,7 +226,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -170,7 +170,8 @@
                         "Trino",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -155,7 +155,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -160,7 +160,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -154,7 +154,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -163,7 +163,8 @@
                         "PostgreSQL",
                         "MySQL",
                         "MSSQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -176,7 +176,8 @@
                         "PostgreSQL",
                         "MySQL",
                         "MSSQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -164,7 +164,8 @@
                         "Spark",
                         "PostgreSQL",
                         "MySQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -176,7 +176,8 @@
                         "Spark",
                         "PostgreSQL",
                         "MySQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -226,7 +226,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -155,7 +155,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -163,7 +163,8 @@
                         "PostgreSQL",
                         "MySQL",
                         "MSSQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -166,7 +166,8 @@
                         "PostgreSQL",
                         "MySQL",
                         "MSSQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -163,7 +163,8 @@
                         "Spark",
                         "PostgreSQL",
                         "MySQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -166,7 +166,8 @@
                         "Spark",
                         "PostgreSQL",
                         "MySQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -167,7 +167,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -173,7 +173,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -163,7 +163,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
@@ -166,7 +166,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
@@ -138,7 +138,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -144,7 +144,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -149,7 +149,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -172,7 +172,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -152,7 +152,8 @@
                         "MSSQL",
                         "Redshift",
                         "BigQuery",
-                        "Snowflake"
+                        "Snowflake",
+                        "Databricks (SQL)"
                     ]
                 }
             }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -142,7 +142,8 @@
                         "PostgreSQL",
                         "MySQL",
                         "MSSQL",
-                        "Redshift"
+                        "Redshift",
+                        "Databricks (SQL)"
                     ]
                 }
             }


### PR DESCRIPTION
## Description
Adds Databricks as a supported datasource to corresponding expectations, which are all the ones that are displayed in expectations gallery except:
- ExpectColumnPairValuesToBeInSet
- ExpectColumnKLDivergenceToBeLessThan
- ExpectColumnQuantileValuesToBeBetween

JIRA Ticket: https://greatexpectations.atlassian.net/browse/DSB-1198

---

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
