### PR TITLE
[DOCS] Args and Raises in API reference should be able to display several rows

### DIFF
--- a/docs/sphinx_api_docs_source/utils.py
+++ b/docs/sphinx_api_docs_source/utils.py
@@ -98,19 +98,21 @@ def create_table(soup, item, dd, title):
     p = dd.find("p")
     if p is None:
         return
-    columns = []
 
     if title in ("Parameters", "Raises"):
-        columns = p.get_text().split(" – ")  # noqa: RUF001
-        if len(columns) != 2:
-            return
+        for p in dd.find_all("p"):
+            columns = p.get_text().split(" – ")  # noqa: RUF001
+            if len(columns) != 2:
+                return
+            create_row(soup, tbody, columns)
+
     if title == "Returns":
         type_text = closest_return_type(dd)
         if type_text == "":
             return
         columns = [type_text, p.get_text()]
+        create_row(soup, tbody, columns)
 
-    create_row(soup, tbody, columns)
     dd.find_previous_sibling("dt").extract()
     dd.extract()
     table.append(tbody)


### PR DESCRIPTION
## Description
A bug in the manipulation of Args and Raises data in the API reference pages caused only one row to be displayed in each method, resulting on loss of information. This PR aims to fix this error and support having multiple Args and Raises in each method

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/c7a138af-4df9-4e9c-89de-32e49258a6bf)

### After
![image](https://github.com/user-attachments/assets/ed12768d-fa69-4a76-8154-c4baddc28c10)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
