### PR TITLE
[DOCS] DOC-966: display api reference methods signatures as code blocks

### DIFF
--- a/docs/docusaurus/src/css/api_docs/api_docs.scss
+++ b/docs/docusaurus/src/css/api_docs/api_docs.scss
@@ -105,7 +105,6 @@
     table td {
       border: none;
       border-left: 1px solid rgba(112, 112, 112, 0.4);
-      border-right: 1px solid transparent;
 
       &:first-of-type {
         border-left: 1px solid transparent;

--- a/docs/docusaurus/src/css/api_docs/api_docs.scss
+++ b/docs/docusaurus/src/css/api_docs/api_docs.scss
@@ -105,6 +105,7 @@
     table td {
       border: none;
       border-left: 1px solid rgba(112, 112, 112, 0.4);
+      border-right: 1px solid transparent;
 
       &:first-of-type {
         border-left: 1px solid transparent;

--- a/docs/docusaurus/src/css/api_docs/api_docs.scss
+++ b/docs/docusaurus/src/css/api_docs/api_docs.scss
@@ -112,8 +112,8 @@
       }
     }
 
-    div pre {
-      border-top: none;
+    .theme-code-block pre {
+      border: 1px solid transparent;
       margin: 0;
       padding-top: 0;
     }

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -36,10 +36,6 @@ def apply_markdown_adjustments(soup, html_file_path, html_file_contents):  # noq
             item.insert(0, "\r\n")
             item.append("\r\n")
 
-    for item in soup.find_all(text=True):
-        if item.string and ("CodeBlock" not in item.string):
-            item.string.replaceWith(item.get_text().replace("<", r"\<"))
-
 
 def apply_structure_changes(soup, html_file_path, html_file_contents):
     # Add h2 title to Methods section
@@ -71,6 +67,11 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
         code_block = soup.new_tag("CodeBlock", language="python", title="Signature")
         code_block.append("{`" + item.get_text().replace("#", "") + "`}")
         item.replace_with(code_block)
+
+    # Prevent build from failing when there's code-like text outside code blocks
+    for item in soup.find_all(text=True):
+        if item.string and ("CodeBlock" not in item.string):
+            item.string.replaceWith(item.get_text().replace("<", r"\<"))
 
 
 def add_section_title(soup, items, title):

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -36,9 +36,6 @@ def apply_markdown_adjustments(soup, html_file_path, html_file_contents):  # noq
             item.insert(0, "\r\n")
             item.append("\r\n")
 
-    # for item in soup.find_all("cite"):
-    #     item.string.replaceWith(item.get_text().replace("<", r"\<"))
-
     for item in soup.find_all(text=True):
         if item.string and ("CodeBlock" not in item.string):
             item.string.replaceWith(item.get_text().replace("<", r"\<"))

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -88,6 +88,7 @@ def add_section_title(soup, items, title):
     wrapper_div.insert(2, "\r\n")
     parent.insert_after(wrapper_div)
 
+
 def create_header_row(soup, table):
     thead = soup.new_tag("thead")
     thead_row = soup.new_tag("tr")
@@ -105,6 +106,7 @@ def create_header_row(soup, table):
     table.append("\r\n")
     table.insert(0, "\r\n")
 
+
 def create_row(soup, tbody, prop):
     new_row = soup.new_tag("tr")
     reference_link = prop.select("a")[0]
@@ -113,7 +115,7 @@ def create_row(soup, tbody, prop):
     columns = [
         "`" + prop.select(".descname")[0].get_text() + "`",
         prop.select("dd")[0].get_text(),
-        reference_link
+        reference_link,
     ]
 
     for column in columns:

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -59,16 +59,16 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
         head_row = soup.new_tag("tr")
 
         head_column = soup.new_tag("th")
-        head_column_link = soup.new_tag("th")
         head_column_desc = soup.new_tag("th")
+        head_column_reference = soup.new_tag("th")
 
-        head_column.append("Setting")
-        head_column_link.append("Link")
+        head_column.append("Name")
         head_column_desc.append("Description")
+        head_column_reference.append("Reference")
 
         head_row.append(head_column)
-        head_row.append(head_column_link)
         head_row.append(head_column_desc)
+        head_row.append(head_column_reference)
         head.append(head_row)
         table.append(head)
         table.append("\r\n")
@@ -78,24 +78,24 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
             new_row = soup.new_tag("tr")
 
             new_column = soup.new_tag("td")
-            new_column_link = soup.new_tag("td")
             new_column_desc = soup.new_tag("td")
+            new_column_reference = soup.new_tag("td")
 
             new_column.append("\r\n")
-            new_column_link.append("\r\n")
             new_column_desc.append("\r\n")
+            new_column_reference.append("\r\n")
 
             new_column.append("`" + prop.select(".descname")[0].get_text() + "`")
-            new_column_link.append(prop.select("a")[0])
             new_column_desc.append(prop.select("dd")[0].get_text())
+            new_column_reference.append(prop.select("a")[0])
 
             new_column.append("\r\n")
-            new_column_link.append("\r\n")
             new_column_desc.append("\r\n")
+            new_column_reference.append("\r\n")
 
             new_row.append(new_column)
-            new_row.append(new_column_link)
             new_row.append(new_column_desc)
+            new_row.append(new_column_reference)
 
             body.append(new_row)
             prop.extract()

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -47,6 +47,65 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
     if properties:
         # Add h2 title to Properties section
         add_section_title(soup, properties, "Properties")
+        # add_section_title(soup, "Properties", properties)
+        wrapper_div = soup.new_tag("div")
+        title_h2 = soup.new_tag("h2")
+        title_h2.string = "Properties"
+        parent = properties[0].parent
+
+        table = soup.new_tag("table")
+        body = soup.new_tag("tbody")
+        head = soup.new_tag("thead")
+        head_row = soup.new_tag("tr")
+
+        head_column = soup.new_tag("th")
+        head_column_link = soup.new_tag("th")
+        head_column_desc = soup.new_tag("th")
+
+        head_column.append("Setting")
+        head_column_link.append("Link")
+        head_column_desc.append("Description")
+
+        head_row.append(head_column)
+        head_row.append(head_column_link)
+        head_row.append(head_column_desc)
+        head.append(head_row)
+        table.append(head)
+        table.append("\r\n")
+        table.insert(0, "\r\n")
+
+        for prop in properties:
+            new_row = soup.new_tag("tr")
+
+            new_column = soup.new_tag("td")
+            new_column_link = soup.new_tag("td")
+            new_column_desc = soup.new_tag("td")
+
+            new_column.append("\r\n")
+            new_column_link.append("\r\n")
+            new_column_desc.append("\r\n")
+
+            new_column.append("`" + prop.select(".descname")[0].get_text() + "`")
+            new_column_link.append(prop.select("a")[0])
+            new_column_desc.append(prop.select("dd")[0].get_text())
+
+            new_column.append("\r\n")
+            new_column_link.append("\r\n")
+            new_column_desc.append("\r\n")
+
+            new_row.append(new_column)
+            new_row.append(new_column_link)
+            new_row.append(new_column_desc)
+
+            body.append(new_row)
+            prop.extract()
+
+        wrapper_div.insert(0, "\r\n")
+        wrapper_div.insert(1, title_h2)
+        wrapper_div.insert(2, "\r\n")
+        table.append(body)
+        wrapper_div.append(table)
+        parent.insert_after(wrapper_div)
 
         # Display properties as table
         table = soup.new_tag("table")

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -47,65 +47,6 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
     if properties:
         # Add h2 title to Properties section
         add_section_title(soup, properties, "Properties")
-        # add_section_title(soup, "Properties", properties)
-        wrapper_div = soup.new_tag("div")
-        title_h2 = soup.new_tag("h2")
-        title_h2.string = "Properties"
-        parent = properties[0].parent
-
-        table = soup.new_tag("table")
-        body = soup.new_tag("tbody")
-        head = soup.new_tag("thead")
-        head_row = soup.new_tag("tr")
-
-        head_column = soup.new_tag("th")
-        head_column_desc = soup.new_tag("th")
-        head_column_reference = soup.new_tag("th")
-
-        head_column.append("Name")
-        head_column_desc.append("Description")
-        head_column_reference.append("Reference")
-
-        head_row.append(head_column)
-        head_row.append(head_column_desc)
-        head_row.append(head_column_reference)
-        head.append(head_row)
-        table.append(head)
-        table.append("\r\n")
-        table.insert(0, "\r\n")
-
-        for prop in properties:
-            new_row = soup.new_tag("tr")
-
-            new_column = soup.new_tag("td")
-            new_column_desc = soup.new_tag("td")
-            new_column_reference = soup.new_tag("td")
-
-            new_column.append("\r\n")
-            new_column_desc.append("\r\n")
-            new_column_reference.append("\r\n")
-
-            new_column.append("`" + prop.select(".descname")[0].get_text() + "`")
-            new_column_desc.append(prop.select("dd")[0].get_text())
-            new_column_reference.append(prop.select("a")[0])
-
-            new_column.append("\r\n")
-            new_column_desc.append("\r\n")
-            new_column_reference.append("\r\n")
-
-            new_row.append(new_column)
-            new_row.append(new_column_desc)
-            new_row.append(new_column_reference)
-
-            body.append(new_row)
-            prop.extract()
-
-        wrapper_div.insert(0, "\r\n")
-        wrapper_div.insert(1, title_h2)
-        wrapper_div.insert(2, "\r\n")
-        table.append(body)
-        wrapper_div.append(table)
-        parent.insert_after(wrapper_div)
 
         # Display properties as table
         table = soup.new_tag("table")
@@ -136,7 +77,6 @@ def add_section_title(soup, items, title):
     wrapper_div.insert(2, "\r\n")
     parent.insert_after(wrapper_div)
 
-
 def create_header_row(soup, table):
     thead = soup.new_tag("thead")
     thead_row = soup.new_tag("tr")
@@ -154,7 +94,6 @@ def create_header_row(soup, table):
     table.append("\r\n")
     table.insert(0, "\r\n")
 
-
 def create_row(soup, tbody, prop):
     new_row = soup.new_tag("tr")
     reference_link = prop.select("a")[0]
@@ -163,7 +102,7 @@ def create_row(soup, tbody, prop):
     columns = [
         "`" + prop.select(".descname")[0].get_text() + "`",
         prop.select("dd")[0].get_text(),
-        reference_link,
+        reference_link
     ]
 
     for column in columns:

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -36,8 +36,12 @@ def apply_markdown_adjustments(soup, html_file_path, html_file_contents):  # noq
             item.insert(0, "\r\n")
             item.append("\r\n")
 
-    for item in soup.find_all("cite"):
-        item.string.replaceWith(item.get_text().replace("<", r"\<"))
+    # for item in soup.find_all("cite"):
+    #     item.string.replaceWith(item.get_text().replace("<", r"\<"))
+
+    for item in soup.find_all(text=True):
+        if item.string and (not "CodeBlock" in item.string):
+            item.string.replaceWith(item.get_text().replace("<", r"\<"))
 
 
 def apply_structure_changes(soup, html_file_path, html_file_contents):
@@ -68,7 +72,7 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
     items = soup.select(".sig-object")
     for item in items:
         code_block = soup.new_tag("CodeBlock", language="python", title="Signature")
-        code_block.append("{`" + item.get_text() + "`}")
+        code_block.append("{`" + item.get_text().replace("#", "") + "`}")
         item.replace_with(code_block)
 
 

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -40,7 +40,7 @@ def apply_markdown_adjustments(soup, html_file_path, html_file_contents):  # noq
     #     item.string.replaceWith(item.get_text().replace("<", r"\<"))
 
     for item in soup.find_all(text=True):
-        if item.string and (not "CodeBlock" in item.string):
+        if item.string and ("CodeBlock" not in item.string):
             item.string.replaceWith(item.get_text().replace("<", r"\<"))
 
 

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -37,7 +37,8 @@ def apply_markdown_adjustments(soup, html_file_path, html_file_contents):  # noq
             item.append("\r\n")
 
     for item in soup.find_all("cite"):
-        item.string.replaceWith(item.get_text().replace("<", "\<"))
+        item.string.replaceWith(item.get_text().replace("<", r"\<"))
+
 
 def apply_structure_changes(soup, html_file_path, html_file_contents):
     # Add h2 title to Methods section
@@ -69,6 +70,7 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
         code_block = soup.new_tag("CodeBlock", language="python", title="Signature")
         code_block.append("{`" + item.get_text() + "`}")
         item.replace_with(code_block)
+
 
 def add_section_title(soup, items, title):
     wrapper_div = soup.new_tag("div")

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -36,6 +36,9 @@ def apply_markdown_adjustments(soup, html_file_path, html_file_contents):  # noq
             item.insert(0, "\r\n")
             item.append("\r\n")
 
+    for item in soup.find_all("cite"):
+        item.string.replaceWith(item.get_text().replace("<", "\<"))
+
 def apply_structure_changes(soup, html_file_path, html_file_contents):
     # Add h2 title to Methods section
     methods = soup.select(".py.method")
@@ -60,6 +63,12 @@ def apply_structure_changes(soup, html_file_path, html_file_contents):
         parent_div = soup.select("#properties")[0]
         parent_div.append(table)
 
+    # Display signatures as code blocks
+    items = soup.select(".sig-object")
+    for item in items:
+        code_block = soup.new_tag("CodeBlock", language="python", title="Signature")
+        code_block.append("{`" + item.get_text() + "`}")
+        item.replace_with(code_block)
 
 def add_section_title(soup, items, title):
     wrapper_div = soup.new_tag("div")

--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -36,7 +36,6 @@ def apply_markdown_adjustments(soup, html_file_path, html_file_contents):  # noq
             item.insert(0, "\r\n")
             item.append("\r\n")
 
-
 def apply_structure_changes(soup, html_file_path, html_file_contents):
     # Add h2 title to Methods section
     methods = soup.select(".py.method")


### PR DESCRIPTION
## Description
Display signatures in API Reference files as code blocks

Preview app: [https://deploy-preview-10882.docs.greatexpectations.io/docs/reference/api/data_context/abstractdatacontext_class/](https://deploy-preview-10882.docs.greatexpectations.io/docs/reference/api/data_context/abstractdatacontext_class/)

Note: is assumed that all will show under the name "Signature" and as Python code, so that's hardcoded, we can discuss if we want to take this logic further to contemplate other scenarios

## Screenshots
### Before
![screencapture-docs-greatexpectations-io-docs-reference-api-data-context-AbstractDataContext-class-2025-01-27-16_46_08](https://github.com/user-attachments/assets/63dc8a55-0544-4ef3-b783-e337db7e3413)

### After
![screencapture-deploy-preview-10882-docs-greatexpectations-io-docs-reference-api-data-context-AbstractDataContext-class-2025-01-27-16_44_21](https://github.com/user-attachments/assets/82f831dc-5133-4207-85c7-e6ee4b9b17e7)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
