### PR TITLE
[BUGFIX] Trim the unexpected rows query

### DIFF
--- a/great_expectations/expectations/core/unexpected_rows_expectation.py
+++ b/great_expectations/expectations/core/unexpected_rows_expectation.py
@@ -113,7 +113,7 @@ class UnexpectedRowsExpectation(BatchExpectation):
             print(batch_warning_message)
             logger.info(batch_warning_message)
 
-        return query
+        return query.rstrip("; \t\r\n\v\f")
 
     class Config:
         title = "Custom Expectation with SQL"

--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -111,7 +111,7 @@ def test_unexpected_rows_expectation_validate(
 
 @pytest.mark.unit
 def test_unexpected_rows_expectation_correctly_interprets_query(
-        sqlite_batch: Batch,
+    sqlite_batch: Batch,
 ):
     query = "SELECT * FROM {batch}\r\n\t  ;\v\r ;"
 

--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -110,6 +110,17 @@ def test_unexpected_rows_expectation_validate(
 
 
 @pytest.mark.unit
+def test_unexpected_rows_expectation_correctly_interprets_query(
+        sqlite_batch: Batch,
+):
+    query = "SELECT * FROM {batch}\r\n\t  ;\v\r ;"
+
+    expectation = UnexpectedRowsExpectation(unexpected_rows_query=query)
+
+    assert expectation.unexpected_rows_query == "SELECT * FROM {batch}"
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "description, unexpected_rows_query",
     [


### PR DESCRIPTION
Allow trailing whitespace and `;` in the unexpected rows query.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
