### PR TITLE
[BUGFIX] Make `MetricConfiguration.id` immutable

### DIFF
--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -20,7 +20,7 @@ import pandas as pd
 from great_expectations._docs_decorators import deprecated_argument
 from great_expectations.compatibility import pyspark
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core.id_dict import BatchKwargs, BatchSpec, IDDict
+from great_expectations.core.id_dict import BatchKwargs, BatchSpec, IDDict, IDDictID
 from great_expectations.exceptions import InvalidBatchIdError
 from great_expectations.types import DictDot, SerializableDictDot, safe_deep_copy
 from great_expectations.util import (
@@ -223,7 +223,7 @@ class LegacyBatchDefinition(SerializableDictDot):
         self._batch_spec_passthrough = batch_spec_passthrough
 
     @property
-    def id(self) -> str:
+    def id(self) -> IDDictID:
         return IDDict(self.to_json_dict()).to_id()
 
     @property
@@ -354,7 +354,7 @@ class BatchRequestBase(SerializableDictDot):
         self._batch_spec_passthrough = value
 
     @property
-    def id(self) -> str:
+    def id(self) -> IDDictID:
         return IDDict(self.to_json_dict()).to_id()
 
     @override

--- a/great_expectations/core/domain.py
+++ b/great_expectations/core/domain.py
@@ -180,7 +180,7 @@ not exist as value of appropriate key in "domain_kwargs" dictionary.
     # Adding this property for convenience (also, in the future, arguments may not be all set to their default values).  # noqa: E501 # FIXME CoP
     @property
     def id(self) -> str:
-        return IDDict(self.to_json_dict()).to_id()
+        return str(IDDict(self.to_json_dict()).to_id())
 
     @override
     def to_json_dict(self) -> dict:

--- a/great_expectations/core/id_dict.py
+++ b/great_expectations/core/id_dict.py
@@ -4,16 +4,21 @@ import hashlib
 import json
 from typing import Any, Set, TypeVar, Union
 
+from typing_extensions import Never
+
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
 
 T = TypeVar("T")
 
 
+IDDictID = Union[str, tuple[Never, ...]]
+
+
 class IDDict(dict):
     _id_ignore_keys: Set[str] = set()
 
-    def to_id(self, id_keys=None, id_ignore_keys=None):
+    def to_id(self, id_keys=None, id_ignore_keys=None) -> IDDictID:
         if id_keys is None:
             id_keys = self.keys()
         if id_ignore_keys is None:

--- a/great_expectations/core/id_dict.py
+++ b/great_expectations/core/id_dict.py
@@ -4,15 +4,13 @@ import hashlib
 import json
 from typing import Any, Set, TypeVar, Union
 
-from typing_extensions import Never
-
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
 
 T = TypeVar("T")
 
 
-IDDictID = Union[str, tuple[Never, ...]]
+IDDictID = Union[str, tuple[()]]
 
 
 class IDDict(dict):
@@ -25,7 +23,7 @@ class IDDict(dict):
             id_ignore_keys = self._id_ignore_keys
         id_keys = set(id_keys) - set(id_ignore_keys)
         if len(id_keys) == 0:
-            return tuple()
+            return ()
         elif len(id_keys) == 1:
             key = list(id_keys)[0]
             return f"{key}={self[key]!s}"

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -32,9 +32,6 @@ from great_expectations.util import (
     filter_properties_dict,
 )
 from great_expectations.validator.computed_metric import MetricValue  # noqa: TCH001 # FIXME CoP
-from great_expectations.validator.metric_configuration import (
-    MetricConfiguration,  # noqa: TCH001 # FIXME CoP
-)
 
 if TYPE_CHECKING:
     from great_expectations.compatibility.pyspark import functions as F
@@ -47,6 +44,10 @@ if TYPE_CHECKING:
         BatchSpec,
     )
     from great_expectations.expectations.metrics.metric_provider import MetricProvider
+    from great_expectations.validator.metric_configuration import (
+        MetricConfiguration,
+        MetricConfigurationID,
+    )
     from great_expectations.validator.validator import Validator
 
 logger = logging.getLogger(__name__)
@@ -249,9 +250,9 @@ class ExecutionEngine(ABC):
     def resolve_metrics(
         self,
         metrics_to_resolve: Iterable[MetricConfiguration],
-        metrics: Optional[Dict[Tuple[str, str, str], MetricValue]] = None,
+        metrics: Optional[dict[MetricConfigurationID, MetricValue]] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> Dict[Tuple[str, str, str], MetricValue]:
+    ) -> dict[MetricConfigurationID, MetricValue]:
         """resolve_metrics is the main entrypoint for an execution engine. The execution engine will compute the value
         of the provided metrics.
 
@@ -281,7 +282,7 @@ class ExecutionEngine(ABC):
             metric_fn_bundle_configurations=metric_fn_bundle_configurations,
         )
 
-    def resolve_metric_bundle(self, metric_fn_bundle) -> Dict[Tuple[str, str, str], MetricValue]:
+    def resolve_metric_bundle(self, metric_fn_bundle) -> dict[MetricConfigurationID, MetricValue]:
         """Resolve a bundle of metrics with the same compute Domain as part of a single trip to the compute engine."""  # noqa: E501 # FIXME CoP
         raise NotImplementedError
 
@@ -372,7 +373,7 @@ class ExecutionEngine(ABC):
     def _build_direct_and_bundled_metric_computation_configurations(
         self,
         metrics_to_resolve: Iterable[MetricConfiguration],
-        metrics: Optional[Dict[Tuple[str, str, str], MetricValue]] = None,
+        metrics: Optional[dict[MetricConfigurationID, MetricValue]] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> Tuple[
         List[MetricComputationConfiguration],
@@ -471,7 +472,7 @@ class ExecutionEngine(ABC):
     def _get_computed_metric_evaluation_dependencies_by_metric_name(
         self,
         metric_to_resolve: MetricConfiguration,
-        metrics: Dict[Tuple[str, str, str], MetricValue],
+        metrics: Dict[MetricConfigurationID, MetricValue],
     ) -> Dict[str, Union[MetricValue, Tuple[Any, dict, dict]]]:
         """
         Gathers resolved (already computed) evaluation dependencies of metric-to-resolve (not yet computed)
@@ -511,7 +512,7 @@ class ExecutionEngine(ABC):
         self,
         metric_fn_direct_configurations: List[MetricComputationConfiguration],
         metric_fn_bundle_configurations: List[MetricComputationConfiguration],
-    ) -> Dict[Tuple[str, str, str], MetricValue]:
+    ) -> dict[MetricConfigurationID, MetricValue]:
         """
         This method processes directly-computable and bundled "MetricComputationConfiguration" objects.
 
@@ -522,7 +523,7 @@ class ExecutionEngine(ABC):
         Returns:
             resolved_metrics (Dict): a dictionary with the values for the metrics that have just been resolved.
         """  # noqa: E501 # FIXME CoP
-        resolved_metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+        resolved_metrics: dict[MetricConfigurationID, MetricValue] = {}
 
         metric_computation_configuration: MetricComputationConfiguration
 
@@ -541,7 +542,7 @@ class ExecutionEngine(ABC):
 
         try:
             # an engine-specific way of computing metrics together
-            resolved_metric_bundle: Dict[Tuple[str, str, str], MetricValue] = (
+            resolved_metric_bundle: dict[MetricConfigurationID, MetricValue] = (
                 self.resolve_metric_bundle(metric_fn_bundle=metric_fn_bundle_configurations)
             )
             resolved_metrics.update(resolved_metric_bundle)

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -59,6 +59,8 @@ from great_expectations.expectations.model_field_types import CONDITION_PARSER_P
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
+    from great_expectations.validator.metric_configuration import MetricConfigurationID
+
 logger = logging.getLogger(__name__)
 
 
@@ -479,7 +481,7 @@ not {batch_spec.__class__.__name__}"""  # noqa: E501 # FIXME CoP
             )
 
     @override
-    def resolve_metric_bundle(self, metric_fn_bundle) -> Dict[Tuple[str, str, str], Any]:
+    def resolve_metric_bundle(self, metric_fn_bundle) -> dict[MetricConfigurationID, Any]:
         """Resolve a bundle of metrics with the same compute Domain as part of a single trip to the compute engine."""  # noqa: E501 # FIXME CoP
         return {}  # This is NO-OP for "PandasExecutionEngine" (no bundling for direct execution computational backend).  # noqa: E501 # FIXME CoP
 

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -10,7 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Iterable,
     List,
     Optional,
@@ -36,7 +35,7 @@ from great_expectations.core.batch_spec import (
     PathBatchSpec,
     RuntimeDataBatchSpec,
 )
-from great_expectations.core.id_dict import IDDict
+from great_expectations.core.id_dict import IDDict, IDDictID
 from great_expectations.core.metric_domain_types import (
     MetricDomainTypes,  # noqa: TCH001 # FIXME CoP
 )
@@ -72,12 +71,13 @@ from great_expectations.expectations.row_conditions import (
 )
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
 from great_expectations.validator.computed_metric import MetricValue  # noqa: TCH001 # FIXME CoP
-from great_expectations.validator.metric_configuration import (
-    MetricConfiguration,  # noqa: TCH001 # FIXME CoP
-)
 
 if TYPE_CHECKING:
     from great_expectations.datasource.fluent.spark_datasource import SparkConfig
+    from great_expectations.validator.metric_configuration import (
+        MetricConfiguration,
+        MetricConfigurationID,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -850,7 +850,7 @@ illegal.  Please check your config."""  # noqa: E501 # FIXME CoP
     def resolve_metric_bundle(
         self,
         metric_fn_bundle: Iterable[MetricComputationConfiguration],
-    ) -> Dict[Tuple[str, str, str], MetricValue]:
+    ) -> dict[MetricConfigurationID, MetricValue]:
         """For every metric in a set of Metrics to resolve, obtains necessary metric keyword arguments and builds
         bundles of the metrics into one large query dictionary so that they are all executed simultaneously. Will fail
         if bundling the metrics together is not possible.
@@ -864,15 +864,15 @@ illegal.  Please check your config."""  # noqa: E501 # FIXME CoP
             Returns:
                 A dictionary of "MetricConfiguration" IDs and their corresponding fully resolved values for domains.
         """  # noqa: E501 # FIXME CoP
-        resolved_metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+        resolved_metrics: dict[MetricConfigurationID, MetricValue] = {}
 
         res: List[pyspark.Row]
 
-        aggregates: Dict[Tuple[str, str, str], dict] = {}
+        aggregates: dict[IDDictID, dict] = {}
 
         aggregate: dict
 
-        domain_id: Tuple[str, str, str]
+        domain_id: IDDictID
 
         bundled_metric_configuration: MetricComputationConfiguration
         for bundled_metric_configuration in metric_fn_bundle:
@@ -913,7 +913,7 @@ illegal.  Please check your config."""  # noqa: E501 # FIXME CoP
             ), "unexpected number of metrics returned"
 
             idx: int
-            metric_id: Tuple[str, str, str]
+            metric_id: MetricConfigurationID
             for idx, metric_id in enumerate(aggregate["metric_ids"]):
                 # Converting DataFrame.collect() results into JSON-serializable format produces simple data types,  # noqa: E501 # FIXME CoP
                 # amenable for subsequent post-processing by higher-level "Metric" and "Expectation" layers.  # noqa: E501 # FIXME CoP

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -300,7 +300,7 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
         # computes the same metric over more than one domain
         # ValidationDependencies does not allow duplicate metric names
         # and the registry is checked to ensure the metric name is registered
-        # As a work-around, after the regsitry check
+        # As a work-around, after the registry check
         # we create a second table.row_count metric for the other table manually
         # and rename the metrics defined in ValidationDependencies
         table_row_count_metric_config_self: Optional[MetricConfiguration] = (

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -300,6 +300,7 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
         # computes the same metric over more than one domain
         # ValidationDependencies does not allow duplicate metric names
         # and the registry is checked to ensure the metric name is registered
+        # as a side effect of the super().get_validation_dependencies() call above
         # As a work-around, after the registry check
         # we create a second table.row_count metric for the other table manually
         # and rename the metrics defined in ValidationDependencies

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -24,7 +24,7 @@ from great_expectations.render.renderer_configuration import (
     RendererValueType,
 )
 from great_expectations.render.util import num_to_str, substitute_none_for_missing
-from great_expectations.validator.metric_configuration import (  # FIXME CoP
+from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
 )
 

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -24,7 +24,7 @@ from great_expectations.render.renderer_configuration import (
     RendererValueType,
 )
 from great_expectations.render.util import num_to_str, substitute_none_for_missing
-from great_expectations.validator.metric_configuration import (  # noqa: TCH001 # FIXME CoP
+from great_expectations.validator.metric_configuration import (  # FIXME CoP
     MetricConfiguration,
 )
 
@@ -296,23 +296,27 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
         kwargs = configuration.kwargs if configuration else {}
         other_table_name = kwargs.get("other_table_name")
 
-        # create copy of table.row_count metric and modify "table" metric domain kwarg to be other table name  # noqa: E501 # FIXME CoP
-        table_row_count_metric_config_other: Optional[MetricConfiguration] = deepcopy(
+        # At this time, this is the only Expectation that
+        # computes the same metric over more than one domain
+        # ValidationDependencies does not allow duplicate metric names
+        # and checks the registry to ensure the metric name is registered before this step
+        # As a work-around, after the regsitry check
+        # we create a second table.row_count metric for the other table manually
+        table_row_count_metric_config_self: Optional[MetricConfiguration] = (
             validation_dependencies.get_metric_configuration(metric_name="table.row_count")
         )
-        assert (
-            table_row_count_metric_config_other
-        ), "table_row_count_metric_config_other should not be None"
-
-        table_row_count_metric_config_other.metric_domain_kwargs["table"] = other_table_name
-        # rename original "table.row_count" metric to "table.row_count.self"
-        table_row_count_metric = validation_dependencies.get_metric_configuration(
-            metric_name="table.row_count"
+        assert table_row_count_metric_config_self, "table_row_count_metric should not be None"
+        copy_table_row_count_metric_config_self = deepcopy(table_row_count_metric_config_self)
+        copy_table_row_count_metric_config_self.metric_domain_kwargs["table"] = other_table_name
+        table_row_count_metric_config_other = MetricConfiguration(
+            metric_name="table.row_count",
+            metric_domain_kwargs=copy_table_row_count_metric_config_self.metric_domain_kwargs,
+            metric_value_kwargs=copy_table_row_count_metric_config_self.metric_value_kwargs,
         )
-        assert table_row_count_metric, "table_row_count_metric should not be None"
+        # rename original "table.row_count" metric to "table.row_count.self"
         validation_dependencies.set_metric_configuration(
             metric_name="table.row_count.self",
-            metric_configuration=table_row_count_metric,
+            metric_configuration=table_row_count_metric_config_self,
         )
         validation_dependencies.remove_metric_configuration(metric_name="table.row_count")
         # add a new metric dependency named "table.row_count.other" with modified metric config

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -299,15 +299,17 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
         # At this time, this is the only Expectation that
         # computes the same metric over more than one domain
         # ValidationDependencies does not allow duplicate metric names
-        # and checks the registry to ensure the metric name is registered before this step
+        # and the registry is checked to ensure the metric name is registered
         # As a work-around, after the regsitry check
         # we create a second table.row_count metric for the other table manually
+        # and rename the metrics defined in ValidationDependencies
         table_row_count_metric_config_self: Optional[MetricConfiguration] = (
             validation_dependencies.get_metric_configuration(metric_name="table.row_count")
         )
         assert table_row_count_metric_config_self, "table_row_count_metric should not be None"
         copy_table_row_count_metric_config_self = deepcopy(table_row_count_metric_config_self)
         copy_table_row_count_metric_config_self.metric_domain_kwargs["table"] = other_table_name
+        # instantiating a new MetricConfiguration gives us a new id
         table_row_count_metric_config_other = MetricConfiguration(
             metric_name="table.row_count",
             metric_domain_kwargs=copy_table_row_count_metric_config_self.metric_domain_kwargs,

--- a/great_expectations/experimental/metric_repository/metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_retriever.py
@@ -83,8 +83,8 @@ class MetricRetriever(abc.ABC):
         if metric_lookup_key is None:
             metric_lookup_key = MetricConfigurationID(
                 metric_name,
-                tuple(),
-                tuple(),
+                (),
+                (),
             )
         value = None
         metric_exception = None
@@ -237,7 +237,7 @@ class MetricRetriever(abc.ABC):
 
         for metric_name in column_metric_names:
             for column in column_list:
-                metric_lookup_key = MetricConfigurationID(metric_name, f"column={column}", tuple())
+                metric_lookup_key = MetricConfigurationID(metric_name, f"column={column}", ())
                 value, exception = self._get_metric_from_computed_metrics(
                     metric_name=metric_name,
                     metric_lookup_key=metric_lookup_key,
@@ -294,7 +294,7 @@ class MetricRetriever(abc.ABC):
     def _get_table_column_types(self, batch_request: BatchRequest) -> Metric:
         metric_name = MetricTypes.TABLE_COLUMN_TYPES
 
-        metric_lookup_key = MetricConfigurationID(metric_name, tuple(), tuple())
+        metric_lookup_key = MetricConfigurationID(metric_name, (), ())
         table_metric_configs = self._generate_table_metric_configurations(
             table_metric_names=[metric_name]
         )

--- a/great_expectations/experimental/metric_repository/metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_retriever.py
@@ -20,7 +20,10 @@ from great_expectations.experimental.metric_repository.metrics import (
 )
 from great_expectations.experimental.rule_based_profiler.domain_builder import ColumnDomainBuilder
 from great_expectations.validator.exception_info import ExceptionInfo
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 
 if TYPE_CHECKING:
     from great_expectations.data_context import AbstractDataContext
@@ -28,7 +31,6 @@ if TYPE_CHECKING:
     from great_expectations.experimental.metric_repository.metrics import Metric
     from great_expectations.validator.metrics_calculator import (
         _AbortedMetricsInfoDict,
-        _MetricKey,
         _MetricsDict,
     )
     from great_expectations.validator.validator import (
@@ -71,7 +73,7 @@ class MetricRetriever(abc.ABC):
         metric_name: str | MetricTypes,
         computed_metrics: _MetricsDict,
         aborted_metrics: _AbortedMetricsInfoDict,
-        metric_lookup_key: _MetricKey | None = None,
+        metric_lookup_key: MetricConfigurationID | None = None,
     ) -> tuple[Any, MetricException | None]:
         # look up is done by string
         # TODO: update to be MetricTypes once MetricListMetricRetriever implementation is complete.
@@ -79,7 +81,7 @@ class MetricRetriever(abc.ABC):
             metric_name = metric_name.value
 
         if metric_lookup_key is None:
-            metric_lookup_key = (
+            metric_lookup_key = MetricConfigurationID(
                 metric_name,
                 tuple(),
                 tuple(),
@@ -232,11 +234,10 @@ class MetricRetriever(abc.ABC):
         # Convert computed_metrics
         ColumnMetric.update_forward_refs()
         metrics: list[Metric] = []
-        metric_lookup_key: _MetricKey
 
         for metric_name in column_metric_names:
             for column in column_list:
-                metric_lookup_key = (metric_name, f"column={column}", tuple())
+                metric_lookup_key = MetricConfigurationID(metric_name, f"column={column}", tuple())
                 value, exception = self._get_metric_from_computed_metrics(
                     metric_name=metric_name,
                     metric_lookup_key=metric_lookup_key,
@@ -293,7 +294,7 @@ class MetricRetriever(abc.ABC):
     def _get_table_column_types(self, batch_request: BatchRequest) -> Metric:
         metric_name = MetricTypes.TABLE_COLUMN_TYPES
 
-        metric_lookup_key: _MetricKey = (metric_name, tuple(), tuple())
+        metric_lookup_key = MetricConfigurationID(metric_name, tuple(), tuple())
         table_metric_configs = self._generate_table_metric_configurations(
             table_metric_names=[metric_name]
         )

--- a/great_expectations/experimental/metric_repository/metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_retriever.py
@@ -293,7 +293,7 @@ class MetricRetriever(abc.ABC):
     def _get_table_column_types(self, batch_request: BatchRequest) -> Metric:
         metric_name = MetricTypes.TABLE_COLUMN_TYPES
 
-        metric_lookup_key: _MetricKey = (metric_name, tuple(), "include_nested=True")
+        metric_lookup_key: _MetricKey = (metric_name, tuple(), tuple())
         table_metric_configs = self._generate_table_metric_configurations(
             table_metric_names=[metric_name]
         )

--- a/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
+++ b/great_expectations/experimental/rule_based_profiler/attributed_resolved_metrics.py
@@ -16,6 +16,7 @@ from great_expectations.util import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.core.id_dict import IDDictID
     from great_expectations.experimental.rule_based_profiler.metric_computation_result import (
         MetricValues,
     )
@@ -135,7 +136,7 @@ class AttributedResolvedMetrics(SerializableDictDot):
         self.metric_values_by_batch_id[batch_id] = value
 
     @property
-    def id(self) -> str:
+    def id(self) -> IDDictID:
         if self.metric_attributes is None:
             return ""
 

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1068,9 +1068,6 @@ def build_spark_engine(
     ):
         raise ValueError("Exactly one of batch_id or batch_definition must be specified.")  # noqa: TRY003 # FIXME CoP
 
-    if batch_id is None:
-        batch_id = cast(LegacyBatchDefinition, batch_definition).id
-
     if isinstance(df, pd.DataFrame):
         if schema is None:
             data: Union[pd.DataFrame, List[tuple]] = [
@@ -1091,7 +1088,7 @@ def build_spark_engine(
     execution_engine = SparkDFExecutionEngine(
         spark_config=spark_config,
         batch_data_dict={
-            batch_id: df,
+            batch_id or cast(LegacyBatchDefinition, batch_definition).id: df,
         },
     )
     return execution_engine

--- a/great_expectations/validator/exception_info.py
+++ b/great_expectations/validator/exception_info.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core import IDDict
+from great_expectations.core.id_dict import IDDict, IDDictID
 from great_expectations.types.base import SerializableDotDict
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
 
@@ -52,7 +52,7 @@ class ExceptionInfo(SerializableDotDict):
         return str(fields_dict)
 
     @property
-    def id(self) -> str:
+    def id(self) -> IDDictID:
         return IDDict(self.to_json_dict()).to_id()
 
     def __eq__(self, other):  # type: ignore[explicit-override] # FIXME

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -51,6 +51,12 @@ class MetricConfiguration:
 
         self._metric_dependencies: IDDict = IDDict({})
 
+        self._id = (
+            self.metric_name,
+            self.metric_domain_kwargs_id,
+            self.metric_value_kwargs_id,
+        )
+
     def __repr__(self):  # type: ignore[explicit-override] # FIXME
         return json.dumps(self.to_json_dict(), indent=2)
 
@@ -153,11 +159,7 @@ class MetricConfiguration:
 
     @property
     def id(self) -> Tuple[str, str, str]:
-        return (
-            self.metric_name,
-            self.metric_domain_kwargs_id,
-            self.metric_value_kwargs_id,
-        )
+        return self._id
 
     def to_json_dict(self) -> dict:
         """Returns a JSON-serializable dict representation of this MetricConfiguration.

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Optional, Tuple, Union
+from typing import NamedTuple, Optional, Union
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.domain import Domain
@@ -9,6 +9,12 @@ from great_expectations.core.id_dict import IDDict
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.experimental.metric_repository.metrics import MetricTypes
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
+
+
+class MetricConfigurationID(NamedTuple):
+    metric_name: str
+    metric_domain_kwargs_id: str
+    metric_value_kwargs_id: str
 
 
 class MetricConfiguration:
@@ -35,7 +41,6 @@ class MetricConfiguration:
     ) -> None:
         if isinstance(metric_name, MetricTypes):
             metric_name = metric_name.value
-        self._metric_name = metric_name
 
         if not isinstance(metric_domain_kwargs, IDDict):
             metric_domain_kwargs = IDDict(metric_domain_kwargs)
@@ -51,10 +56,10 @@ class MetricConfiguration:
 
         self._metric_dependencies: IDDict = IDDict({})
 
-        self._id = (
-            self.metric_name,
-            self.metric_domain_kwargs_id,
-            self.metric_value_kwargs_id,
+        self._id = MetricConfigurationID(
+            metric_name,
+            metric_domain_kwargs.to_id(),
+            metric_value_kwargs.to_id(),
         )
 
     def __repr__(self):  # type: ignore[explicit-override] # FIXME
@@ -66,7 +71,7 @@ class MetricConfiguration:
 
     @property
     def metric_name(self) -> str:
-        return self._metric_name
+        return self.id.metric_name
 
     @property
     def metric_domain_kwargs(self) -> IDDict:
@@ -78,11 +83,11 @@ class MetricConfiguration:
 
     @property
     def metric_domain_kwargs_id(self) -> str:
-        return self.metric_domain_kwargs.to_id()
+        return self.id.metric_domain_kwargs_id
 
     @property
     def metric_value_kwargs_id(self) -> str:
-        return self.metric_value_kwargs.to_id()
+        return self.id.metric_value_kwargs_id
 
     @property
     def metric_dependencies(self) -> IDDict:
@@ -158,7 +163,7 @@ class MetricConfiguration:
         return MetricDomainTypes.TABLE
 
     @property
-    def id(self) -> Tuple[str, str, str]:
+    def id(self) -> MetricConfigurationID:
         return self._id
 
     def to_json_dict(self) -> dict:

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -51,12 +51,6 @@ class MetricConfiguration:
 
         self._metric_dependencies: IDDict = IDDict({})
 
-        self._id = (
-            self.metric_name,
-            self.metric_domain_kwargs_id,
-            self.metric_value_kwargs_id,
-        )
-
     def __repr__(self):  # type: ignore[explicit-override] # FIXME
         return json.dumps(self.to_json_dict(), indent=2)
 
@@ -159,7 +153,11 @@ class MetricConfiguration:
 
     @property
     def id(self) -> Tuple[str, str, str]:
-        return self._id
+        return (
+            self.metric_name,
+            self.metric_domain_kwargs_id,
+            self.metric_value_kwargs_id,
+        )
 
     def to_json_dict(self) -> dict:
         """Returns a JSON-serializable dict representation of this MetricConfiguration.

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -5,7 +5,7 @@ from typing import NamedTuple, Optional, Union
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.domain import Domain
-from great_expectations.core.id_dict import IDDict
+from great_expectations.core.id_dict import IDDict, IDDictID
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.experimental.metric_repository.metrics import MetricTypes
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
@@ -13,8 +13,8 @@ from great_expectations.util import convert_to_json_serializable  # noqa: TID251
 
 class MetricConfigurationID(NamedTuple):
     metric_name: str
-    metric_domain_kwargs_id: str
-    metric_value_kwargs_id: str
+    metric_domain_kwargs_id: IDDictID
+    metric_value_kwargs_id: IDDictID
 
 
 class MetricConfiguration:
@@ -82,11 +82,11 @@ class MetricConfiguration:
         return self._metric_value_kwargs
 
     @property
-    def metric_domain_kwargs_id(self) -> str:
+    def metric_domain_kwargs_id(self) -> IDDictID:
         return self.id.metric_domain_kwargs_id
 
     @property
-    def metric_value_kwargs_id(self) -> str:
+    def metric_value_kwargs_id(self) -> IDDictID:
         return self.id.metric_value_kwargs_id
 
     @property

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.exception_info import ExceptionInfo
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from great_expectations.validator.validation_graph import ValidationGraph
 
 if TYPE_CHECKING:
@@ -19,10 +21,9 @@ logger = logging.getLogger(__name__)
 logging.captureWarnings(True)
 
 
-_MetricKey: TypeAlias = Union[Tuple[str, Hashable, Hashable], Tuple[str, str, str]]
-_MetricsDict: TypeAlias = Dict[_MetricKey, MetricValue]
+_MetricsDict: TypeAlias = Dict[MetricConfigurationID, MetricValue]
 _AbortedMetricsInfoDict: TypeAlias = Dict[
-    _MetricKey,
+    MetricConfigurationID,
     Dict[str, Union[MetricConfiguration, ExceptionInfo, int]],
 ]
 

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -19,7 +19,10 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.registry import get_metric_provider
 from great_expectations.validator.exception_info import ExceptionInfo
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 
 if TYPE_CHECKING:
     from great_expectations.core import IDDict
@@ -31,7 +34,6 @@ if TYPE_CHECKING:
     from great_expectations.validator.computed_metric import MetricValue
     from great_expectations.validator.metrics_calculator import (
         _AbortedMetricsInfoDict,
-        _MetricKey,
     )
 
 __all__ = [
@@ -196,10 +198,10 @@ class ValidationGraph:
         # Set to low number (e.g., 3) to suppress progress bar for small graphs.
         show_progress_bars: bool = True,
     ) -> Tuple[
-        Dict[_MetricKey, MetricValue],
+        Dict[MetricConfigurationID, MetricValue],
         _AbortedMetricsInfoDict,
     ]:
-        resolved_metrics: Dict[_MetricKey, MetricValue] = {}
+        resolved_metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
         # updates graph with aborted metrics
         aborted_metrics_info: _AbortedMetricsInfoDict = self._resolve(
@@ -213,7 +215,7 @@ class ValidationGraph:
 
     def _resolve(  # noqa: C901, PLR0912, PLR0915 # FIXME CoP
         self,
-        metrics: Dict[_MetricKey, MetricValue],
+        metrics: Dict[MetricConfigurationID, MetricValue],
         runtime_configuration: Optional[dict] = None,
         min_graph_edges_pbar_enable: int = 0,  # Set to low number (e.g., 3) to suppress progress bar for small graphs.  # noqa: E501 # FIXME CoP
         show_progress_bars: bool = True,
@@ -323,7 +325,7 @@ class ValidationGraph:
 
     def _parse(
         self,
-        metrics: Dict[_MetricKey, MetricValue],
+        metrics: Dict[MetricConfigurationID, MetricValue],
     ) -> Tuple[Set[MetricConfiguration], Set[MetricConfiguration]]:
         """Given validation graph, returns the ready and needed metrics necessary for validation using a traversal of
         validation graph (a graph structure of metric ids) edges"""  # noqa: E501 # FIXME CoP
@@ -403,7 +405,7 @@ class ExpectationValidationGraph:
     ) -> Dict[str, Union[MetricConfiguration, ExceptionInfo, int]]:
         metric_info = self._filter_metric_info_in_graph(metric_info=metric_info)
         metric_exception_info: Dict[str, Union[MetricConfiguration, ExceptionInfo, int]] = {}
-        metric_id: _MetricKey
+        metric_id: MetricConfigurationID
         metric_info_item: Dict[str, Union[MetricConfiguration, ExceptionInfo, int]]
         for metric_id, metric_info_item in metric_info.items():
             metric_exception_info[str(metric_id)] = metric_info_item["exception_info"]
@@ -414,7 +416,7 @@ class ExpectationValidationGraph:
         self,
         metric_info: _AbortedMetricsInfoDict,
     ) -> _AbortedMetricsInfoDict:
-        graph_metric_ids: List[_MetricKey] = []
+        graph_metric_ids: List[MetricConfigurationID] = []
         edge: MetricEdge
         vertex: MetricConfiguration
         for edge in self.graph.edges:
@@ -422,7 +424,7 @@ class ExpectationValidationGraph:
                 if vertex is not None:
                     graph_metric_ids.append(vertex.id)
 
-        metric_id: _MetricKey
+        metric_id: MetricConfigurationID
         metric_info_item: Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]]
         return {
             metric_id: metric_info_item

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -276,8 +276,8 @@ class ValidationGraph:
                 # Access "ExecutionEngine.resolve_metrics()" method, to resolve missing "MetricConfiguration" objects.  # noqa: E501 # FIXME CoP
                 metrics.update(
                     self._execution_engine.resolve_metrics(
-                        metrics_to_resolve=computable_metrics,  # type: ignore[arg-type]  # Metric typing needs further refinement.
-                        metrics=metrics,  # type: ignore[arg-type]  # Metric typing needs further refinement.
+                        metrics_to_resolve=computable_metrics,
+                        metrics=metrics,
                         runtime_configuration=runtime_configuration,
                     )
                 )

--- a/tests/datasource/fluent/integration/integration_test_utils.py
+++ b/tests/datasource/fluent/integration/integration_test_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Tuple
 
 import pytest
 
@@ -19,7 +18,10 @@ from great_expectations.datasource.fluent.interfaces import (
 from great_expectations.exceptions.exceptions import DataContextError
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.validator.computed_metric import MetricValue
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from great_expectations.validator.metrics_calculator import MetricsCalculator
 from tests.expectations.test_util import get_table_columns_metric
 
@@ -135,10 +137,10 @@ def run_batch_head(  # noqa: C901 # FIXME CoP
         execution_engine: ExecutionEngine = batch.data.execution_engine
         execution_engine.batch_manager.load_batch_list(batch_list=[batch])
 
-        metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+        metrics: dict[MetricConfigurationID, MetricValue] = {}
 
         table_columns_metric: MetricConfiguration
-        results: Dict[Tuple[str, str, str], MetricValue]
+        results: dict[MetricConfigurationID, MetricValue]
 
         table_columns_metric, results = get_table_columns_metric(execution_engine=execution_engine)
         metrics.update(results)

--- a/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
@@ -81,7 +81,7 @@ def test_get_metrics_table_metrics_only(
     computed_metrics = {
         ("table.row_count", (), ()): 2,
         ("table.columns", (), ()): ["col1", "col2"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {"name": "col2", "type": "float"},
         ],
@@ -132,7 +132,7 @@ def test_get_metrics_full_list(
     computed_metrics = {
         ("table.row_count", (), ()): 2,
         ("table.columns", (), ()): ["col1", "col2"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {"name": "col2", "type": "float"},
         ],
@@ -325,7 +325,7 @@ def test_get_metrics_metrics_missing(
     mock_computed_metrics = {
         # ("table.row_count", (), ()): 2, # Missing table.row_count metric
         ("table.columns", (), ()): ["col1", "col2"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {"name": "col2", "type": "float"},
         ],
@@ -426,7 +426,7 @@ def test_get_metrics_with_exception(
     computed_metrics = {
         # ("table.row_count", (), ()): 2, # Error in table.row_count metric
         ("table.columns", (), ()): ["col1", "col2"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {"name": "col2", "type": "float"},
         ],
@@ -497,7 +497,7 @@ def test_get_metrics_with_column_type_missing(
     computed_metrics = {
         # ("table.row_count", (), ()): 2, # Error in table.row_count metric
         ("table.columns", (), ()): ["col1", "col2"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {
                 "name": "col2",
@@ -570,7 +570,7 @@ def test_get_metrics_with_timestamp_columns(
     computed_metrics = {
         ("table.row_count", (), ()): 2,
         ("table.columns", (), ()): ["timestamp_col"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "timestamp_col", "type": "TIMESTAMP_NTZ"},
         ],
         ("column.min", "column=timestamp_col", ()): "2023-01-01T00:00:00",
@@ -648,7 +648,7 @@ def test_get_metrics_only_gets_a_validator_once(
     computed_metrics = {
         ("table.row_count", (), ()): 2,
         ("table.columns", (), ()): ["col1", "col2"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {"name": "col2", "type": "float"},
         ],
@@ -683,7 +683,7 @@ def test_get_metrics_only_gets_new_validator_on_asset_change(
     computed_metrics = {
         ("table.row_count", (), ()): 2,
         ("table.columns", (), ()): ["col1", "col2"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {"name": "col2", "type": "float"},
         ],
@@ -767,7 +767,7 @@ def test_get_table_column_types(
     mocker: MockerFixture, mock_context, mock_validator, mock_batch_request, metric_retriever
 ):
     computed_metrics = {
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "col1", "type": "float"},
             {"name": "col2", "type": "float"},
         ],
@@ -821,7 +821,7 @@ def test_get_metrics_with_timestamp_columns_exclude_time(
     computed_metrics = {
         ("table.row_count", (), ()): 2,
         ("table.columns", (), ()): ["timestamp_col", "time_col"],
-        ("table.column_types", (), "include_nested=True"): [
+        ("table.column_types", (), ()): [
             {"name": "timestamp_col", "type": "TIMESTAMP_NTZ"},
             {"name": "time_col", "type": "TIME"},
         ],


### PR DESCRIPTION
- Makes `MetricConfiguration.id` immutable, and updates references to mutated `id`s
- Narrows types by adding `MetricConfigurationID` and `IDDictID` and update references

There is buggy behavior where `MetricConfiguration.id`s are changing in the middle of metric computation, due to changes in `metric_domain_kwargs` and `metric_value_kwargs`, which are referenced in the `id` property.

---------

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated