### PR TITLE
[MAINTENANCE] Add `strict` to Window type

### DIFF
--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -282,6 +282,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -289,8 +290,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -279,13 +279,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -282,6 +282,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -289,8 +290,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -279,13 +279,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -282,6 +282,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -289,8 +290,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -279,13 +279,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -282,6 +282,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -289,8 +290,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -279,13 +279,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -259,13 +259,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -262,6 +262,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -269,8 +270,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -259,13 +259,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -262,6 +262,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -269,8 +270,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -259,13 +259,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -262,6 +262,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -269,8 +270,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -259,13 +259,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -262,6 +262,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -269,8 +270,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -288,6 +288,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -295,8 +296,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -285,13 +285,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -245,13 +245,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -248,6 +248,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -255,8 +256,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -245,6 +245,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -252,8 +253,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -242,13 +242,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -254,13 +254,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -257,6 +257,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -264,8 +265,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -276,13 +276,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -279,6 +279,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -286,8 +287,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -232,6 +232,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -239,8 +240,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -229,13 +229,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -259,13 +259,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -262,6 +262,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -269,8 +270,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -259,13 +259,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -262,6 +262,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -269,8 +270,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -208,6 +208,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -215,8 +216,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -205,13 +205,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -276,13 +276,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -279,6 +279,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -286,8 +287,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -267,13 +267,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -270,6 +270,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -277,8 +278,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -239,6 +239,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -246,8 +247,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -236,13 +236,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -252,6 +252,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -259,8 +260,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -249,13 +249,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -278,6 +278,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -285,8 +286,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -275,13 +275,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -296,13 +296,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -299,6 +299,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -306,8 +307,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -237,6 +237,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -244,8 +245,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -234,13 +234,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -226,6 +226,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -233,8 +234,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -223,13 +223,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -232,6 +232,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -239,8 +240,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -229,13 +229,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -226,6 +226,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -233,8 +234,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -223,13 +223,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -237,6 +237,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -244,8 +245,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -234,13 +234,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -247,13 +247,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -250,6 +250,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -257,8 +258,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -237,6 +237,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -244,8 +245,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -234,13 +234,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -247,13 +247,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -250,6 +250,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -257,8 +258,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -296,13 +296,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -299,6 +299,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -306,8 +307,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -226,6 +226,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -233,8 +234,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -223,13 +223,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -236,6 +236,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -243,8 +244,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -233,13 +233,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -239,6 +239,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -246,8 +247,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -236,13 +236,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -236,6 +236,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -243,8 +244,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -233,13 +233,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -239,6 +239,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -246,8 +247,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -236,13 +236,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -235,13 +235,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -238,6 +238,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -245,8 +246,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -245,6 +245,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -252,8 +253,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -242,13 +242,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -231,13 +231,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -234,6 +234,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -241,8 +242,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
@@ -224,13 +224,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
@@ -227,6 +227,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -234,8 +235,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
@@ -202,6 +202,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -209,8 +210,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
@@ -199,13 +199,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -202,13 +202,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -205,6 +205,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -212,8 +213,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -208,13 +208,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -211,6 +211,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -218,8 +219,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -245,6 +245,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -252,8 +253,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -242,13 +242,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -216,6 +216,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -223,8 +224,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -213,13 +213,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -207,6 +207,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -214,8 +215,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -204,13 +204,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
+++ b/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
@@ -172,13 +172,18 @@
                 },
                 "offset": {
                     "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset"
+                "offset",
+                "strict"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
+++ b/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
@@ -175,6 +175,7 @@
                 },
                 "strict": {
                     "title": "Strict",
+                    "default": false,
                     "type": "boolean"
                 }
             },
@@ -182,8 +183,7 @@
                 "constraint_fn",
                 "parameter_name",
                 "range",
-                "offset",
-                "strict"
+                "offset"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/expectations/window.py
+++ b/great_expectations/expectations/window.py
@@ -23,7 +23,7 @@ class Window(pydantic.BaseModel):
     parameter_name: str
     range: int
     offset: Offset
-    strict: bool
+    strict: bool = False
 
     class Config:
         extra = Extra.forbid

--- a/great_expectations/expectations/window.py
+++ b/great_expectations/expectations/window.py
@@ -23,6 +23,7 @@ class Window(pydantic.BaseModel):
     parameter_name: str
     range: int
     offset: Offset
+    strict: bool
 
     class Config:
         extra = Extra.forbid

--- a/tests/expectations/core/test_expectation_serialization.py
+++ b/tests/expectations/core/test_expectation_serialization.py
@@ -60,7 +60,6 @@ from great_expectations.expectations.window import Offset, Window
                         parameter_name="b",
                         range=5,
                         offset=Offset(positive=0.2, negative=0.2),
-                        strict=False,
                     )
                 ],
             ),

--- a/tests/expectations/core/test_expectation_serialization.py
+++ b/tests/expectations/core/test_expectation_serialization.py
@@ -60,6 +60,7 @@ from great_expectations.expectations.window import Offset, Window
                         parameter_name="b",
                         range=5,
                         offset=Offset(positive=0.2, negative=0.2),
+                        strict=False,
                     )
                 ],
             ),
@@ -67,8 +68,8 @@ from great_expectations.expectations.window import Offset, Window
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
                 '"windows": [{"constraint_fn": "a", "parameter_name": "b", "range": 5, '
-                '"offset": {"positive": 0.2, "negative": 0.2}}], "batch_id": null, '
-                '"column": "test_column", "mostly": 0.82, '
+                '"offset": {"positive": 0.2, "negative": 0.2}, "strict": false}], '
+                '"batch_id": null, "column": "test_column", "mostly": 0.82, '
                 '"row_condition": null, "condition_parser": null}'
             ),
         ),

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -250,6 +250,7 @@ def test_expectation_configuration_window():
                 parameter_name="b",
                 range=5,
                 offset=Offset(positive=0.2, negative=0.2),
+                strict=False,
             )
         ],
     )
@@ -266,6 +267,7 @@ def test_expectation_configuration_window():
                     "parameter_name": "b",
                     "range": 5,
                     "offset": {"positive": 0.2, "negative": 0.2},
+                    "strict": False,
                 }
             ],
         },

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -250,7 +250,7 @@ def test_expectation_configuration_window():
                 parameter_name="b",
                 range=5,
                 offset=Offset(positive=0.2, negative=0.2),
-                strict=False,
+                strict=True,
             )
         ],
     )
@@ -267,7 +267,7 @@ def test_expectation_configuration_window():
                     "parameter_name": "b",
                     "range": 5,
                     "offset": {"positive": 0.2, "negative": 0.2},
-                    "strict": False,
+                    "strict": True,
                 }
             ],
         },


### PR DESCRIPTION
Add `strict` to Window type so it can be used with dynamic parameters Expectations

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated