### PR TITLE
[BUGFIX] Allow adding Expectations with identical attributes to Suites

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -169,9 +169,12 @@ class ExpectationSuite(SerializableDictDot):
         that are not relevant for uniqueness in the suite.
         """
         exclude_params = {"id", "rendered_content", "notes", "meta"}
-        return expectation_a.dict(exclude=exclude_params) == expectation_b.dict(
+        # pydantic model.dict() excludes ClassVars, so we compare Expectation type explicitly
+        types_are_equal = expectation_a.expectation_type == expectation_b.expectation_type
+        attributes_are_equal = expectation_a.dict(exclude=exclude_params) == expectation_b.dict(
             exclude=exclude_params
         )
+        return types_are_equal and attributes_are_equal
 
     def _submit_expectation_created_event(self, expectation: Expectation) -> None:
         if expectation.__module__.startswith("great_expectations."):

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -915,6 +915,52 @@ class TestEqDunder:
         assert different_but_equivalent_suite != suite_with_single_expectation
 
 
+class TestExpectationsAreEqualish:
+    @pytest.fixture
+    def expectation_3(self) -> gxe.ExpectColumnValuesToNotBeNull:
+        return gxe.ExpectColumnValuesToNotBeNull(column="a")
+
+    @pytest.fixture
+    def expectation_4(self) -> gxe.ExpectColumnValuesToBeUnique:
+        return gxe.ExpectColumnValuesToBeUnique(column="a")
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "expectation_a,expectation_b",
+        [
+            pytest.param(
+                gxe.ExpectColumnValuesToBeInSet(
+                    column="a",
+                    value_set=[1, 2, 3],
+                    result_format="BASIC",
+                ),
+                gxe.ExpectColumnValuesToBeInSet(
+                    column="a",
+                    value_set=[1, 2, 3],
+                    result_format="BASIC",
+                ),
+                id="same expectation, same args passed in",
+            ),
+        ],
+    )
+    def test_equalish(self, expectation_a, expectation_b):
+        assert ExpectationSuite._expectations_are_equalish(expectation_a, expectation_b)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "expectation_a,expectation_b",
+        [
+            pytest.param(
+                gxe.ExpectColumnValuesToNotBeNull(column="a"),
+                gxe.ExpectColumnValuesToBeUnique(column="a"),
+                id="different expectation, same args passed in",
+            ),
+        ],
+    )
+    def test_not_equalish(self, expectation_a, expectation_b):
+        assert not ExpectationSuite._expectations_are_equalish(expectation_a, expectation_b)
+
+
 # ### Below this line are mainly existing tests and fixtures that we are in the process of cleaning up  # noqa: E501 # FIXME CoP
 
 

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -35,6 +35,7 @@ from great_expectations.expectations.expectation import Expectation
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
+from great_expectations.render import RenderedAtomicContent, RenderedAtomicValue
 
 
 @pytest.fixture
@@ -931,7 +932,36 @@ class TestExpectationsAreEqualish:
                     value_set=[1, 2, 3],
                     result_format="BASIC",
                 ),
-                id="same expectation, same args passed in",
+                id="same args passed in",
+            ),
+            pytest.param(
+                gxe.ExpectColumnValuesToNotBeNull(column="a", id=str(uuid4())),
+                gxe.ExpectColumnValuesToNotBeNull(column="a", id=str(uuid4())),
+                id="different ids",
+            ),
+            pytest.param(
+                gxe.ExpectColumnValuesToNotBeNull(column="a", rendered_content=[]),
+                gxe.ExpectColumnValuesToNotBeNull(
+                    column="a",
+                    rendered_content=[
+                        RenderedAtomicContent(
+                            name="atomic.prescriptive.summary",
+                            value=RenderedAtomicValue(template="Render this string!"),
+                            value_type="StringValueType",
+                        )
+                    ],
+                ),
+                id="different rendered_content",
+            ),
+            pytest.param(
+                gxe.ExpectColumnValuesToNotBeNull(column="a", notes="Note ABC"),
+                gxe.ExpectColumnValuesToNotBeNull(column="a", notes="Note 123"),
+                id="different notes",
+            ),
+            pytest.param(
+                gxe.ExpectColumnValuesToNotBeNull(column="a", meta={"warehouse": "theirs"}),
+                gxe.ExpectColumnValuesToNotBeNull(column="a", meta={"warehouse": "ours"}),
+                id="different meta",
             ),
         ],
     )
@@ -944,8 +974,18 @@ class TestExpectationsAreEqualish:
         [
             pytest.param(
                 gxe.ExpectColumnValuesToNotBeNull(column="a"),
+                gxe.ExpectColumnValuesToBeUnique(column="b"),
+                id="different expectation, different args passed in",
+            ),
+            pytest.param(
+                gxe.ExpectColumnValuesToNotBeNull(column="a"),
                 gxe.ExpectColumnValuesToBeUnique(column="a"),
                 id="different expectation, same args passed in",
+            ),
+            pytest.param(
+                gxe.ExpectColumnValuesToNotBeNull(column="a"),
+                gxe.ExpectColumnValuesToNotBeNull(column="b"),
+                id="same expectation, different args passed in",
             ),
         ],
     )

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -27,6 +27,10 @@ from great_expectations.data_context import AbstractDataContext
 from great_expectations.data_context.data_context.context_factory import set_context
 from great_expectations.data_context.store.expectations_store import ExpectationsStore
 from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.expectations import (
+    ExpectColumnValuesToBeUnique,
+    ExpectColumnValuesToNotBeNull,
+)
 from great_expectations.expectations.expectation import Expectation
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
@@ -393,6 +397,25 @@ class TestCRUDMethods:
             suite.add_expectation(expectation=expectation)
 
         assert len(suite.expectations) == 0, "Expectation must not be added to Suite."
+
+    @pytest.mark.unit
+    def test_add_success_when_attributes_are_identical(self):
+        context = Mock(spec=AbstractDataContext)
+        set_context(project=context)
+
+        parameters = {"column": "passenger_count"}
+        expectation_a = ExpectColumnValuesToBeUnique(**parameters)
+        expectation_b = ExpectColumnValuesToNotBeNull(**parameters)
+
+        suite = ExpectationSuite(
+            name=self.expectation_suite_name,
+            expectations=[expectation_a],
+        )
+
+        with mock.patch.object(ExpectationSuite, "_submit_expectation_created_event"):
+            suite.add_expectation(expectation=expectation_b)
+
+        assert len(suite.expectations) == 2
 
     @pytest.mark.unit
     def test_delete_success_with_saved_suite(self, expectation):

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -916,14 +916,6 @@ class TestEqDunder:
 
 
 class TestExpectationsAreEqualish:
-    @pytest.fixture
-    def expectation_3(self) -> gxe.ExpectColumnValuesToNotBeNull:
-        return gxe.ExpectColumnValuesToNotBeNull(column="a")
-
-    @pytest.fixture
-    def expectation_4(self) -> gxe.ExpectColumnValuesToBeUnique:
-        return gxe.ExpectColumnValuesToBeUnique(column="a")
-
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "expectation_a,expectation_b",


### PR DESCRIPTION
There was a bug where Expectations with different types would not be added to a Suite if their attributes were identical

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
