### PR TITLE
[MAINTENANCE] Better logging around and only calling cleanup when we have old BigQuery schemas

### DIFF
--- a/scripts/cleanup/cleanup_big_query.py
+++ b/scripts/cleanup/cleanup_big_query.py
@@ -1,10 +1,12 @@
 import logging
+import sys
 
 from great_expectations.compatibility.pydantic import BaseSettings
 from great_expectations.compatibility.sqlalchemy import TextClause, create_engine
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 class BigQueryConnectionConfig(BaseSettings):
@@ -39,9 +41,12 @@ def cleanup_big_query(config: BigQueryConnectionConfig) -> None:
             ),
             {"schema_format": SCHEMA_FORMAT},
         ).fetchall()
-        to_run = TextClause("\n".join([row[0] for row in results]))
-        conn.execute(to_run)
-        logger.info(f"Cleaned up {len(results)} BigQuery schema(s)")
+        if results:
+            to_run = TextClause("\n".join([row[0] for row in results]))
+            conn.execute(to_run)
+            logger.info(f"Cleaned up {len(results)} BigQuery schema(s)")
+        else:
+            logger.info("No BigQuery schemas to clean up!")
     engine.dispose()
 
 


### PR DESCRIPTION
Fixes 2 things:
* This action failed a few times over the weekend with 400s, saying there was no `query` param. LIkely because it was an empty string. Now we only conditionally execute the query.
* Logging didn't show up. I think it will now. Tested with `act` locally.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
