### PR TITLE
[BUGFIX] check for variance in validator and batch asset

### DIFF
--- a/great_expectations/experimental/metric_repository/metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_retriever.py
@@ -48,6 +48,11 @@ class MetricRetriever(abc.ABC):
     def get_validator(self, batch_request: BatchRequest) -> Validator:
         if self._validator is None:
             self._validator = self._context.get_validator(batch_request=batch_request)
+
+        if isinstance(self._validator.active_batch, Batch):
+            if self._validator.active_batch.data_asset.name != batch_request.data_asset_name:
+                self._validator = self._context.get_validator(batch_request=batch_request)
+
         return self._validator
 
     @abc.abstractmethod

--- a/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
@@ -4,7 +4,7 @@ import pytest
 
 from great_expectations.data_context import CloudDataContext
 from great_expectations.datasource.fluent import BatchRequest
-from great_expectations.datasource.fluent.interfaces import Batch
+from great_expectations.datasource.fluent.interfaces import Batch, DataAsset
 from great_expectations.experimental.metric_repository.metric_list_metric_retriever import (
     MetricListMetricRetriever,
 )
@@ -28,6 +28,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function")
+def mock_data_asset(mocker):
+    data_asset = mocker.Mock(spec=DataAsset)
+    data_asset.name = "some_data_asset_name"
+    return data_asset
+
+
+@pytest.fixture(scope="function")
 def mock_validator(mocker, mock_batch):
     validator = mocker.Mock(spec=Validator)
     validator.active_batch = mock_batch
@@ -42,9 +49,10 @@ def mock_context(mocker, mock_validator):
 
 
 @pytest.fixture(scope="function")
-def mock_batch(mocker):
+def mock_batch(mocker, mock_data_asset):
     batch = mocker.Mock(spec=Batch)
     batch.id = "batch_id"
+    batch.data_asset = mock_data_asset
     return batch
 
 
@@ -55,7 +63,16 @@ def metric_retriever(mock_context):
 
 @pytest.fixture(scope="function")
 def mock_batch_request(mocker):
-    return mocker.Mock(spec=BatchRequest)
+    batch_request = mocker.Mock(spec=BatchRequest)
+    batch_request.data_asset_name = "some_data_asset_name"
+    return batch_request
+
+
+@pytest.fixture(scope="function")
+def mock_batch_request_variant(mocker):
+    batch_request = mocker.Mock(spec=BatchRequest)
+    batch_request.data_asset_name = "other_data_asset_name"
+    return batch_request
 
 
 def test_get_metrics_table_metrics_only(
@@ -652,6 +669,42 @@ def test_get_metrics_only_gets_a_validator_once(
     metric_retriever.get_metrics(batch_request=mock_batch_request, metric_list=metrics_list)
 
     mock_context.get_validator.assert_called_once_with(batch_request=mock_batch_request)
+
+
+def test_get_metrics_only_gets_new_validator_on_asset_change(
+    mocker: MockerFixture,
+    mock_context,
+    mock_validator,
+    mock_batch_request_variant,
+    metric_retriever,
+):
+    aborted_metrics = {}
+
+    computed_metrics = {
+        ("table.row_count", (), ()): 2,
+        ("table.columns", (), ()): ["col1", "col2"],
+        ("table.column_types", (), "include_nested=True"): [
+            {"name": "col1", "type": "float"},
+            {"name": "col2", "type": "float"},
+        ],
+    }
+    metrics_list: List[MetricTypes] = [
+        MetricTypes.TABLE_ROW_COUNT,
+        MetricTypes.TABLE_COLUMNS,
+        MetricTypes.TABLE_COLUMN_TYPES,
+    ]
+    mock_validator.compute_metrics.return_value = (
+        computed_metrics,
+        aborted_metrics,
+    )
+    mocker.patch(
+        f"{ColumnDomainBuilder.__module__}.{ColumnDomainBuilder.__name__}.get_effective_column_names",
+        return_value=["col1", "col2"],
+    )
+    metric_retriever.get_metrics(batch_request=mock_batch_request_variant, metric_list=metrics_list)
+
+    assert mock_context.get_validator.call_count == 4
+    mock_context.get_validator.assert_called_with(batch_request=mock_batch_request_variant)
 
 
 def test_get_metrics_with_no_metrics(


### PR DESCRIPTION
When fetching metrics for multiple assets in a single call, the metric_retriever caches the prior data asset and causes an erroneous fetch of subsequent asset metrics.

This adds a check against the stored batch in the validator and the incoming batch request.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
