### PR TITLE
Remove Renderer from public API

### DIFF
--- a/great_expectations/render/renderer/renderer.py
+++ b/great_expectations/render/renderer/renderer.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from typing_extensions import ParamSpec
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
@@ -34,7 +33,6 @@ def renderer(renderer_type: str, **kwargs) -> Callable[[Callable[P, T]], Callabl
     return wrapper
 
 
-@public_api
 class Renderer:
     """A convenience class to provide an explicit mechanism to instantiate any Renderer."""
 

--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -1,4 +1,4 @@
-boto3>=1.17.106
+boto3>=1.17.106,<1.36.0
 coverage[toml]>=7.5.1
 flaky>=3.7.0 # for docs-integration tests that access cloud-resources that access cloud-resources
 flask>=1.0.0 # for s3 test only (with moto)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 40
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 44
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -204,6 +204,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-contrib.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev-dremio.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
+        ("requirements-dev-lite.txt", "boto3", (("<", "1.36.0"), (">=", "1.17.106"))),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-pagerduty.txt", "pypd", (("==", "1.1.0"),)),
         ("requirements-dev-snowflake.txt", "pandas", (("<", "2.2.0"),)),
@@ -212,6 +213,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             "snowflake-sqlalchemy",
             (("<", "1.7.0"), (">=", "1.2.3")),
         ),
+        ("requirements-dev-sqlalchemy.txt", "boto3", (("<", "1.36.0"), (">=", "1.17.106"))),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-sqlalchemy.txt", "pandas", (("<", "2.2.0"),)),
         (
@@ -247,10 +249,12 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             (("==", "17.0.0.5"),),
         ),
         ("requirements-dev-test.txt", "adr-tools-python", (("==", "1.0.3"),)),
+        ("requirements-dev-test.txt", "boto3", (("<", "1.36.0"), (">=", "1.17.106"))),
         ("requirements-dev-test.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev-test.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
+        ("requirements-dev.txt", "boto3", (("<", "1.36.0"), (">=", "1.17.106"))),
         ("requirements-dev.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),


### PR DESCRIPTION
This should not be part of the public API.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
