### PR TITLE
[MAINTENANCE] Exclude `snowflake-sqlalchemy` version

### DIFF
--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,4 +1,4 @@
 pandas<2.2.0; python_version >= "3.9"
 snowflake-connector-python>=2.5.0; python_version < "3.11"
 snowflake-connector-python>2.9.0; python_version >= "3.11" # earlier versions fail to build on 3.11
-snowflake-sqlalchemy>=1.2.3,<1.7.0  # pinned due to breaking in 1.7
+snowflake-sqlalchemy>=1.2.3,<1.7.0,!=1.6.1  # pinned due to breaking in 1.7

--- a/reqs/requirements-dev-sqlalchemy2.txt
+++ b/reqs/requirements-dev-sqlalchemy2.txt
@@ -12,6 +12,6 @@
 # -----------
 # Tempory pins for type checking step
 # TODO: update these pins in their respective requirements files and remove from here
-snowflake-sqlalchemy>=1.6,<1.7.0  # min version required for sqlalchemy 2.0, pinned due to breaking in 1.7
+snowflake-sqlalchemy>=1.6,<1.7.0,!=1.6.1  # min version required for sqlalchemy 2.0, pinned due to breaking in 1.7
 sqlalchemy>=2.0
 sqlalchemy-bigquery>=1.11.0 # min version required for sqlalchemy 2.0


### PR DESCRIPTION
Exclude version 1.6.1 due to flaky test that installs that version

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated