### PR TITLE
[DOCS] Adds script to update links when new docs version is cut

### DIFF
--- a/scripts/explicit_docusaurus_version_in_api_reference_links.py
+++ b/scripts/explicit_docusaurus_version_in_api_reference_links.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import sys
+
+if __name__ == "__main__":
+    version_to_update = sys.argv[1]
+    folder_path = f"../docs/docusaurus/versioned_docs/version-{version_to_update}/reference/api"
+    for file in Path(folder_path).rglob('*'):
+        if file.is_file():
+            try:
+                with file.open('r', encoding='utf-8') as f:
+                    file_content = f.read()
+
+                replaced_content = file_content.replace("/docs/reference/api", f"/docs/{version_to_update}/reference/api")
+
+                with file.open('w', encoding='utf-8') as f:
+                    f.write(replaced_content)
+
+            except Exception as e:
+                print(f"Error processing file {file}: {e}")

--- a/scripts/explicit_docusaurus_version_in_api_reference_links.py
+++ b/scripts/explicit_docusaurus_version_in_api_reference_links.py
@@ -1,19 +1,20 @@
-from pathlib import Path
-
 import sys
+from pathlib import Path
 
 if __name__ == "__main__":
     version_to_update = sys.argv[1]
     folder_path = f"../docs/docusaurus/versioned_docs/version-{version_to_update}/reference/api"
-    for file in Path(folder_path).rglob('*'):
+    for file in Path(folder_path).rglob("*"):
         if file.is_file():
             try:
-                with file.open('r', encoding='utf-8') as f:
+                with file.open("r", encoding="utf-8") as f:
                     file_content = f.read()
 
-                replaced_content = file_content.replace("/docs/reference/api", f"/docs/{version_to_update}/reference/api")
+                replaced_content = file_content.replace(
+                    "/docs/reference/api", f"/docs/{version_to_update}/reference/api"
+                )
 
-                with file.open('w', encoding='utf-8') as f:
+                with file.open("w", encoding="utf-8") as f:
                     f.write(replaced_content)
 
             except Exception as e:


### PR DESCRIPTION
## Description
As the API Reference doc files are generated with sphinx and later manipulated with beautiful soup, links for a newly cut version of docusaurus will not be updated correctly automatically. The purpose of this script is to be able to update all the links of api reference mdx files inside `versioned_docs` folder.

## How to use

1. Cut new version of Docusaurus first
2. Run the script passing as a param the last archived version (so for example if old version was 1.1.0 and you release version 1.2.0 after cut, you should pass 1.1.0 as a parameter)
`python3 explicit_docusaurus_version_in_api_reference_links.py 1.1.0`
This will result on the internal links on version 1.1.0 folder to have the version explicitly set in the links so they won't break when the page is up 

---

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
