### PR TITLE
[DOCS] Clarify Connect GX Cloud landing page

### DIFF
--- a/docs/docusaurus/docs/cloud/connect/connect_lp.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_lp.md
@@ -11,7 +11,7 @@ import LinkCard from '@site/src/components/LinkCard';
 import OverviewCard from '@site/src/components/OverviewCard';
 
 <OverviewCard title={frontMatter.title}>
-  Connect GX Cloud to your deployment environment. To connect to a Data Source not currently available in GX Cloud, see [Connect to data](/core/connect_to_data/connect_to_data.md) in the GX Core documentation. 
+  Connect GX Cloud to your deployment environment. To connect to a Data Source not currently available in GX Cloud, use [GX Core](/core/connect_to_data/connect_to_data.md).
 </OverviewCard>
 
 <LinkCardGrid>


### PR DESCRIPTION
This issueless PR clarifies the Connect GX Cloud landing page per a devrel discussion today

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [X] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
