### PR TITLE
[BUGFIX] Set metric id at metric config initialization.

### DIFF
--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -51,6 +51,12 @@ class MetricConfiguration:
 
         self._metric_dependencies: IDDict = IDDict({})
 
+        self._id = (
+            self.metric_name,
+            self.metric_domain_kwargs_id,
+            self.metric_value_kwargs_id,
+        )
+
     def __repr__(self):  # type: ignore[explicit-override] # FIXME
         return json.dumps(self.to_json_dict(), indent=2)
 
@@ -153,11 +159,7 @@ class MetricConfiguration:
 
     @property
     def id(self) -> Tuple[str, str, str]:
-        return (
-            self.metric_name,
-            self.metric_domain_kwargs_id,
-            self.metric_value_kwargs_id,
-        )
+        return self._id
 
     def to_json_dict(self) -> dict:
         """Returns a JSON-serializable dict representation of this MetricConfiguration.


### PR DESCRIPTION
This is an experiment. If I like the results I will add tests, update this description, and ask for a review.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
