### PR TITLE
[MAINTENANCE] Simplify bigquery assertion

### DIFF
--- a/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
@@ -67,7 +67,7 @@ class TestNumericExpectationAgainstStrDataMisconfiguration:
     def test_bigquery(self, batch_for_datasource) -> None:
         self._assert_misconfiguration(
             batch_for_datasource=batch_for_datasource,
-            exception_message="No matching signature for operator * for argument types: FLOAT64, STRING",  # noqa: E501
+            exception_message="No matching signature for operator *",
         )
 
     @parameterize_batch_for_data_sources(


### PR DESCRIPTION
Looks to me like bigquery updated their error message. Rather than be too prescriptive, I just loosened the error that we show. Ideally we'd be wrapping this and controlling the error msg, but we aren't.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
