### PR TITLE
[BUGFIX] Quote password before passing to SnowflakeURL

### DIFF
--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -17,6 +17,7 @@ from typing import (
     Type,
     Union,
 )
+from urllib.parse import quote
 
 from great_expectations._docs_decorators import deprecated_method_or_class, public_api
 from great_expectations.compatibility import pydantic
@@ -788,6 +789,11 @@ class SnowflakeDatasource(SQLDatasource):
         if not url:
             url_args = self._get_url_args()
             url_args.update(kwargs)
+
+            password = url_args.get("password")
+            if isinstance(password, str):
+                url_args["password"] = quote(password)
+
             url = SnowflakeURL(**url_args)
         else:
             url_args = {}

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -12,6 +12,7 @@ import sqlalchemy as sa
 from pytest import param
 
 from great_expectations.compatibility import pydantic
+from great_expectations.compatibility.snowflake import URL as SnowflakeURL
 from great_expectations.compatibility.snowflake import snowflake
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent import (
@@ -892,6 +893,53 @@ def test_create_engine_is_called_with_expected_kwargs(
     print(engine)
 
     create_engine_spy.assert_called_once_with(**expected_called_with)
+
+
+@pytest.mark.parametrize(
+    ("password", "encoded_password"),
+    [
+        pytest.param("abc", "abc", id="no need to encode"),
+        pytest.param("a@b", "a%40b", id="encode it"),
+    ],
+)
+def test_test_connection_encoding(
+    mocker: MockerFixture,
+    ephemeral_context_with_defaults: AbstractDataContext,
+    password: str,
+    encoded_password: str,
+):
+    account = "account"
+    user = "foo"
+    role = "role"
+    warehouse = "warehouse"
+    db = "db"
+    schema = "schema"
+    create_engine_spy = mocker.patch.object(sa, "create_engine")
+
+    datasource = ephemeral_context_with_defaults.data_sources.add_snowflake(
+        name="foo",
+        account=account,
+        user=user,
+        password=password,
+        database=db,
+        schema=schema,
+        role=role,
+        warehouse=warehouse,
+    )
+    datasource.get_engine()
+
+    create_engine_spy.assert_called_with(
+        url=SnowflakeURL(
+            account=account,
+            user=user,
+            password=encoded_password,
+            database=db,
+            schema=schema,
+            role=role,
+            warehouse=warehouse,
+            application="great_expectations_core",
+        )
+    )
 
 
 @pytest.mark.unit

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -895,6 +895,7 @@ def test_create_engine_is_called_with_expected_kwargs(
     create_engine_spy.assert_called_once_with(**expected_called_with)
 
 
+@pytest.mark.snowflake
 @pytest.mark.parametrize(
     ("password", "encoded_password"),
     [


### PR DESCRIPTION

![Screenshot 2025-02-06 at 5 27 45 PM](https://github.com/user-attachments/assets/e88b6269-6440-48d1-bc74-3956fcbcdf37)

See screenshot for why. Without this, we can't connect to snowflake using special characters in passwords.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
