### PR TITLE
[MAINTENANCE] Ensure clear error if cloud mode requested and env vars aren't found

### DIFF
--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -351,7 +351,7 @@ class ProjectManager:
             )
         else:
             raise GXCloudConfigurationError(  # noqa: TRY003 # one time exception
-                "Unable to create a CloudDataContext due to one or more missing environment variables: " 
+                "Unable to create a CloudDataContext due to one or more missing environment variables: "
                 "GX_CLOUD_ORGANIZATION_ID, GX_CLOUD_ACCESS_TOKEN"
             )
 

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -206,6 +206,7 @@ class ProjectManager:
                 cloud_organization_id=cloud_organization_id,
                 user_agent_str=user_agent_str,
                 cloud_mode=cloud_mode,
+                mode=mode,
             ),
         }
         try:
@@ -263,6 +264,7 @@ class ProjectManager:
         cloud_organization_id: str | None = None,
         user_agent_str: str | None = None,
         cloud_mode: bool | None = None,
+        mode: ContextModes | None = None,
     ) -> AbstractDataContext:
         """Infer which type of DataContext a user wants based on available parameters."""
         # First, check for GX Cloud conditions
@@ -276,6 +278,7 @@ class ProjectManager:
             cloud_access_token=cloud_access_token,
             cloud_organization_id=cloud_organization_id,
             user_agent_str=user_agent_str,
+            mode=mode,
         )
 
         if cloud_context:
@@ -326,6 +329,7 @@ class ProjectManager:
         cloud_organization_id: str | None = None,
         user_agent_str: str | None = None,
         cloud_mode: bool | None = None,
+        mode: ContextModes | None = None,
     ) -> CloudDataContext | None:
         if cloud_mode is False:
             return None  # user has specifically disabled cloud mode, so we don't check for env vars
@@ -349,13 +353,13 @@ class ProjectManager:
                 cloud_organization_id=cloud_organization_id,
                 user_agent_str=user_agent_str,
             )
+        elif mode != "cloud":  # cloud mode not specified, and env vars not available
+            return None
         else:
             raise GXCloudConfigurationError(  # noqa: TRY003 # one time exception
-                "Unable to create a CloudDataContext due to one or more missing environment variables: "
-                "GX_CLOUD_ORGANIZATION_ID, GX_CLOUD_ACCESS_TOKEN"
+                "Unable to create a CloudDataContext due to one or more missing environment "
+                "variables: GX_CLOUD_ORGANIZATION_ID, GX_CLOUD_ACCESS_TOKEN"
             )
-
-        return None
 
     def _get_file_context(
         self,

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -353,7 +353,9 @@ class ProjectManager:
                 cloud_organization_id=cloud_organization_id,
                 user_agent_str=user_agent_str,
             )
-        elif mode != "cloud":  # cloud mode not specified, and env vars not available
+        elif (
+            mode != "cloud" and not cloud_mode
+        ):  # cloud mode not specified, and env vars not available
             return None
         else:
             raise GXCloudConfigurationError(  # noqa: TRY003 # one time exception

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -194,6 +194,7 @@ class ProjectManager:
                 cloud_access_token=cloud_access_token,
                 cloud_organization_id=cloud_organization_id,
                 user_agent_str=user_agent_str,
+                cloud_mode=True,
             ),
             None: dict(
                 project_config=project_config,
@@ -245,7 +246,6 @@ class ProjectManager:
         expected_type = expected_ctx_types[mode]
         if not isinstance(context, expected_type):
             # example I want an ephemeral context but the presence of a GX_CLOUD env var gives me a cloud context  # noqa: E501 # FIXME CoP
-            # this kind of thing should not be possible but there may be some edge cases
             raise ValueError(  # noqa: TRY003, TRY004 # FIXME CoP
                 f"Provided mode {mode} returned context of type {type(context).__name__} instead of {expected_type.__name__}; please check your input arguments."  # noqa: E501 # FIXME CoP
             )
@@ -327,6 +327,9 @@ class ProjectManager:
         user_agent_str: str | None = None,
         cloud_mode: bool | None = None,
     ) -> CloudDataContext | None:
+        if cloud_mode is False:
+            return None  # user has specifically disabled cloud mode, so we don't check for env vars
+
         from great_expectations.data_context.data_context import CloudDataContext
 
         config_available = CloudDataContext.is_cloud_config_available(
@@ -335,8 +338,7 @@ class ProjectManager:
             cloud_organization_id=cloud_organization_id,
         )
 
-        # If config available and not explicitly disabled
-        if config_available and cloud_mode is not False:
+        if config_available:
             return CloudDataContext(
                 project_config=project_config,
                 runtime_environment=runtime_environment,
@@ -347,10 +349,10 @@ class ProjectManager:
                 cloud_organization_id=cloud_organization_id,
                 user_agent_str=user_agent_str,
             )
-
-        if cloud_mode and not config_available:
-            raise GXCloudConfigurationError(  # noqa: TRY003 # FIXME CoP
-                "GX Cloud Mode enabled, but missing env vars: GX_CLOUD_ORGANIZATION_ID, GX_CLOUD_ACCESS_TOKEN"  # noqa: E501 # FIXME CoP
+        else:
+            raise GXCloudConfigurationError(  # noqa: TRY003 # one time exception
+                "Unable to create a CloudDataContext due to one or more missing environment variables: " 
+                "GX_CLOUD_ORGANIZATION_ID, GX_CLOUD_ACCESS_TOKEN"
             )
 
         return None

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -21,7 +21,7 @@ from great_expectations.exceptions.exceptions import (
 from tests.test_utils import working_directory
 
 GX_CLOUD_PARAMS_ALL = {
-    "cloud_base_url": "http://hello.com",
+    "cloud_base_url": "localhost:7000",
     "cloud_organization_id": "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
     "cloud_access_token": "i_am_a_token",
 }
@@ -33,7 +33,7 @@ GX_CLOUD_PARAMS_REQUIRED = {
 
 @pytest.fixture()
 def set_up_cloud_envs(monkeypatch):
-    monkeypatch.setenv("GX_CLOUD_BASE_URL", "http://hello.com")
+    monkeypatch.setenv("GX_CLOUD_BASE_URL", "localhost:7000")
     monkeypatch.setenv("GX_CLOUD_ORGANIZATION_ID", "bd20fead-2c31-4392-bcd1-f1e87ad5a79c")
     monkeypatch.setenv("GX_CLOUD_ACCESS_TOKEN", "i_am_a_token")
 
@@ -170,7 +170,7 @@ def test_cloud_context_with_in_memory_config_overrides(
         return_value=empty_ge_cloud_data_context_config,
     ):
         context = gx.get_context(
-            cloud_base_url="http://hello.com",
+            cloud_base_url="localhost:7000",
             cloud_organization_id="bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
             cloud_access_token="i_am_a_token",
         )
@@ -192,7 +192,7 @@ def test_cloud_context_with_in_memory_config_overrides(
         )
         context = gx.get_context(
             project_config=config,
-            cloud_base_url="http://hello.com",
+            cloud_base_url="localhost:7000",
             cloud_organization_id="bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
             cloud_access_token="i_am_a_token",
         )


### PR DESCRIPTION
Previously, there was a bug where the legacy param `cloud_mode` would always be `None` in `ProjectManager._get_cloud_context`. As a result, the error intended for users who set `mode="cloud"` was never reached, and users received an opaque message about their DataContext being `None`. This PR clarifies the logic, and maintains the same behavior as before:
- if cloud envs are set, the user gets a CloudDataContext
- if cloud envs are set but the user specifies `cloud_mode=False`, the user gets an EphemeralDataContext
- if the user sets `mode=...`, it takes precedence over `cloud_mode`

Example of users hitting this bug: https://discourse.greatexpectations.io/t/valueerror-when-trying-to-create-clouddatacontext/2024