### PR TITLE
[CONTRIB] Handle connection error during version check

### DIFF
--- a/great_expectations/data_context/_version_checker.py
+++ b/great_expectations/data_context/_version_checker.py
@@ -54,7 +54,9 @@ class _VersionChecker:
         except requests.HTTPError as http_err:
             logger.debug(f"An HTTP error occurred when trying to hit PyPI API: {http_err}")
         except requests.Timeout as timeout_exc:
-            logger.debug(f"Failed to hit the PyPI API due a timeout error: {timeout_exc}")
+            logger.debug(f"Failed to hit the PyPI API due to a timeout error: {timeout_exc}")
+        except requests.ConnectionError as connection_err:
+            logger.debug(f"Failed to hit the PyPI API due to a connection error: {connection_err}")
 
         if not response_json:
             return None


### PR DESCRIPTION
We are currently having an issue merging contributor PRs because of a permissions issue. This PR is @stejin's [PR](https://github.com/great-expectations/great_expectations/pull/10650/) which I've co-authored to work around the permissions issue for the moment.  

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
