### PR TITLE
[BUGFIX] Extend existing version logic for pandas `series.between()` `inclusive` to missing conditions

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
@@ -123,7 +123,7 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
 
         metric_series = None
         if min_value is not None and max_value is not None:
-            # the word "strict" can be taken as a synonmym for the word "exclusive"
+            # the word "strict" can be taken as a synonym for the word "exclusive"
             if strict_min and strict_max:
                 metric_series = pandas_series_between(
                     series=column_lengths,

--- a/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
@@ -123,6 +123,7 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
 
         metric_series = None
         if min_value is not None and max_value is not None:
+            # the word "strict" can be taken as a synonmym for the word "exclusive"
             if strict_min and strict_max:
                 metric_series = pandas_series_between(
                     series=column_lengths,

--- a/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
@@ -19,7 +19,7 @@ from great_expectations.expectations.metrics.map_metric_provider import (
     column_condition_partial,
     column_function_partial,
 )
-from great_expectations.util import pandas_series_between_inclusive
+from great_expectations.util import pandas_series_between
 from great_expectations.validator.metric_configuration import MetricConfiguration
 
 if TYPE_CHECKING:
@@ -124,14 +124,32 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
         metric_series = None
         if min_value is not None and max_value is not None:
             if strict_min and strict_max:
-                metric_series = column_lengths.between(min_value, max_value, inclusive=False)
+                metric_series = pandas_series_between(
+                    series=column_lengths,
+                    min_value=min_value,
+                    max_value=max_value,
+                    inclusive="neither",
+                )
             elif strict_min and not strict_max:
-                metric_series = (column_lengths > min_value) & (column_lengths <= max_value)
+                metric_series = pandas_series_between(
+                    series=column_lengths,
+                    min_value=min_value,
+                    max_value=max_value,
+                    inclusive="right",
+                )
             elif not strict_min and strict_max:
-                metric_series = (column_lengths >= min_value) & (column_lengths < max_value)
+                metric_series = pandas_series_between(
+                    series=column_lengths,
+                    min_value=min_value,
+                    max_value=max_value,
+                    inclusive="left",
+                )
             elif not strict_min and not strict_max:
-                metric_series = pandas_series_between_inclusive(
-                    series=column_lengths, min_value=min_value, max_value=max_value
+                metric_series = pandas_series_between(
+                    series=column_lengths,
+                    min_value=min_value,
+                    max_value=max_value,
+                    inclusive="both",
                 )
         elif min_value is None and max_value is not None:
             if strict_max:

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1036,9 +1036,9 @@ def pandas_series_between(
     elif inclusive == "right":
         metric_series = (series > min_value) & (series <= max_value)
     elif inclusive == "neither":
-        metric_series = series.between(min_value, max_value, inclusive=False)
+        metric_series = series.between(min_value, max_value, inclusive=False)  # type: ignore[arg-type]  # valid for pandas < 1.3
     elif inclusive == "both":
-        metric_series = series.between(min_value, max_value, inclusive=True)
+        metric_series = series.between(min_value, max_value, inclusive=True)  # type: ignore[arg-type]  # valid for pandas < 1.3
     else:
         metric_series = series.between(min_value, max_value)
 

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -29,6 +29,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Set,
     SupportsFloat,
@@ -1018,13 +1019,26 @@ def get_trino_potential_type(type_module: ModuleType, type_: str) -> object:
     return potential_type
 
 
-def pandas_series_between_inclusive(series: pd.Series, min_value: int, max_value: int) -> pd.Series:
+Inclusive = Literal["left", "right", "neither", "both"]
+
+
+def pandas_series_between(
+    series: pd.Series, min_value: int, max_value: int, inclusive: Inclusive
+) -> pd.Series:
     """
-    As of Pandas 1.3.0, the 'inclusive' arg in between() is an enum: {"left", "right", "neither", "both"}
+    As of Pandas 1.3.0, the 'inclusive' arg in between() is a string leteral: {"left", "right", "neither", "both"}
     """  # noqa: E501 # FIXME CoP
     metric_series: pd.Series
     if version.parse(pd.__version__) >= version.parse("1.3.0"):
-        metric_series = series.between(min_value, max_value, inclusive="both")
+        metric_series = series.between(min_value, max_value, inclusive=inclusive)
+    elif inclusive == "left":
+        metric_series = (series >= min_value) & (series < max_value)
+    elif inclusive == "right":
+        metric_series = (series > min_value) & (series <= max_value)
+    elif inclusive == "neither":
+        metric_series = series.between(min_value, max_value, inclusive=False)
+    elif inclusive == "both":
+        metric_series = series.between(min_value, max_value, inclusive=True)
     else:
         metric_series = series.between(min_value, max_value)
 

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1026,7 +1026,7 @@ def pandas_series_between(
     series: pd.Series, min_value: int, max_value: int, inclusive: Inclusive
 ) -> pd.Series:
     """
-    As of Pandas 1.3.0, the 'inclusive' arg in between() is a string leteral: {"left", "right", "neither", "both"}
+    As of Pandas 1.3.0, the 'inclusive' arg in between() is a string literal: {"left", "right", "neither", "both"}
     """  # noqa: E501 # FIXME CoP
     metric_series: pd.Series
     if version.parse(pd.__version__) >= version.parse("1.3.0"):

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
@@ -37,7 +37,6 @@ def test_success_complete(batch_for_datasource: Batch) -> None:
             gxe.ExpectColumnValueLengthsToBeBetween(
                 column=COL_NAME, min_value=1, max_value=4, strict_min=True, strict_max=True
             ),
-            marks=pytest.mark.xfail(strict=False, reason="fails for python > 3.9"),
             id="strict_bounds",
         ),
     ],


### PR DESCRIPTION
Extend existing version logic for pandas `series.between()` `inclusive` to missing conditions

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
