### PR TITLE
[MAINTENANCE] Make `Metric.config` un-instantiable and excluded from auto-complete

### DIFF
--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -1,4 +1,5 @@
 import re
+from functools import cache
 from typing import ClassVar, Final
 
 from typing_extensions import dataclass_transform
@@ -78,7 +79,9 @@ class Metric(BaseModel, metaclass=MetaMetric):
 
     @property
     def config(self) -> MetricConfiguration:
-        return self._to_config()
+        return Metric._metric_to_config(
+            instance_class=self.__class__, metric_value_set=frozenset(self.dict().items())
+        )
 
     @staticmethod
     def _pascal_to_snake(class_name: str) -> str:
@@ -114,11 +117,15 @@ class Metric(BaseModel, metaclass=MetaMetric):
         # that a Domain exists in __bases__ should have been confirmed in MetaMetric.__new__
         raise MixinTypeError(cls.__name__, "Domain")
 
-    def _to_config(self) -> MetricConfiguration:
+    @staticmethod
+    @cache
+    def _metric_to_config(
+        instance_class: type["Metric"], metric_value_set: frozenset
+    ) -> MetricConfiguration:
         """Returns a MetricConfiguration instance for this Metric."""
-        instance_class = self.__class__
         metric_domain_kwargs = {}
         metric_value_kwargs = {}
+        metric_values = dict(metric_value_set)
         for base_type in instance_class.__bases__:
             if issubclass(base_type, Domain):
                 domain_fields = base_type.__fields__
@@ -129,11 +136,11 @@ class Metric(BaseModel, metaclass=MetaMetric):
                     if field_name not in domain_fields and field_name not in metric_fields
                 }
                 for field_name, field_info in domain_fields.items():
-                    metric_domain_kwargs[field_name] = self.dict().get(
+                    metric_domain_kwargs[field_name] = metric_values.get(
                         field_name, field_info.default
                     )
                 for field_name, field_info in value_fields.items():
-                    metric_value_kwargs[field_name] = self.dict().get(
+                    metric_value_kwargs[field_name] = metric_values.get(
                         field_name, field_info.default
                     )
 

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -79,7 +79,7 @@ class Metric(BaseModel, metaclass=MetaMetric):
 
     @property
     def config(self) -> MetricConfiguration:
-        return Metric._metric_to_config(
+        return Metric._to_config(
             instance_class=self.__class__,
             metric_value_set=frozenset(self.dict().items()),
         )
@@ -120,7 +120,7 @@ class Metric(BaseModel, metaclass=MetaMetric):
 
     @staticmethod
     @cache
-    def _metric_to_config(
+    def _to_config(
         instance_class: type["Metric"], metric_value_set: frozenset
     ) -> MetricConfiguration:
         """Returns a MetricConfiguration instance for this Metric."""

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -3,7 +3,7 @@ from typing import ClassVar, Final
 
 from typing_extensions import dataclass_transform
 
-from great_expectations.compatibility.pydantic import BaseModel, ModelMetaclass, root_validator
+from great_expectations.compatibility.pydantic import BaseModel, ModelMetaclass
 from great_expectations.metrics.domain import AbstractClassInstantiationError, Domain
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
@@ -61,7 +61,6 @@ class Metric(BaseModel, metaclass=MetaMetric):
     """
 
     name: ClassVar[str]
-    config: MetricConfiguration
 
     class Config:
         arbitrary_types_allowed = True
@@ -73,16 +72,13 @@ class Metric(BaseModel, metaclass=MetaMetric):
         cls.name = cls._get_metric_name()
         return super().__new__(cls)
 
-    @root_validator(pre=True)
-    @classmethod
-    def _set_config(cls, values) -> dict:
-        if "config" not in values or values["config"] is None:
-            values["config"] = cls._to_config(values)
-        return values
-
     @property
     def id(self) -> MetricConfigurationID:
         return self.config.id
+
+    @property
+    def config(self) -> MetricConfiguration:
+        return self._to_config()
 
     @staticmethod
     def _pascal_to_snake(class_name: str) -> str:
@@ -118,31 +114,31 @@ class Metric(BaseModel, metaclass=MetaMetric):
         # that a Domain exists in __bases__ should have been confirmed in MetaMetric.__new__
         raise MixinTypeError(cls.__name__, "Domain")
 
-    @classmethod
-    def _to_config(cls, model_values: dict) -> MetricConfiguration:
+    def _to_config(self) -> MetricConfiguration:
         """Returns a MetricConfiguration instance for this Metric."""
+        instance_class = self.__class__
         metric_domain_kwargs = {}
         metric_value_kwargs = {}
-        for base_type in cls.__bases__:
+        for base_type in instance_class.__bases__:
             if issubclass(base_type, Domain):
                 domain_fields = base_type.__fields__
                 metric_fields = Metric.__fields__
                 value_fields = {
                     field_name: field_info
-                    for field_name, field_info in cls.__fields__.items()
+                    for field_name, field_info in instance_class.__fields__.items()
                     if field_name not in domain_fields and field_name not in metric_fields
                 }
                 for field_name, field_info in domain_fields.items():
-                    metric_domain_kwargs[field_name] = model_values.get(
+                    metric_domain_kwargs[field_name] = self.dict().get(
                         field_name, field_info.default
                     )
                 for field_name, field_info in value_fields.items():
-                    metric_value_kwargs[field_name] = model_values.get(
+                    metric_value_kwargs[field_name] = self.dict().get(
                         field_name, field_info.default
                     )
 
         return MetricConfiguration(
-            metric_name=cls.name,
+            metric_name=instance_class.name,
             metric_domain_kwargs=metric_domain_kwargs,
             metric_value_kwargs=metric_value_kwargs,
         )

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -43,12 +43,12 @@ class Metric(BaseModel, metaclass=MetaMetric):
     Examples:
         A metric for column nullity values computed on each row:
 
-        >>> class Null(Metric, ColumnValues):
+        >>> class ColumnValuesNull(Metric, ColumnValues):
         ...     ...
 
         A metric for a single table row count value:
 
-        >>> class RowCount(Metric, Table):
+        >>> class TableRowCount(Metric, Table):
         ...     ...
 
     Notes:

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -121,7 +121,7 @@ class Metric(BaseModel, metaclass=MetaMetric):
     @staticmethod
     @cache
     def _to_config(
-        instance_class: type["Metric"], metric_value_set: frozenset
+        instance_class: type["Metric"], metric_value_set: frozenset[tuple]
     ) -> MetricConfiguration:
         """Returns a MetricConfiguration instance for this Metric."""
         metric_domain_kwargs = {}

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -80,7 +80,8 @@ class Metric(BaseModel, metaclass=MetaMetric):
     @property
     def config(self) -> MetricConfiguration:
         return Metric._metric_to_config(
-            instance_class=self.__class__, metric_value_set=frozenset(self.dict().items())
+            instance_class=self.__class__,
+            metric_value_set=frozenset(self.dict().items()),
         )
 
     @staticmethod


### PR DESCRIPTION
This makes `Metric.config` un-instantiable and removes it from auto-complete

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
