### PR TITLE
[MAINTENANCE] CI skips xfailed quoted identifier tests

### DIFF
--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -834,7 +834,7 @@ class TestColumnExpectations:
             pytest.skip(f"see _desired_state tests for {column_name!r}")
         elif _fails_expectation(param_id):
             # apply marker this way so that xpasses can be seen in the report
-            request.applymarker(pytest.mark.xfail)
+            request.applymarker(pytest.mark.xfail(run=False))
 
         print(f"expectations_type:\n  {expectation_type}")
 
@@ -939,7 +939,7 @@ class TestColumnExpectations:
             pytest.skip(f"quote char dialect mismatch: {column_name[0]}")
         elif _fails_expectation(param_id):
             # apply marker this way so that xpasses can be seen in the report
-            request.applymarker(pytest.mark.xfail)
+            request.applymarker(pytest.mark.xfail(run=False))
 
         print(f"expectations_type:\n  {expectation_type}")
 


### PR DESCRIPTION
These tests are slow as heck. This PR leaves the xfailed tests as xfailed, but skips running them.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
