### PR TITLE
[BUGFIX] Ensure datetime.time can be serialized to JSON

### DIFF
--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import OrderedDict
+
 import copy
 import datetime
 import decimal
@@ -13,7 +15,6 @@ import re
 import sys
 import time
 import uuid
-from collections import OrderedDict
 from functools import wraps
 from inspect import (
     BoundArguments,
@@ -37,7 +38,6 @@ from typing import (
     cast,
     overload,
 )
-
 import numpy as np
 import pandas as pd
 from dateutil.parser import parse
@@ -47,7 +47,6 @@ from great_expectations.compatibility import pydantic, pyspark, sqlalchemy
 from great_expectations.compatibility.sqlalchemy import LegacyRow, Row
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
-
 # import of private class will be removed when deprecated methods are removed from this module
 from great_expectations.exceptions import (
     InvalidExpectationConfigurationError,
@@ -1164,7 +1163,7 @@ def convert_to_json_serializable(  # noqa: C901, PLR0911, PLR0912
     if isinstance(data, np.float64):
         return float(data)
 
-    if isinstance(data, (datetime.datetime, datetime.date)):
+    if isinstance(data, (datetime.datetime, datetime.date, datetime.time)):
         return data.isoformat()
 
     if isinstance(data, (np.datetime64)):
@@ -1309,7 +1308,7 @@ def ensure_json_serializable(data: Any) -> None:  # noqa: C901, PLR0911, PLR0912
         _ = [ensure_json_serializable(x) for x in data.tolist()]  # type: ignore[func-returns-value]
         return
 
-    if isinstance(data, (datetime.datetime, datetime.date)):
+    if isinstance(data, (datetime.datetime, datetime.date, datetime.time)):
         return
 
     if isinstance(data, pathlib.PurePath):

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections import OrderedDict
-
 import copy
 import datetime
 import decimal
@@ -15,6 +13,7 @@ import re
 import sys
 import time
 import uuid
+from collections import OrderedDict
 from functools import wraps
 from inspect import (
     BoundArguments,
@@ -38,6 +37,7 @@ from typing import (
     cast,
     overload,
 )
+
 import numpy as np
 import pandas as pd
 from dateutil.parser import parse
@@ -47,6 +47,7 @@ from great_expectations.compatibility import pydantic, pyspark, sqlalchemy
 from great_expectations.compatibility.sqlalchemy import LegacyRow, Row
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
+
 # import of private class will be removed when deprecated methods are removed from this module
 from great_expectations.exceptions import (
     InvalidExpectationConfigurationError,

--- a/tests/test_convert_to_json_serializable.py
+++ b/tests/test_convert_to_json_serializable.py
@@ -3,7 +3,7 @@ import re
 import numpy as np
 import pytest
 
-from great_expectations.util import convert_to_json_serializable
+from great_expectations.util import convert_to_json_serializable, ensure_json_serializable
 
 try:
     from shapely.geometry import LineString, MultiPolygon, Point, Polygon
@@ -63,3 +63,17 @@ def test_serialization_of_pattern():
     pattern_to_test = r"data_(?P<year>\d{4})-(?P<month>\d{2}).csv"
     data = re.compile(pattern_to_test)
     assert convert_to_json_serializable(data) == pattern_to_test
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+def test_convert_to_json_serializable_converts_correctly(data: dict):
+    ret = convert_to_json_serializable(data)
+    assert ret == {"t": "01:30:45"}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+def test_ensure_json_serializable(data: dict):
+    ensure_json_serializable(data)
+    # Passes if no exception raised

--- a/tests/test_convert_to_json_serializable.py
+++ b/tests/test_convert_to_json_serializable.py
@@ -66,14 +66,18 @@ def test_serialization_of_pattern():
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+@pytest.mark.parametrize(
+    "data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")]
+)
 def test_convert_to_json_serializable_converts_correctly(data: dict):
     ret = convert_to_json_serializable(data)
     assert ret == {"t": "01:30:45"}
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+@pytest.mark.parametrize(
+    "data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")]
+)
 def test_ensure_json_serializable(data: dict):
     ensure_json_serializable(data)
     # Passes if no exception raised

--- a/tests/test_convert_to_json_serializable.py
+++ b/tests/test_convert_to_json_serializable.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 
 import numpy as np

--- a/tests/test_ge_utils.py
+++ b/tests/test_ge_utils.py
@@ -11,9 +11,7 @@ from great_expectations.util import (
     convert_ndarray_datetime_to_float_dtype_utc_timezone,
     convert_ndarray_float_to_datetime_tuple,
     convert_ndarray_to_datetime_dtype_best_effort,
-    convert_to_json_serializable,
     deep_filter_properties_iterable,
-    ensure_json_serializable,
     filter_properties_dict,
     hyphen,
     is_ndarray_datetime_dtype,
@@ -559,6 +557,7 @@ def test_convert_ndarray_float_to_datetime_tuple(
 def test_hyphen():
     txt: str = "validation_result"
     assert hyphen(txt=txt) == "validation-result"
+<<<<<<< HEAD
 
 
 @pytest.mark.unit

--- a/tests/test_ge_utils.py
+++ b/tests/test_ge_utils.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import os
 from typing import TYPE_CHECKING, Any
+
 import pytest
 
 import great_expectations as gx
@@ -561,14 +562,18 @@ def test_hyphen():
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+@pytest.mark.parametrize(
+    "data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")]
+)
 def test_convert_to_json_serializable_converts_correctly(data: dict):
     ret = convert_to_json_serializable(data)
     assert ret == {"t": "01:30:45"}
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+@pytest.mark.parametrize(
+    "data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")]
+)
 def test_ensure_json_serializable(data: dict):
     ensure_json_serializable(data)
     # Passes if no exception raised

--- a/tests/test_ge_utils.py
+++ b/tests/test_ge_utils.py
@@ -557,22 +557,3 @@ def test_convert_ndarray_float_to_datetime_tuple(
 def test_hyphen():
     txt: str = "validation_result"
     assert hyphen(txt=txt) == "validation-result"
-<<<<<<< HEAD
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    "data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")]
-)
-def test_convert_to_json_serializable_converts_correctly(data: dict):
-    ret = convert_to_json_serializable(data)
-    assert ret == {"t": "01:30:45"}
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    "data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")]
-)
-def test_ensure_json_serializable(data: dict):
-    ensure_json_serializable(data)
-    # Passes if no exception raised

--- a/tests/test_ge_utils.py
+++ b/tests/test_ge_utils.py
@@ -2,7 +2,6 @@ import copy
 import datetime
 import os
 from typing import TYPE_CHECKING, Any
-
 import pytest
 
 import great_expectations as gx
@@ -11,7 +10,9 @@ from great_expectations.util import (
     convert_ndarray_datetime_to_float_dtype_utc_timezone,
     convert_ndarray_float_to_datetime_tuple,
     convert_ndarray_to_datetime_dtype_best_effort,
+    convert_to_json_serializable,
     deep_filter_properties_iterable,
+    ensure_json_serializable,
     filter_properties_dict,
     hyphen,
     is_ndarray_datetime_dtype,
@@ -557,3 +558,17 @@ def test_convert_ndarray_float_to_datetime_tuple(
 def test_hyphen():
     txt: str = "validation_result"
     assert hyphen(txt=txt) == "validation-result"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+def test_convert_to_json_serializable_converts_correctly(data: dict):
+    ret = convert_to_json_serializable(data)
+    assert ret == {"t": "01:30:45"}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("data", [pytest.param({"t": datetime.time(hour=1, minute=30, second=45)}, id="datetime.time")])
+def test_ensure_json_serializable(data: dict):
+    ensure_json_serializable(data)
+    # Passes if no exception raised


### PR DESCRIPTION
Adds `datetime.time` handling to the serialization code in utils. `datetime.time` is now serializable, and serialization is performed by converting it to its ISO format string.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
