### PR TITLE
[DOCS] Remove uppercase transformation for alerts' titles

### DIFF
--- a/docs/docusaurus/src/css/alerts.scss
+++ b/docs/docusaurus/src/css/alerts.scss
@@ -31,7 +31,7 @@
   border-left-width: var(--ifm-alert-border-left-width);
   box-shadow: none;
 
-  & [class^="admonitionHeading"] {
+  [class^="admonitionHeading"] {
     text-transform: none;
   }
 

--- a/docs/docusaurus/src/css/alerts.scss
+++ b/docs/docusaurus/src/css/alerts.scss
@@ -31,6 +31,10 @@
   border-left-width: var(--ifm-alert-border-left-width);
   box-shadow: none;
 
+  & [class^="admonitionHeading"] {
+    text-transform: none;
+  }
+
   div:first-child {
     font-size: var(--p-font-size);
 


### PR DESCRIPTION
[Jira Ticket](https://greatexpectations.atlassian.net/jira/software/c/projects/DSB/boards/79?assignee=712020%3A309fac2a-9c8e-412d-aa31-c2bbd94510b0&assignee=5b3bc63c7954ee2e97ae760a&selectedIssue=DOC-918)

[Deploy Preview](https://deploy-preview-10800.docs.greatexpectations.io/docs/cloud/validations/manage_validations/)

## Description

 override the text-transform: uppercase that comes out of the box for admonitions and replace it with text-transform: none

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
