### PR TITLE
[BUGFIX] Handle expectation description from cloud

### DIFF
--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -41,6 +41,7 @@ class ExpectationConfigurationDTO(pydantic.BaseModel):
     rendered_content: List[dict] = pydantic.Field(default_factory=list)
     kwargs: dict
     meta: Union[dict, None]
+    description: Union[str, None]
     expectation_context: Union[dict, None]
 
 

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -196,6 +196,24 @@ _SUITE_CONFIG_WITH_EXPECTATIONS = _create_suite_config(
     [
         {
             "type": "expect_column_to_exist",
+            "description": None,
+            "id": "c8a239a6-fb80-4f51-a90e-40c38dffdf91",
+            "kwargs": {"column": "infinities"},
+            "meta": {},
+            "expectation_context": None,
+            "rendered_content": [],
+        }
+    ],
+)
+
+# this should have non-null values
+_SUITE_CONFIG_WITH_FULLY_POPULATED_EXPECTATIONS = _create_suite_config(
+    "my_suite_with_expectations",
+    "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+    [
+        {
+            "type": "expect_column_to_exist",
+            "description": "some description",
             "id": "c8a239a6-fb80-4f51-a90e-40c38dffdf91",
             "kwargs": {"column": "infinities"},
             "meta": {},
@@ -226,6 +244,12 @@ _SUITE_CONFIG_WITH_EXPECTATIONS = _create_suite_config(
         pytest.param(
             {"data": _SUITE_CONFIG_WITH_EXPECTATIONS},
             _SUITE_CONFIG_WITH_EXPECTATIONS,
+            None,
+            id="null_result_format",
+        ),
+        pytest.param(
+            {"data": _SUITE_CONFIG_WITH_FULLY_POPULATED_EXPECTATIONS},
+            _SUITE_CONFIG_WITH_FULLY_POPULATED_EXPECTATIONS,
             None,
             id="null_result_format",
         ),

--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -8,6 +8,7 @@ import pytest
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.expectations import UnexpectedRowsExpectation
 from great_expectations.expectations.metrics.util import MAX_RESULT_RECORDS
+from great_expectations.render.renderer.content_block.content_block import ContentBlockRenderer
 
 if TYPE_CHECKING:
     from great_expectations.data_context import AbstractDataContext
@@ -144,3 +145,17 @@ def test_unexpected_rows_expectation_render(
         == "$unexpected_rows_query"
     )
     assert expectation.rendered_content[0].value.code_block.get("language") == "sql"
+
+
+@pytest.mark.unit
+def test_data_docs_rendering():
+    query = "SELECT * FROM {batch} WHERE passenger_count > 7"
+    expectation = UnexpectedRowsExpectation(unexpected_rows_query=query)
+    results = ContentBlockRenderer.render(expectation.configuration)
+    assert isinstance(results, list) and len(results) == 1
+    result = results[0]
+    assert result.string_template == {
+        "template": "Unexpected rows query: $unexpected_rows_query",
+        "params": {"unexpected_rows_query": query},
+        "styling": {},
+    }


### PR DESCRIPTION
NOTE: This is dependent on a change to GX cloud, but is compatible with older version of cloud, so we are safe to merge.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
