### PR TITLE
[BUGFIX] Fix expectation description rendering in DataDocs

### DIFF
--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -299,8 +299,9 @@ diagnose and repair the underlying issue.  Detailed information follows:
             raise ValueError("Cannot render an expectation with no description.")  # noqa: TRY003
         # If we wish to support $VAR substitution, we should use RenderedStringTemplateContent with params  # noqa: E501
         return [
-            RenderedMarkdownContent(
-                markdown=description, styling=runtime_configuration.get("styling", {})
+            RenderedStringTemplateContent(
+                string_template={"template": description},
+                styling=runtime_configuration.get("styling", {}),
             )
         ]
 

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -297,7 +297,6 @@ diagnose and repair the underlying issue.  Detailed information follows:
         description = expectation.description
         if not description:
             raise ValueError("Cannot render an expectation with no description.")  # noqa: TRY003
-        # If we wish to support $VAR substitution, we should use RenderedStringTemplateContent with params  # noqa: E501
         return [
             RenderedStringTemplateContent(
                 string_template={"template": description},

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -80,7 +80,7 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
 
     @override
     @classmethod
-    def _get_content_block_fn(  # noqa: C901, PLR0915
+    def _get_content_block_fn(  # noqa: C901
         cls,
         expectation_type: str,
         expectation_config: ExpectationConfiguration | None = None,
@@ -88,8 +88,6 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
         content_block_fn = super()._get_content_block_fn(
             expectation_type=expectation_type, expectation_config=expectation_config
         )
-        if content_block_fn == cls._render_expectation_description:
-            return content_block_fn
 
         expectation_string_fn = content_block_fn
         if expectation_string_fn is None:

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -1130,9 +1130,9 @@ def test_ExpectationSuiteColumnSectionRenderer_render_expectation_with_descripti
 
     content_block = result.content_blocks[1]
     content = content_block.bullet_list[0]
-    markdown = content.markdown
-
-    assert markdown == expectation.description
+    assert content.string_template == {
+        "template": "column values must be a legal adult age (**18** or older)"
+    }
 
 
 @pytest.mark.unit
@@ -1588,10 +1588,10 @@ def test_ValidationResultsTableContentBlockRenderer_render_evr_with_description(
     result = ValidationResultsColumnSectionRenderer().render([evr])
 
     content_block = result.content_blocks[1]
-    content = content_block.table[0]
-    markdown = content.markdown
-
-    assert markdown == expectation.description
+    _, description_cell, _ = content_block.table[0]
+    assert description_cell.string_template == {
+        "template": "column values must be a legal adult age (**18** or older)"
+    }
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
The primary source of the bug was that we early exited with the description renderer if `content_block_fn == cls._render_expectation_description`. That ended up meaning our whole table row was represented by the description renderer dict, which had the keys `markdown`, `style`, etc. When we later iterate through the "cells" for the row later, it ended up just being the keys to that dict. By not early returning,`cls._render_expectation_description` ends up getting sandwiched between the status and observed values renderers, just like the normal expectation renderer. So then the row is composed of the "cells", each of which is a renderer. The test changes hopefully show this off.

I changed the return type to a string renderer because there was already a comment about it and the markdown renderer had messed up formatting, so it seemed like I might as well.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
