### PR TITLE
[BUGFIX] Default `exact_match` to `True` for `ExpectTableColumnsToMatchSet`

### DIFF
--- a/docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_validation_over_time.py
+++ b/docs/docusaurus/docs/reference/learn/data_quality_use_cases/schema_resources/schema_validation_over_time.py
@@ -69,7 +69,8 @@ suite.add_expectation(
             "recipient_fullname",
             "transfer_amount",
             "transfer_date",
-        ]
+        ],
+        exact_match=False,
     )
 )
 suite.add_expectation(gxe.ExpectTableColumnCountToEqual(value=5))

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -171,7 +171,7 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
         description=COLUMN_SET_DESCRIPTION
     )
     exact_match: Union[bool, None] = pydantic.Field(
-        default=None, description=EXACT_MATCH_DESCRIPTION
+        default=True, description=EXACT_MATCH_DESCRIPTION
     )
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -87,6 +87,7 @@
         "exact_match": {
             "title": "Exact Match",
             "description": "If True, the list of columns must exactly match the observed columns. If False, observed columns must include column_set but additional columns will pass.",
+            "default": true,
             "type": "boolean"
         },
         "metadata": {

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
@@ -64,7 +64,6 @@ def test_success(
         ),
         pytest.param(
             gxe.ExpectTableColumnsToMatchSet(column_set=[COL_A]),
-            marks=pytest.mark.xfail,
             id="defaults_to_exact_match",
         ),
         pytest.param(


### PR DESCRIPTION
The implementation didn't match [the docs in the gallery](https://greatexpectations.io/expectations/expect_table_columns_to_match_set).

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
