### PR TITLE
[BUGFIX] remove unused domain key

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1577,9 +1577,7 @@ class BatchExpectation(Expectation, ABC):
 
     batch_id: Union[str, None] = None
 
-    domain_keys: ClassVar[Tuple[str, ...]] = (
-        "batch_id",
-    )
+    domain_keys: ClassVar[Tuple[str, ...]] = ("batch_id",)
     metric_dependencies: ClassVar[Tuple[str, ...]] = ()
     domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.TABLE
     args_keys: ClassVar[Tuple[str, ...]] = ()

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1579,7 +1579,6 @@ class BatchExpectation(Expectation, ABC):
 
     domain_keys: ClassVar[Tuple[str, ...]] = (
         "batch_id",
-        "table",
     )
     metric_dependencies: ClassVar[Tuple[str, ...]] = ()
     domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.TABLE
@@ -1867,7 +1866,6 @@ class ColumnMapExpectation(BatchExpectation, ABC):
     map_metric: ClassVar[Optional[str]] = None
     domain_keys: ClassVar[Tuple[str, ...]] = (
         "batch_id",
-        "table",
         "column",
         "row_condition",
         "condition_parser",


### PR DESCRIPTION
The `table` domain key is unused, and causes many log messages when attempting to resolve metrics.