### PR TITLE
[BUGFIX] Renderer for UnexpectedRowsExpectation

### DIFF
--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -8,6 +8,7 @@ import pytest
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.expectations import UnexpectedRowsExpectation
 from great_expectations.expectations.metrics.util import MAX_RESULT_RECORDS
+from great_expectations.render.renderer.content_block.content_block import ContentBlockRenderer
 
 if TYPE_CHECKING:
     from great_expectations.data_context import AbstractDataContext
@@ -144,3 +145,17 @@ def test_unexpected_rows_expectation_render(
         == "$unexpected_rows_query"
     )
     assert expectation.rendered_content[0].value.code_block.get("language") == "sql"
+
+
+@pytest.mark.unit
+def test_data_docs_rendering():
+    query = "SELECT * FROM {batch} WHERE passenger_count > 7"
+    expectation = UnexpectedRowsExpectation(unexpected_rows_query=query)
+    results = ContentBlockRenderer.render(expectation.configuration)
+    assert isinstance(results, list) and len(results) == 1
+    result = results[0]
+    assert result.string_template == {
+        "template": "Unexpected rows query: $unexpected_rows_query",
+        "params": {"unexpected_rows_query": query},
+        "styling": {},
+    }


### PR DESCRIPTION
Here's what it looks like:

![Screenshot 2024-12-12 at 10 12 31 AM](https://github.com/user-attachments/assets/d2314329-99b7-4637-a7d7-1fc416ec4016)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
