### PR TITLE
[BUGFIX] Stop overwriting template with description

### DIFF
--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -352,9 +352,6 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
             ].expectation_config
             values["expectation_type"] = expectation_configuration.type
             values["kwargs"] = expectation_configuration.kwargs
-            # description is the template_str override
-            if expectation_configuration.description:
-                values["template_str"] = expectation_configuration.description
             raw_configuration: ExpectationConfiguration = (
                 expectation_configuration.get_raw_configuration()
             )
@@ -543,13 +540,7 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
 
     @validator("template_str")
     def _set_template_str(cls, v: str, values: dict) -> str:
-        if values.get("configuration") and values["configuration"].description:
-            # description always overrides other template_strs
-            v = values["configuration"].description
-        elif values.get("result") and values["result"].expectation_config.description:
-            # description always overrides other template_strs
-            v = values["result"].expectation_config.description
-        elif values.get("_row_condition"):
+        if values.get("_row_condition"):
             row_condition_str: str = RendererConfiguration._get_row_condition_string(
                 row_condition_str=values["_row_condition"]
             )

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -2995,3 +2995,22 @@ def test_unexpected_rows_expectation_atomic_diagnostic_observed_value(
 
     # assert
     assert res["value"]["template"] == expected_template_string
+
+
+def test_unexpected_rows_expectation_atomic_diagnostic_observed_value_when_description_present(
+    get_diagnostic_rendered_content,
+):
+    """Fixes regression where description overwrote the template"""
+
+    x = {
+        "expectation_config": ExpectationConfiguration(
+            type="unexpected_rows_expectation",
+            kwargs={"description": "my description", "unexpected_rows_query": "valid query"},
+            description="plz ignore me",
+        ),
+        "result": {"observed_value": 123},
+    }
+
+    res = get_diagnostic_rendered_content(x).to_json_dict()
+
+    assert res["value"]["template"] == "$observed_value unexpected rows"

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -2997,6 +2997,7 @@ def test_unexpected_rows_expectation_atomic_diagnostic_observed_value(
     assert res["value"]["template"] == expected_template_string
 
 
+@pytest.mark.unit
 def test_unexpected_rows_expectation_atomic_diagnostic_observed_value_when_description_present(
     get_diagnostic_rendered_content,
 ):

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -3014,3 +3014,37 @@ def test_unexpected_rows_expectation_atomic_diagnostic_observed_value_when_descr
     res = get_diagnostic_rendered_content(x).to_json_dict()
 
     assert res["value"]["template"] == "$observed_value unexpected rows"
+
+
+@pytest.mark.unit
+def test_atomic_prescriptive_summary_with_description(
+    get_prescriptive_rendered_content,
+):
+    description = "I should overwite"
+    update_dict = {
+        "type": "expect_column_distinct_values_to_be_in_set",
+        "description": description,
+        "kwargs": {
+            "column": "my_column",
+            "value_set": [1, 2, 3],
+        },
+    }
+    rendered_content = get_prescriptive_rendered_content(update_dict)
+
+    res = rendered_content.to_json_dict()
+    pprint(res)
+    assert res == {
+        "name": "atomic.prescriptive.summary",
+        "value": {
+            "params": {
+                "column": {"schema": {"type": "string"}, "value": "my_column"},
+                "v__0": {"schema": {"type": "number"}, "value": 1},
+                "v__1": {"schema": {"type": "number"}, "value": 2},
+                "v__2": {"schema": {"type": "number"}, "value": 3},
+                "value_set": {"schema": {"type": "array"}, "value": [1, 2, 3]},
+            },
+            "schema": {"type": "com.superconductive.rendered.string"},
+            "template": description,
+        },
+        "value_type": "StringValueType",
+    }


### PR DESCRIPTION
This was the cause of a bug in which the expectation's description rendered instead of the the observed value.

Including screenshots of how this shows in 3 views of cloud, as well as 2 views of DataDocs. Anything I'm missing? (there's 4 expectations - 2 passing, and 2 with descriptions, cloud renders "No description" for us)


![Screenshot 2025-01-06 at 4 31 58 PM](https://github.com/user-attachments/assets/83d5c3b5-635e-4bf7-a702-2e248601dbf7)
![Screenshot 2025-01-06 at 4 32 11 PM](https://github.com/user-attachments/assets/f0399d55-77b5-4882-9f6b-6ea3a6a307aa)
![Screenshot 2025-01-06 at 4 52 20 PM](https://github.com/user-attachments/assets/18988ff2-3eeb-4a01-81bf-216bafc8f2d0)
![Screenshot 2025-01-06 at 4 52 28 PM](https://github.com/user-attachments/assets/41f83c70-3676-4a13-9441-d36ecd0d71a0)
![Screenshot 2025-01-06 at 4 52 35 PM](https://github.com/user-attachments/assets/ed8d3ad6-f471-4a5e-a014-d6e3e14a421c)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
