### PR TITLE
[DOCS] update checkpoint snippet location

### DIFF
--- a/docs/docusaurus/docs/cloud/connect/connect_airflow.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_airflow.md
@@ -77,7 +77,7 @@ Apache Airflow is an orchestration tool that allows you to schedule and monitor 
             GX_CLOUD_ACCESS_TOKEN = "<YOUR_ACCESS_TOKEN>"
             GX_CLOUD_ORGANIZATION_ID = "<YOUR_CLOUD_ORGANIZATION_ID>"
             # Find the Checkpoint name in the GX Cloud UI. 
-            # - Go to the "Expectations" tab.
+            # - Go to the "Validations" tab.
             # - Next to the "Validate" button, click the code snippet icon.
             # - Click "Generate snippet". 
             # - Copy the Checkpoint name from the code snippet and use it below.

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/run_a_checkpoint.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/run_a_checkpoint.md
@@ -22,7 +22,7 @@ At runtime, a Checkpoint can take in a `batch_parameters` dictionary that select
 ### Procedure
 
 :::tip Generate a code snippet to validate GX-managed Expectations
-If you want to use the API to run a validation for [GX-managed Expectations](/cloud/expectations/manage_expectations.md#gx-managed-vs-api-managed-expectations) in a GX Cloud deployment, you can use the GX Cloud UI to generate the necessary code. For the Data Asset of interest, go to the **Expectations** tab and click **Use code snippet** near the **Validate** button.
+If you want to use the API to run a validation for [GX-managed Expectations](/cloud/expectations/manage_expectations.md#gx-managed-vs-api-managed-expectations) in a GX Cloud deployment, you can use the GX Cloud UI to generate the necessary code. For the Data Asset of interest, go to the **Validations** tab, click the code snippet icon next to the **Validate** button, and then click **Generate snippet** .
 :::
 
 <Tabs 

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/run_a_checkpoint.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/run_a_checkpoint.md
@@ -22,7 +22,7 @@ At runtime, a Checkpoint can take in a `batch_parameters` dictionary that select
 ### Procedure
 
 :::tip Generate a code snippet to validate GX-managed Expectations
-If you want to use the API to run a validation for [GX-managed Expectations](/cloud/expectations/manage_expectations.md#gx-managed-vs-api-managed-expectations) in a GX Cloud deployment, you can use the GX Cloud UI to generate the necessary code. For the Data Asset of interest, go to the **Validations** tab, click the code snippet icon next to the **Validate** button, and then click **Generate snippet** .
+If you want to use the API to run a validation for [GX-managed Expectations](/cloud/expectations/manage_expectations.md#gx-managed-vs-api-managed-expectations) in a GX Cloud deployment, you can use the GX Cloud UI to generate the necessary code. For the Data Asset of interest, go to the **Validations** tab, click the code snippet icon next to the **Validate** button, and then click **Generate snippet**.
 :::
 
 <Tabs 


### PR DESCRIPTION
This issueless PR updates the documented location of the "generate snippet" button since we're [deferring adding it to the Expectations tab](https://greatexpectationslabs.slack.com/archives/C07EPTSTYD9/p1736794149210969)

@netlify /docs/cloud/connect/connect_airflow

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
