### PR TITLE
[DOCS] ADR around public API docstrings

### DIFF
--- a/docs/adr/0005-public-api-docstrings.md
+++ b/docs/adr/0005-public-api-docstrings.md
@@ -1,0 +1,19 @@
+# 5. Docstrings for public API functions/classes 
+
+Date: 2024-12-19
+
+## Status
+
+Accepted
+
+## Context
+
+By marking an object as part of the public API, it automatically renders in our docs site. In order to provide a clear and informative experience for our end users, we should make sure we always include docstrings for public functions/classes. These docstrings should adhere to a consistent format such that they can be rendered in the same manner by our public API infrastructure. 
+
+## Decision
+
+All objects decorated with `@public_api` will have docstrings. In order to be considered public, they must meet this criteria.
+
+## Consequences
+
+Marginal increase in developer burden but worthwhile due to a higher level of thought and care around what actually gets marked and rendered as part of our public API.

--- a/great_expectations/_docs_decorators.py
+++ b/great_expectations/_docs_decorators.py
@@ -134,11 +134,9 @@ def public_api(func: F) -> F:
 
     This tag is added at import time.
     """
-    existing_docstring = func.__doc__
-    if not existing_docstring:
-        raise ValueError("Public API classes/functions must have docstrings.")  # noqa: TRY003
-    func.__doc__ = WHITELISTED_TAG + existing_docstring
     public_api_introspector.add(func)
+    existing_docstring = func.__doc__ if func.__doc__ else ""
+    func.__doc__ = WHITELISTED_TAG + existing_docstring
     return func
 
 

--- a/great_expectations/_docs_decorators.py
+++ b/great_expectations/_docs_decorators.py
@@ -134,9 +134,11 @@ def public_api(func: F) -> F:
 
     This tag is added at import time.
     """
-    public_api_introspector.add(func)
-    existing_docstring = func.__doc__ if func.__doc__ else ""
+    existing_docstring = func.__doc__
+    if not existing_docstring:
+        raise ValueError("Public API classes/functions must have docstrings.")  # noqa: TRY003
     func.__doc__ = WHITELISTED_TAG + existing_docstring
+    public_api_introspector.add(func)
     return func
 
 


### PR DESCRIPTION
Let's be a bit more stringent with our requirements when decorating with `@public_api`

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
