### PR TITLE
[DOCS] Fix HTML entity character in API reference code blocks

### DIFF
--- a/docs/docusaurus/docs/reference/learn/reference_overview.md
+++ b/docs/docusaurus/docs/reference/learn/reference_overview.md
@@ -27,6 +27,3 @@ import OverviewCard from '@site/src/components/OverviewCard';
 
   <LinkCard topIcon label="Glossary" description="An alphabetical list of GX terms and words with definitions" to="/reference/learn/glossary" icon="/img/glossary_icon.svg" />
 </LinkCardGrid>
-
-
-

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -601,7 +601,7 @@ class SphinxInvokeDocsBuilder:
         Also quotes use a different quote character. This method cleans up
         these items so that the code block is rendered appropriately.
         """
-        doc = doc.replace("&lt;", "<").replace("&gt;", ">")
+        doc = doc.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;42;", "*")
         doc = (
             doc.replace("“", '"')
             .replace("”", '"')


### PR DESCRIPTION
## Description
CodeBlock character `*` gets escaped when generating HTML, so I'm adding that special character as one more that needs to be reverted

## Examples in the deploy preview
[Checkpoint](https://deploy-preview-10915.docs.greatexpectations.io/docs/reference/api/Checkpoint_class)
[ValidationDefinition](https://deploy-preview-10915.docs.greatexpectations.io/docs/reference/api/ValidationDefinition_class)

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/595676c5-5c66-4555-95be-70dca7bd0848)

### After
![image](https://github.com/user-attachments/assets/f5c0c53b-920f-406c-bc98-bdda3bed599d)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
