### PR TITLE
[DOCS] Fix underline in links on inline code

### DIFF
--- a/docs/docusaurus/src/css/custom.scss
+++ b/docs/docusaurus/src/css/custom.scss
@@ -143,6 +143,10 @@ h3 {
     padding: 0 var(--ifm-pre-padding);
 }
 
+a code {
+  vertical-align: text-top;
+}
+
 /*footer*/
 
 .footer__items {

--- a/docs/docusaurus/src/css/custom.scss
+++ b/docs/docusaurus/src/css/custom.scss
@@ -144,7 +144,7 @@ h3 {
 }
 
 a code {
-  vertical-align: text-top;
+  vertical-align: top;
 }
 
 /*footer*/


### PR DESCRIPTION
[Jira Ticket](https://greatexpectations.atlassian.net/jira/software/c/projects/DSB/boards/79?assignee=712020%3A309fac2a-9c8e-412d-aa31-c2bbd94510b0&assignee=5b3bc63c7954ee2e97ae760a&selectedIssue=DOC-912)

[Deploy Preview](https://deploy-preview-10783.docs.greatexpectations.io/docs/reference/learn/data_quality_use_cases/missingness/#avoid-common-missingness-pitfalls)

In some browsers its hard to read.
Using chrome Version 129.0.6668.103 (Official Build) (arm64) and MacOS Sonoma 14.7 its displayed like this: 
![image](https://github.com/user-attachments/assets/ab51fab5-5d15-4256-b7fe-5a4a0184360f)

## After Changes:
![image](https://github.com/user-attachments/assets/7874851c-ceb7-4a29-a4bc-a290c8321fc3)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
