### PR TITLE
[DOCS] Feedback form issues should have status "intake"

### DIFF
--- a/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
+++ b/docs/docusaurus/netlify/functions/createJiraTicketInDocsBoard.js
@@ -48,18 +48,6 @@ exports.handler = async (req, context) => {
 
         const result = await response.json()
 
-        if (result.id) {
-            try {
-                await httpPostRequest(`${JIRA_ISSUE_ENDPOINT_URL}/${result.id}/transitions`, {
-                    "transition": {
-                        "id": TO_DO_STATE_ID
-                    }
-                })
-            } catch (error) {
-                console.error("Fetch failed", error.message)
-            }
-        }
-
         return {
             statusCode: response.status,
             body: JSON.stringify(result)


### PR DESCRIPTION
[Jira Ticket ](https://greatexpectations.atlassian.net/jira/software/c/projects/DSB/boards/79?assignee=712020%3A309fac2a-9c8e-412d-aa31-c2bbd94510b0&selectedIssue=DOC-1039)

[Deploy Preview](https://deploy-preview-10933.docs.greatexpectations.io/docs/cloud/overview/gx_cloud_overview#:~:text=Was%20this%20topic,No)

## Description

After completing a feedbak form in the documentation, a Jira Ticket is created. This ticket should stay in "Intake" status instead of changing it to "To-do" 

Deleted test where the ticket is created and stays in "intake" status
![image](https://github.com/user-attachments/assets/30cd59dd-ddfb-4862-ab9d-c00fcca7ecc3)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
