### PR TITLE
[Docs] Remove `print(validation_results.result_url)` as it isn't supported

### DIFF
--- a/docs/docusaurus/docs/core/run_validations/run_a_validation_definition.md
+++ b/docs/docusaurus/docs/core/run_validations/run_a_validation_definition.md
@@ -58,16 +58,6 @@ import PrereqValidationDefinition from '../_core_components/prerequisites/_valid
    
    When you print the returned Validation Result object you will recieve a json representation of the results.  By default this will include a `"results"` list that includes each Expectation in your Validation Definition's Expectation Suite, whether the Expectation was successfully met or failed to pass, and some sumarized information explaining the why the Expectation succeeded or failed.
 
-   :::tip Result presentation
-
-   When using a [GX Cloud Data Context](/core/set_up_a_gx_environment/create_a_data_context.md?context_type=gx_cloud), you can view the Validation Results in the GX Cloud UI by following the url provided with:
-
-   ```python title="Python"
-   print(validation_results.result_url)
-   ```
-
-   :::
-
 </TabItem>
 
 <TabItem value="sample_code" label="Sample code">


### PR DESCRIPTION
This issueless PR removes a non-functional tip per discussion at https://greatexpectationslabs.slack.com/archives/C05V0M18TEJ/p1733932067177219?thread_ts=1733869614.354059&cid=C05V0M18TEJ

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [X] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
