### PR TITLE
[BUGFIX] `ExpectColumnUniqueValueCountToBeBetween` `strict_min` and `strict_max` not getting set

### DIFF
--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -208,12 +208,16 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnAggregateExpectation):
     success_keys = (
         "min_value",
         "max_value",
+        "strict_min",
+        "strict_max",
     )
 
     args_keys = (
         "column",
         "min_value",
         "max_value",
+        "strict_min",
+        "strict_max",
     )
 
     """ A Column Aggregate Metric Decorator for the Unique Value Count"""

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_unique_value_count_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_unique_value_count_to_be_between.py
@@ -72,14 +72,12 @@ def test_success(
                 column=COL_NAME, min_value=5, strict_min=True
             ),
             id="strict_min",
-            marks=pytest.mark.xfail(strict=True),
         ),
         pytest.param(
             gxe.ExpectColumnUniqueValueCountToBeBetween(
                 column=COL_NAME, max_value=5, strict_max=True
             ),
             id="strict_max",
-            marks=pytest.mark.xfail(strict=True),
         ),
     ],
 )


### PR DESCRIPTION
`ExpectColumnUniqueValueCountToBeBetween` `strict_min` and `strict_max` are not getting set ever because they aren't included in `success_keys`

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
