### PR TITLE
[MAINTENANCE] Remove `table` parameter from all Metric `Domain`s

### DIFF
--- a/great_expectations/metrics/domain.py
+++ b/great_expectations/metrics/domain.py
@@ -25,7 +25,6 @@ class Domain(BaseModel):
 class Values(Domain):
     """The abstract base class for metric domain types that compute row-level calculations."""
 
-    table: NonEmptyString
     row_condition: Optional[StrictStr] = None
 
     def __new__(cls, *args, **kwargs):
@@ -43,7 +42,6 @@ class ColumnValues(Values):
 
     Attributes:
         batch_id (str): Unique identifier for the batch being processed.
-        table (str): Name of the table containing the column.
         column (str): Name of the column to compute metrics on.
         row_condition (Optional[str]): A condition that can be used to filter rows.
                                        See: https://docs.greatexpectations.io/docs/core/customize_expectations/expectation_conditions/#create-an-expectation-condition
@@ -69,6 +67,5 @@ class Batch(Domain):
     with the Metric class when defining a new Metric.
     """
 
-    table: Optional[NonEmptyString] = None
     row_condition: Optional[StrictStr] = None
     condition_parser: Optional[ConditionParser] = None

--- a/tests/metrics/batch/test_batch.py
+++ b/tests/metrics/batch/test_batch.py
@@ -83,10 +83,7 @@ class TestBatchRowCount:
                 show_progress_bars=False,
             )
             batch.data.execution_engine.batch_manager.load_batch_list(batch_list=[batch])
-            metric = BatchRowCount(
-                batch_id=batch.id,
-                table=batch_setup.table_name,
-            )
+            metric = BatchRowCount(batch_id=batch.id)
             result = BatchRowCountResult(
                 id=metric.id, value=metrics_calculator.get_metric(metric=metric.config)
             )

--- a/tests/metrics/test_domain.py
+++ b/tests/metrics/test_domain.py
@@ -10,7 +10,6 @@ from great_expectations.metrics.domain import (
 )
 
 BATCH_ID = "my_data_source-my_data_asset-year_2025"
-TABLE = "my_table"
 COLUMN = "my_column"
 
 
@@ -23,21 +22,20 @@ class TestAbstractClasses:
     @pytest.mark.unit
     def test_values_instantiation_raises(self):
         with pytest.raises(AbstractClassInstantiationError):
-            Values(batch_id=BATCH_ID, table=TABLE)
+            Values(batch_id=BATCH_ID)
 
 
 class TestColumnValues:
     @pytest.mark.unit
     def test_instantiation(self):
-        ColumnValues(batch_id=BATCH_ID, table=TABLE, column=COLUMN)
+        ColumnValues(batch_id=BATCH_ID, column=COLUMN)
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "kwargs",
         [
-            {"batch_id": "", "table": TABLE, "column": COLUMN},
-            {"batch_id": BATCH_ID, "table": "", "column": COLUMN},
-            {"batch_id": BATCH_ID, "table": TABLE, "column": ""},
+            {"batch_id": "", "column": COLUMN},
+            {"batch_id": BATCH_ID, "column": ""},
         ],
     )
     def test_arguments_empty_string_raises(self, kwargs: dict):
@@ -55,6 +53,4 @@ class TestColumnValues:
 class TestBatch:
     @pytest.mark.unit
     def test_instantiation(self):
-        Batch(
-            batch_id=BATCH_ID, table=TABLE, row_condition='PClass=="1st"', condition_parser="pandas"
-        )
+        Batch(batch_id=BATCH_ID, row_condition='PClass=="1st"', condition_parser="pandas")

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -10,7 +10,6 @@ from great_expectations.validator.metric_configuration import (
 )
 
 BATCH_ID = "my_data_source-my_data_asset-year_2025"
-TABLE = "my_table"
 COLUMN = "my_column"
 
 FULLY_QUALIFIED_METRIC_NAME = "column_values.above"
@@ -27,7 +26,7 @@ class TestMetric:
     @pytest.mark.unit
     def test_metric_instantiation_raises(self):
         with pytest.raises(AbstractClassInstantiationError):
-            Metric(batch_id=BATCH_ID, table=TABLE, column=COLUMN)
+            Metric(batch_id=BATCH_ID, column=COLUMN)
 
 
 class TestMetricDefinition:
@@ -81,7 +80,6 @@ class TestMetricInstantiation:
     def test_instantiation_success(self):
         self.ColumnValuesAbove(
             batch_id=BATCH_ID,
-            table=TABLE,
             column=COLUMN,
             min_value=42,
         )
@@ -105,7 +103,6 @@ class TestMetricConfig:
             metric_name=FULLY_QUALIFIED_METRIC_NAME,
             metric_domain_kwargs={
                 "batch_id": BATCH_ID,
-                "table": TABLE,
                 "row_condition": None,
                 "column": COLUMN,
             },
@@ -117,7 +114,6 @@ class TestMetricConfig:
 
         actual_config = self.ColumnValuesAbove(
             batch_id=BATCH_ID,
-            table=TABLE,
             column=COLUMN,
             min_value=42,
         ).config
@@ -139,19 +135,17 @@ class TestMetricImmutability:
     def test_domain_kwarg_immutability_success(self):
         column_values_above = self.ColumnValuesAbove(
             batch_id=BATCH_ID,
-            table=TABLE,
             column=COLUMN,
             min_value=42,
         )
 
         with pytest.raises(TypeError):
-            column_values_above.table = "updated_table"
+            column_values_above.column = "updated_column"
 
     @pytest.mark.unit
     def test_value_kwarg_immutability_success(self):
         column_values_above = self.ColumnValuesAbove(
             batch_id=BATCH_ID,
-            table=TABLE,
             column=COLUMN,
             min_value=42,
         )


### PR DESCRIPTION
- Remove `table` parameter from `Domain` in new Metrics API
- Follow up to https://github.com/great-expectations/great_expectations/pull/10951
----------------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
