### PR TITLE
[BUGFIX] Fix 3 batch.compute_metrics bugs and enforce len(metrics) == len(results)

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -21,7 +21,6 @@ from typing import (
     Mapping,
     MutableMapping,
     MutableSequence,
-    NamedTuple,
     Optional,
     Protocol,
     Sequence,
@@ -59,16 +58,12 @@ from great_expectations.exceptions.exceptions import (
     MissingDataContextError,
 )
 from great_expectations.metrics.metric import MetaMetric, Metric
-from great_expectations.metrics.metric_name import MetricNameSuffix
 from great_expectations.metrics.metric_results import (
     MetricErrorResult,
-    MetricErrorResultValue,
     MetricResult,
 )
 from great_expectations.validator.metrics_calculator import (
     MetricsCalculator,
-    _AbortedMetricsInfoDict,
-    _MetricsDict,
 )
 
 logger = logging.getLogger(__name__)
@@ -109,8 +104,6 @@ if TYPE_CHECKING:
         TypeLookup,
     )
     from great_expectations.expectations.expectation import Expectation
-    from great_expectations.validator.computed_metric import MetricValue
-    from great_expectations.validator.metric_configuration import MetricConfigurationID
     from great_expectations.validator.v1_validator import (
         Validator as V1Validator,
     )
@@ -1012,16 +1005,6 @@ class Datasource(
 _BASE_DATASOURCE_FIELD_NAMES: Final[Set[str]] = {name for name in Datasource.__fields__}
 
 
-class RawMetric(NamedTuple):
-    metric_configuration_id: MetricConfigurationID
-    value: MetricValue
-
-
-class RawMetricError(NamedTuple):
-    metric_configuration_id: MetricConfigurationID
-    value: MetricErrorResultValue
-
-
 @dataclasses.dataclass(frozen=True)
 class HeadData:
     """
@@ -1302,88 +1285,32 @@ class Batch:
             this by adding an explicit annotation (e.g. metrics: list[Metric] = ...)
             https://github.com/python/mypy/issues/18712
         """
+        is_single_metric = False
         if isinstance(metrics, Metric):
             metrics = [metrics]
+            is_single_metric = True
 
         metrics_calculator = self._get_metrics_calculator()
-
-        requested_metric_names = [metric.name for metric in metrics]
-        metrics_calculator_result = metrics_calculator.compute_metrics(
+        metrics_calculator_results, metrics_calculator_errors = metrics_calculator.compute_metrics(
             metric_configurations=[metric.config(batch_id=self.id) for metric in metrics],
             runtime_configuration=None,
         )
-        return self.metrics_calculator_result_to_metric_result(
-            requested_metric_names=requested_metric_names,
-            metrics_calculator_result=metrics_calculator_result,
-        )
 
-    @classmethod
-    def _metrics_calculator_result_to_metrics_hashmaps(
-        cls, metrics_calculator_result: tuple[_MetricsDict, _AbortedMetricsInfoDict]
-    ) -> tuple[
-        dict[str, RawMetric],
-        dict[str, RawMetricError],
-    ]:
-        # add another level of nesting to these metric dicts
-        # since the key we care about is nested inside the current key
-        # enables us to iterate through these dicts only once
-        raw_metrics = {
-            metric_configuration_id.metric_name: RawMetric(metric_configuration_id, value)
-            for metric_configuration_id, value in metrics_calculator_result[0].items()
-        }
-        raw_metrics_errors = {
-            metric_configuration_id.metric_name: RawMetricError(metric_configuration_id, value)
-            for metric_configuration_id, value in metrics_calculator_result[1].items()
-        }
-        return raw_metrics, raw_metrics_errors
-
-    @classmethod
-    def _parse_raw_metric_to_metric_result_value(
-        cls, metric_name: str, raw_metric: RawMetric
-    ) -> MetricValue:
-        # "condition" metrics return the domain and value kwargs
-        # we just want the value, which is the first item in the tuple
-        if metric_name.endswith(MetricNameSuffix.CONDITION) and isinstance(raw_metric.value, tuple):
-            value = raw_metric.value[0]
-        else:
-            value = raw_metric.value
-        return value
-
-    @classmethod
-    def metrics_calculator_result_to_metric_result(
-        cls,
-        requested_metric_names: list[str],
-        metrics_calculator_result: tuple[_MetricsDict, _AbortedMetricsInfoDict],
-    ) -> MetricResult | list[MetricResult]:
-        """Converts the result of MetricsCalculator.compute_metrics() into
-        a MetricResult or list[MetricResult]. Only the metrics that were
-        requested in the call to MetricsCalculator.compute_metrics()
-        will be returned (dependency metrics are excluded)."""
-        raw_metrics, raw_metrics_errors = cls._metrics_calculator_result_to_metrics_hashmaps(
-            metrics_calculator_result
-        )
-        metric_results = []
-        for metric_name in requested_metric_names:
-            if metric_name in raw_metrics:
-                MetricType = MetaMetric.get_registered_metric_class_from_metric_name(metric_name)
+        results = []
+        for metric in metrics:
+            metric_id_for_batch = metric.metric_id_for_batch(batch_id=self.id)
+            if metric_id_for_batch in metrics_calculator_results:
+                MetricType = MetaMetric.get_registered_metric_class_from_metric_name(metric.name)
                 MetricResultType = MetricType.get_metric_result_type()
-                value = cls._parse_raw_metric_to_metric_result_value(
-                    metric_name, raw_metrics[metric_name]
-                )
-                metric_results.append(
-                    MetricResultType(
-                        id=raw_metrics[metric_name].metric_configuration_id,
-                        value=value,
-                    )
-                )
-            elif metric_name in raw_metrics_errors:
-                metric_results.append(
-                    MetricErrorResult(
-                        id=raw_metrics_errors[metric_name].metric_configuration_id,
-                        value=raw_metrics_errors[metric_name].value,
-                    )
-                )
+                value = metrics_calculator_results[metric_id_for_batch]
+                results.append(MetricResultType(id=metric_id_for_batch, value=value))
+            elif metric_id_for_batch in metrics_calculator_errors:
+                value = metrics_calculator_errors[metric_id_for_batch]
+                results.append(MetricErrorResult(id=metric_id_for_batch, value=value))
+            else:
+                # TODO: Replace this with a more specific error and add to result list
+                raise Exception()
 
-        if len(metric_results) == 1:
-            return metric_results[0]
-        return metric_results
+        if is_single_metric:
+            return results[0]
+        return results

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -58,6 +58,7 @@ from great_expectations.exceptions.exceptions import (
     MissingDataContextError,
 )
 from great_expectations.metrics.metric import MetaMetric, Metric
+from great_expectations.metrics.metric_name import MetricNameSuffix
 from great_expectations.metrics.metric_results import (
     MetricErrorResult,
     MetricInternalErrorResult,
@@ -106,6 +107,7 @@ if TYPE_CHECKING:
         TypeLookup,
     )
     from great_expectations.expectations.expectation import Expectation
+    from great_expectations.validator.computed_metric import MetricValue
     from great_expectations.validator.v1_validator import (
         Validator as V1Validator,
     )
@@ -1304,7 +1306,10 @@ class Batch:
             if metric_id_for_batch in metrics_calculator_results:
                 MetricType = MetaMetric.get_registered_metric_class_from_metric_name(metric.name)
                 MetricResultType = MetricType.get_metric_result_type()
-                value = metrics_calculator_results[metric_id_for_batch]
+                value = self._parse_metric_value(
+                    metric_name=metric.name,
+                    metric_calculator_result=metrics_calculator_results[metric_id_for_batch],
+                )
                 results.append(MetricResultType(id=metric_id_for_batch, value=value))
             elif metric_id_for_batch in metrics_calculator_errors:
                 value = metrics_calculator_errors[metric_id_for_batch]
@@ -1324,3 +1329,14 @@ class Batch:
         if is_single_metric:
             return results[0]
         return results
+
+    def _parse_metric_value(
+        self, metric_name: str, metric_calculator_result: MetricValue
+    ) -> MetricValue:
+        if metric_name.endswith(MetricNameSuffix.CONDITION) and isinstance(
+            metric_calculator_result, tuple
+        ):
+            value = metric_calculator_result[0]
+        else:
+            value = metric_calculator_result
+        return value

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -60,6 +60,8 @@ from great_expectations.exceptions.exceptions import (
 from great_expectations.metrics.metric import MetaMetric, Metric
 from great_expectations.metrics.metric_results import (
     MetricErrorResult,
+    MetricInternalErrorResult,
+    MetricInternalErrorResultValue,
     MetricResult,
 )
 from great_expectations.validator.metrics_calculator import (
@@ -1308,8 +1310,16 @@ class Batch:
                 value = metrics_calculator_errors[metric_id_for_batch]
                 results.append(MetricErrorResult(id=metric_id_for_batch, value=value))
             else:
-                # TODO: Replace this with a more specific error and add to result list
-                raise Exception()
+                results.append(
+                    MetricInternalErrorResult(
+                        id=metric_id_for_batch,
+                        value=MetricInternalErrorResultValue(
+                            msg=f"Metric {metric.name} not found in results: "
+                            "{list(metrics_calculator_results.keys())} or errors: "
+                            "{list(metrics_calculator_errors.keys())}"
+                        ),
+                    )
+                )
 
         if is_single_metric:
             return results[0]

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -105,6 +105,7 @@ class Metric(Generic[_MetricResult], BaseModel, metaclass=MetaMetric):
     name: ClassVar[StrictStr]
 
     _domain_fields: ClassVar[tuple[str, ...]] = (
+        "batch_id",
         "column",
         "row_condition",
         "column_A",
@@ -129,11 +130,12 @@ class Metric(Generic[_MetricResult], BaseModel, metaclass=MetaMetric):
         # when the same batch_id is passed in.
         if not batch_id:
             raise EmptyStrError("batch_id")
+
         config = Metric._to_config(
             instance_class=self.__class__,
+            batch_id=batch_id,
             metric_value_set=list(self.dict().items()),
         )
-        config.metric_domain_kwargs["batch_id"] = batch_id
         return config
 
     @classmethod
@@ -143,7 +145,7 @@ class Metric(Generic[_MetricResult], BaseModel, metaclass=MetaMetric):
 
     @staticmethod
     def _to_config(
-        instance_class: type["Metric"], metric_value_set: list[tuple]
+        instance_class: type["Metric"], batch_id: str, metric_value_set: list[tuple]
     ) -> MetricConfiguration:
         """Returns a MetricConfiguration instance for this Metric."""
         metric_domain_kwargs = {}
@@ -157,6 +159,9 @@ class Metric(Generic[_MetricResult], BaseModel, metaclass=MetaMetric):
         }
         for field_name, field_info in domain_fields.items():
             metric_domain_kwargs[field_name] = metric_values.get(field_name, field_info.default)
+        # Set the batch_id last so past in one is always the one used
+        metric_domain_kwargs["batch_id"] = batch_id
+
         value_fields = {
             field_name: field_info
             for field_name, field_info in instance_class.__fields__.items()

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -6,6 +6,7 @@ from great_expectations.compatibility.pydantic import BaseModel, Field, ModelMet
 from great_expectations.metrics.metric_results import MetricResult
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
+    MetricConfigurationID,
 )
 
 ALLOWABLE_METRIC_MIXINS: Final[int] = 1
@@ -119,6 +120,9 @@ class Metric(Generic[_MetricResult], BaseModel, metaclass=MetaMetric):
         if cls is Metric:
             raise AbstractClassInstantiationError(cls.__name__)
         return super().__new__(cls)
+
+    def metric_id_for_batch(self, batch_id: str) -> MetricConfigurationID:
+        return self.config(batch_id=batch_id).id
 
     def config(self, batch_id: str) -> MetricConfiguration:
         # This class is frozen so Metric._to_config will always return the same value

--- a/great_expectations/metrics/metric.py
+++ b/great_expectations/metrics/metric.py
@@ -105,7 +105,6 @@ class Metric(Generic[_MetricResult], BaseModel, metaclass=MetaMetric):
     name: ClassVar[StrictStr]
 
     _domain_fields: ClassVar[tuple[str, ...]] = (
-        "batch_id",
         "column",
         "row_condition",
         "column_A",
@@ -159,7 +158,7 @@ class Metric(Generic[_MetricResult], BaseModel, metaclass=MetaMetric):
         }
         for field_name, field_info in domain_fields.items():
             metric_domain_kwargs[field_name] = metric_values.get(field_name, field_info.default)
-        # Set the batch_id last so past in one is always the one used
+        # Set the batch_id with the passed in value
         metric_domain_kwargs["batch_id"] = batch_id
 
         value_fields = {

--- a/great_expectations/metrics/metric_results.py
+++ b/great_expectations/metrics/metric_results.py
@@ -33,6 +33,13 @@ class MetricErrorResultValue(TypedDict):
 class MetricErrorResult(MetricResult[MetricErrorResultValue]): ...
 
 
+class MetricInternalErrorResultValue(TypedDict):
+    msg: str
+
+
+class MetricInternalErrorResult(MetricResult[MetricInternalErrorResultValue]): ...
+
+
 class ConditionValuesValueError(ValueError):
     def __init__(self, actual_type: type) -> None:
         super().__init__(

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -1,8 +1,11 @@
+import pandas as pd
 import pytest
 
+import great_expectations as gx
 from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.core.types import Comparable
 from great_expectations.metrics.column import ColumnMetric
+from great_expectations.metrics.column.mean import ColumnMean
 from great_expectations.metrics.metric import AbstractClassInstantiationError, Metric
 from great_expectations.metrics.metric_results import MetricResult
 from great_expectations.validator.metric_configuration import (
@@ -19,6 +22,13 @@ FULLY_QUALIFIED_METRIC_NAME = "column_values.above"
 class ColumnValuesAboveResult(MetricResult[bool]): ...
 
 
+class ColumnValuesAbove(ColumnMetric[ColumnValuesAboveResult]):
+    name = FULLY_QUALIFIED_METRIC_NAME
+
+    min_value: Comparable
+    strict_min: bool = False
+
+
 class TestMetric:
     @pytest.mark.unit
     def test_metric_instantiation_raises(self):
@@ -29,7 +39,7 @@ class TestMetric:
 class TestMetricDefinition:
     @pytest.mark.unit
     def test_success(self):
-        class ColumnValuesAbove(ColumnMetric[ColumnValuesAboveResult]):
+        class MyColumnValuesAbove(ColumnMetric[ColumnValuesAboveResult]):
             name = FULLY_QUALIFIED_METRIC_NAME
 
             min_value: Comparable
@@ -37,7 +47,7 @@ class TestMetricDefinition:
 
     @pytest.mark.unit
     def test_success_without_generic_return_types(self):
-        class ColumnValuesAbove(ColumnMetric):
+        class MyColumnValuesAbove(ColumnMetric):
             name = FULLY_QUALIFIED_METRIC_NAME
 
             min_value: Comparable
@@ -45,15 +55,9 @@ class TestMetricDefinition:
 
 
 class TestMetricInstantiation:
-    class ColumnValuesAbove(ColumnMetric[ColumnValuesAboveResult]):
-        name = FULLY_QUALIFIED_METRIC_NAME
-
-        min_value: Comparable
-        strict_min: bool = False
-
     @pytest.mark.unit
     def test_instantiation_success(self):
-        self.ColumnValuesAbove(
+        ColumnValuesAbove(
             column=COLUMN,
             min_value=42,
         )
@@ -61,16 +65,10 @@ class TestMetricInstantiation:
     @pytest.mark.unit
     def test_instantiation_missing_domain_parameters_raises(self):
         with pytest.raises(ValidationError):
-            self.ColumnValuesAbove(min_value=42)
+            ColumnValuesAbove(min_value=42)
 
 
 class TestMetricConfig:
-    class ColumnValuesAbove(ColumnMetric[ColumnValuesAboveResult]):
-        name = FULLY_QUALIFIED_METRIC_NAME
-
-        min_value: Comparable
-        strict_min: bool = False
-
     @pytest.mark.unit
     def test_success(self):
         expected_config = MetricConfiguration(
@@ -86,7 +84,7 @@ class TestMetricConfig:
             },
         )
 
-        actual_config = self.ColumnValuesAbove(
+        actual_config = ColumnValuesAbove(
             column=COLUMN,
             min_value=42,
         ).config(batch_id=BATCH_ID)
@@ -98,15 +96,9 @@ class TestMetricConfig:
 
 
 class TestMetricImmutability:
-    class ColumnValuesAbove(ColumnMetric[ColumnValuesAboveResult]):
-        name = FULLY_QUALIFIED_METRIC_NAME
-
-        min_value: Comparable
-        strict_min: bool = False
-
     @pytest.mark.unit
     def test_domain_kwarg_immutability_success(self):
-        column_values_above = self.ColumnValuesAbove(
+        column_values_above = ColumnValuesAbove(
             column=COLUMN,
             min_value=42,
         )
@@ -116,10 +108,120 @@ class TestMetricImmutability:
 
     @pytest.mark.unit
     def test_value_kwarg_immutability_success(self):
-        column_values_above = self.ColumnValuesAbove(
+        column_values_above = ColumnValuesAbove(
             column=COLUMN,
             min_value=42,
         )
 
         with pytest.raises(TypeError):
             column_values_above.min_value = 42
+
+
+class TestMetricIdFromBatch:
+    @pytest.mark.unit
+    def test_two_identical_metrics_with_same_batch_id_returns_same_metric_id(self):
+        metric_1 = ColumnValuesAbove(
+            column=COLUMN,
+            min_value=42,
+        )
+        metric_2 = ColumnValuesAbove(
+            column=COLUMN,
+            min_value=42,
+        )
+        assert metric_1.metric_id_for_batch(BATCH_ID) == metric_2.metric_id_for_batch(BATCH_ID)
+
+    @pytest.mark.unit
+    def test_metric_with_different_value_kwargs_return_different_ids(self):
+        metric_1 = ColumnValuesAbove(
+            column=COLUMN,
+            min_value=42,
+        )
+        metric_2 = ColumnValuesAbove(
+            column=COLUMN,
+            min_value=43,
+        )
+        assert metric_1.metric_id_for_batch(BATCH_ID) != metric_2.metric_id_for_batch(BATCH_ID)
+
+    @pytest.mark.unit
+    def test_metric_with_different_batch_ids_return_different_ids(self):
+        metric_1 = ColumnValuesAbove(
+            column=COLUMN,
+            min_value=42,
+        )
+        metric_2 = ColumnValuesAbove(
+            column=COLUMN,
+            min_value=42,
+        )
+        assert metric_1.metric_id_for_batch(BATCH_ID) != metric_2.metric_id_for_batch(
+            BATCH_ID + "_another"
+        )
+
+
+class TestComputeMetric:
+    @pytest.mark.unit
+    def test_same_metric_different_args_have_different_results(self):
+        context = gx.get_context(mode="ephemeral")
+        data_source = context.data_sources.add_pandas("Pandas Data Source")
+        data_asset = data_source.add_dataframe_asset("DataFrame Asset")
+        batch_definition = data_asset.add_batch_definition_whole_dataframe(
+            "Whole DataFrame Batch Definition"
+        )
+        df = pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+                "b": [4, 5, 6],
+            }
+        )
+        batch = batch_definition.get_batch({"dataframe": df})
+        metrics = [
+            ColumnMean(column="a"),
+            ColumnMean(column="b"),
+        ]
+        metric_result = batch.compute_metrics(metrics)
+        assert isinstance(metric_result, list)
+        assert len(metric_result) == 2
+        assert metric_result[0].value == 2.0
+        assert metric_result[0].id == metrics[0].metric_id_for_batch(batch.id)
+        assert metric_result[1].value == 5.0
+        assert metric_result[1].id == metrics[1].metric_id_for_batch(batch.id)
+        assert metric_result[0].id != metric_result[1].id
+
+    @pytest.mark.unit
+    def test_single_metric_as_list_result_is_list(self):
+        context = gx.get_context(mode="ephemeral")
+        data_source = context.data_sources.add_pandas("Pandas Data Source")
+        data_asset = data_source.add_dataframe_asset("DataFrame Asset")
+        batch_definition = data_asset.add_batch_definition_whole_dataframe(
+            "Whole DataFrame Batch Definition"
+        )
+        df = pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+        batch = batch_definition.get_batch({"dataframe": df})
+        metrics = [
+            ColumnMean(column="a"),
+        ]
+        metric_result = batch.compute_metrics(metrics)
+        assert isinstance(metric_result, list)
+        assert len(metric_result) == 1
+        assert metric_result[0].value == 2.0
+
+    @pytest.mark.unit
+    def test_single_metric_result_is_metric_result(self):
+        context = gx.get_context(mode="ephemeral")
+        data_source = context.data_sources.add_pandas("Pandas Data Source")
+        data_asset = data_source.add_dataframe_asset("DataFrame Asset")
+        batch_definition = data_asset.add_batch_definition_whole_dataframe(
+            "Whole DataFrame Batch Definition"
+        )
+        df = pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+        batch = batch_definition.get_batch({"dataframe": df})
+        metric_result = batch.compute_metrics(ColumnMean(column="a"))
+        assert isinstance(metric_result, MetricResult)
+        assert metric_result.value == 2.0


### PR DESCRIPTION
Fixes 3 batch.compute_metrics() bugs:
1. We no longer overwrite the metric result if metric names are identical.
2. The config id is different between batches. Previously, we set the batch_id after the hashing to create the id was computed.
3. Return a list of results if a list is passed into compute_metrics(). Previously a list of 1 would return the result not a list containing only the result.

We also enforce the invariant the the length of metrics passed in will equal the length of the results by adding a catchall `else` branch.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
