### PR TITLE
[MAINTENANCE] Require `Metric.name` instead of using `name` inference

### DIFF
--- a/great_expectations/metrics/batch/batch.py
+++ b/great_expectations/metrics/batch/batch.py
@@ -3,7 +3,8 @@ from great_expectations.metrics.metric import Metric
 from great_expectations.metrics.metric_results import MetricResult
 
 
-class BatchRowCount(Metric, Batch): ...
+class BatchRowCount(Metric, Batch):
+    name = "table.row_count"
 
 
 class BatchRowCountResult(MetricResult[int]): ...

--- a/great_expectations/metrics/column_values/between.py
+++ b/great_expectations/metrics/column_values/between.py
@@ -6,6 +6,8 @@ from great_expectations.metrics.metric import Metric
 
 
 class ColumnValuesBetween(Metric, ColumnValues):
+    name = "column_values.between.condition"
+
     min_value: Optional[Comparable] = None
     max_value: Optional[Comparable] = None
     strict_min: bool = False

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -20,11 +20,6 @@ class MixinTypeError(TypeError):
         )
 
 
-class MissingAttributeError(AttributeError):
-    def __init__(self, class_name: str, attribute_name: str) -> None:
-        super().__init__(f"`{class_name}` must define the `{attribute_name}` attribute.")
-
-
 @dataclass_transform()
 class MetaMetric(ModelMetaclass):
     def __new__(cls, name, bases, attrs):
@@ -34,8 +29,6 @@ class MetaMetric(ModelMetaclass):
             or not any(issubclass(base_type, Domain) for base_type in bases)
         ):
             raise MixinTypeError(name, "Domain")
-        if name != "Metric" and not attrs.get("name"):
-            raise MissingAttributeError(name, "name")
         return super().__new__(cls, name, bases, attrs)
 
 

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -1,10 +1,9 @@
-import re
 from functools import cache
 from typing import ClassVar, Final
 
 from typing_extensions import dataclass_transform
 
-from great_expectations.compatibility.pydantic import BaseModel, ModelMetaclass
+from great_expectations.compatibility.pydantic import BaseModel, ModelMetaclass, StrictStr
 from great_expectations.metrics.domain import AbstractClassInstantiationError, Domain
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
@@ -21,6 +20,11 @@ class MixinTypeError(TypeError):
         )
 
 
+class MissingAttributeError(AttributeError):
+    def __init__(self, class_name: str, attribute_name: str) -> None:
+        super().__init__(f"`{class_name}` must define the `{attribute_name}` attribute.")
+
+
 @dataclass_transform()
 class MetaMetric(ModelMetaclass):
     def __new__(cls, name, bases, attrs):
@@ -30,6 +34,8 @@ class MetaMetric(ModelMetaclass):
             or not any(issubclass(base_type, Domain) for base_type in bases)
         ):
             raise MixinTypeError(name, "Domain")
+        if name != "Metric" and not attrs.get("name"):
+            raise MissingAttributeError(name, "name")
         return super().__new__(cls, name, bases, attrs)
 
 
@@ -61,7 +67,7 @@ class Metric(BaseModel, metaclass=MetaMetric):
         MetricConfiguration: Configuration class for metric computation
     """
 
-    name: ClassVar[str]
+    name: ClassVar[StrictStr]
 
     class Config:
         arbitrary_types_allowed = True
@@ -70,7 +76,6 @@ class Metric(BaseModel, metaclass=MetaMetric):
     def __new__(cls, *args, **kwargs):
         if cls is Metric:
             raise AbstractClassInstantiationError(cls.__name__)
-        cls.name = cls._get_metric_name()
         return super().__new__(cls)
 
     @property
@@ -83,41 +88,6 @@ class Metric(BaseModel, metaclass=MetaMetric):
             instance_class=self.__class__,
             metric_value_set=frozenset(self.dict().items()),
         )
-
-    @staticmethod
-    def _pascal_to_snake(class_name: str) -> str:
-        # Adds an underscore between a sequence of uppercase letters and an uppercase-lowercase pair
-        # APIFunctionMetric -> API_FunctionMetric
-        class_name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", class_name)
-        # Adds an underscore between a lowercase letter/digit and an uppercase letter
-        # APIFunctionMetric -> API_Function_Metric
-        class_name = re.sub(r"([a-z\d])([A-Z])", r"\1_\2", class_name)
-        # Convert the entire string to lowercase
-        # API_Function_Metric -> api_function_metric
-        return class_name.lower()
-
-    @classmethod
-    def _get_metric_name(cls) -> str:
-        """The name of the metric as it exists in the registry."""
-        for base_type in cls.__bases__:
-            if issubclass(base_type, Domain):
-                domain_class_name = str(base_type.__name__)
-                metric_class_name = str(cls.__name__)
-                domain_class_snake_case = Metric._pascal_to_snake(domain_class_name)
-                translated_domain_name = domain_class_snake_case.replace("batch", "table")
-                metric_class_snake_case = Metric._pascal_to_snake(metric_class_name)
-                # the convention is that the metric class name includes the domain class name
-                # but the metric names don't repeat the domain name, so we remove it
-                return ".".join(
-                    [
-                        translated_domain_name,
-                        metric_class_snake_case.replace(domain_class_snake_case, "").strip("_"),
-                    ]
-                )
-
-        # this should never be reached
-        # that a Domain exists in __bases__ should have been confirmed in MetaMetric.__new__
-        raise MixinTypeError(cls.__name__, "Domain")
 
     @staticmethod
     @cache

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -34,7 +34,7 @@ class TestMetricDefinition:
     @pytest.mark.unit
     def test_success(self):
         class ColumnValuesAbove(Metric, ColumnValues):
-            name = "column_values.above"
+            name = FULLY_QUALIFIED_METRIC_NAME
 
             min_value: Comparable
             strict_min: bool = False
@@ -44,7 +44,7 @@ class TestMetricDefinition:
         with pytest.raises(MixinTypeError):
 
             class ColumnValuesAbove(Metric):
-                name = "column_values.above"
+                name = FULLY_QUALIFIED_METRIC_NAME
 
                 min_value: Comparable
                 strict_min: bool = False
@@ -54,7 +54,7 @@ class TestMetricDefinition:
         with pytest.raises(MixinTypeError):
 
             class ColumnValuesAbove(Metric, ColumnValues, MockDomain):
-                name = "column_values.above"
+                name = FULLY_QUALIFIED_METRIC_NAME
 
                 min_value: Comparable
                 strict_min: bool = False
@@ -64,7 +64,7 @@ class TestMetricDefinition:
         with pytest.raises(MixinTypeError):
 
             class ColumnValuesAbove(Metric, NotADomain):
-                name = "column_values.above"
+                name = FULLY_QUALIFIED_METRIC_NAME
 
                 min_value: Comparable
                 strict_min: bool = False
@@ -80,7 +80,7 @@ class TestMetricDefinition:
 
 class TestMetricInstantiation:
     class ColumnValuesAbove(Metric, ColumnValues):
-        name = "column_values.above"
+        name = FULLY_QUALIFIED_METRIC_NAME
 
         min_value: Comparable
         strict_min: bool = False
@@ -102,7 +102,7 @@ class TestMetricInstantiation:
 
 class TestMetricConfig:
     class ColumnValuesAbove(Metric, ColumnValues):
-        name = "column_values.above"
+        name = FULLY_QUALIFIED_METRIC_NAME
 
         min_value: Comparable
         strict_min: bool = False
@@ -138,7 +138,7 @@ class TestMetricConfig:
 
 class TestMetricImmutability:
     class ColumnValuesAbove(Metric, ColumnValues):
-        name = "column_values.above"
+        name = FULLY_QUALIFIED_METRIC_NAME
 
         min_value: Comparable
         strict_min: bool = False

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -3,7 +3,7 @@ import pytest
 from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.core.types import Comparable
 from great_expectations.metrics.domain import AbstractClassInstantiationError, ColumnValues, Domain
-from great_expectations.metrics.metric import Metric, MissingAttributeError, MixinTypeError
+from great_expectations.metrics.metric import Metric, MixinTypeError
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
     MetricConfigurationID,
@@ -66,14 +66,6 @@ class TestMetricDefinition:
             class ColumnValuesAbove(Metric, NotADomain):
                 name = FULLY_QUALIFIED_METRIC_NAME
 
-                min_value: Comparable
-                strict_min: bool = False
-
-    @pytest.mark.unit
-    def test_missing_name_raises(self):
-        with pytest.raises(MissingAttributeError):
-
-            class ColumnValuesAbove(Metric, ColumnValues):
                 min_value: Comparable
                 strict_min: bool = False
 

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -3,7 +3,7 @@ import pytest
 from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.core.types import Comparable
 from great_expectations.metrics.domain import AbstractClassInstantiationError, ColumnValues, Domain
-from great_expectations.metrics.metric import Metric, MixinTypeError
+from great_expectations.metrics.metric import Metric, MissingAttributeError, MixinTypeError
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
     MetricConfigurationID,
@@ -34,6 +34,8 @@ class TestMetricDefinition:
     @pytest.mark.unit
     def test_success(self):
         class ColumnValuesAbove(Metric, ColumnValues):
+            name = "column_values.above"
+
             min_value: Comparable
             strict_min: bool = False
 
@@ -42,6 +44,8 @@ class TestMetricDefinition:
         with pytest.raises(MixinTypeError):
 
             class ColumnValuesAbove(Metric):
+                name = "column_values.above"
+
                 min_value: Comparable
                 strict_min: bool = False
 
@@ -50,6 +54,8 @@ class TestMetricDefinition:
         with pytest.raises(MixinTypeError):
 
             class ColumnValuesAbove(Metric, ColumnValues, MockDomain):
+                name = "column_values.above"
+
                 min_value: Comparable
                 strict_min: bool = False
 
@@ -58,28 +64,24 @@ class TestMetricDefinition:
         with pytest.raises(MixinTypeError):
 
             class ColumnValuesAbove(Metric, NotADomain):
+                name = "column_values.above"
+
                 min_value: Comparable
                 strict_min: bool = False
 
     @pytest.mark.unit
-    def test_metric_name_inference(self):
-        class ColumnValuesAbove(Metric, ColumnValues):
-            min_value: Comparable
-            strict_min: bool = False
+    def test_missing_name_raises(self):
+        with pytest.raises(MissingAttributeError):
 
-        assert (
-            ColumnValuesAbove(
-                batch_id=BATCH_ID,
-                table=TABLE,
-                column=COLUMN,
-                min_value=42,
-            ).name
-            == FULLY_QUALIFIED_METRIC_NAME
-        )
+            class ColumnValuesAbove(Metric, ColumnValues):
+                min_value: Comparable
+                strict_min: bool = False
 
 
 class TestMetricInstantiation:
     class ColumnValuesAbove(Metric, ColumnValues):
+        name = "column_values.above"
+
         min_value: Comparable
         strict_min: bool = False
 
@@ -100,6 +102,8 @@ class TestMetricInstantiation:
 
 class TestMetricConfig:
     class ColumnValuesAbove(Metric, ColumnValues):
+        name = "column_values.above"
+
         min_value: Comparable
         strict_min: bool = False
 
@@ -134,6 +138,8 @@ class TestMetricConfig:
 
 class TestMetricImmutability:
     class ColumnValuesAbove(Metric, ColumnValues):
+        name = "column_values.above"
+
         min_value: Comparable
         strict_min: bool = False
 


### PR DESCRIPTION
The inference step is going to be too hard to maintain due to inconsistencies in naming conventions in the legacy system

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated