### PR TITLE
[MAINTENANCE] Update `responses` pin due to mypy error with latest release

### DIFF
--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -16,6 +16,6 @@ pytest-random-order>=1.1.1
 pytest-timeout>=2.3.1
 pytest-xdist>=3.6.1
 requirements-parser>=0.9.0
-responses>=0.23.1 # requests mocking
+responses>=0.23.1,<0.25.5 # requests mocking - pinning due to https://github.com/getsentry/responses/issues/751
 setuptools>=70.0.0 # required for python 3.12
 sqlalchemy>=1.4.0

--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -16,6 +16,6 @@ pytest-random-order>=1.1.1
 pytest-timeout>=2.3.1
 pytest-xdist>=3.6.1
 requirements-parser>=0.9.0
-responses>=0.23.1,<0.25.5 # requests mocking - pinning due to https://github.com/getsentry/responses/issues/751
+responses>=0.23.1,!=0.25.5 # requests mocking - pinning due to https://github.com/getsentry/responses/issues/751
 setuptools>=70.0.0 # required for python 3.12
 sqlalchemy>=1.4.0

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 40
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 44
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -205,6 +205,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-dremio.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev-lite.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev-pagerduty.txt", "pypd", (("==", "1.1.0"),)),
         ("requirements-dev-snowflake.txt", "pandas", (("<", "2.2.0"),)),
         (
@@ -213,6 +214,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             (("<", "1.7.0"), (">=", "1.2.3")),
         ),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev-sqlalchemy.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev-sqlalchemy.txt", "pandas", (("<", "2.2.0"),)),
         (
             "requirements-dev-sqlalchemy.txt",
@@ -249,11 +251,13 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-test.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev-test.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev-test.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev-test.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements-dev.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev.txt", "posthog", (("<", "4"), (">", "3"))),
         ("requirements-dev.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 44
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 40
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -205,7 +205,6 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-dremio.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
-        ("requirements-dev-lite.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev-pagerduty.txt", "pypd", (("==", "1.1.0"),)),
         ("requirements-dev-snowflake.txt", "pandas", (("<", "2.2.0"),)),
         (
@@ -214,7 +213,6 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             (("<", "1.7.0"), (">=", "1.2.3")),
         ),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
-        ("requirements-dev-sqlalchemy.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev-sqlalchemy.txt", "pandas", (("<", "2.2.0"),)),
         (
             "requirements-dev-sqlalchemy.txt",
@@ -251,13 +249,11 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-test.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev-test.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev-test.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
-        ("requirements-dev-test.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements-dev.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
-        ("requirements-dev.txt", "responses", (("<", "0.25.5"), (">=", "0.23.1"))),
         ("requirements-dev.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev.txt", "posthog", (("<", "4"), (">", "3"))),
         ("requirements-dev.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),


### PR DESCRIPTION
https://github.com/getsentry/responses/issues/751
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
