### PR TITLE
[BUGFIX] Ensure Asset.get_batch_definition returns BatchDefinition with ID

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -750,7 +750,9 @@ class Datasource(
 
         updated_asset = updated_datasource.get_asset(asset_name)
         updated_batch_definition = updated_asset.get_batch_definition(batch_definition.name)
-
+        if batch_definition is not updated_batch_definition:
+            # update in memory copy with the new ID
+            batch_definition.id = updated_batch_definition.id
         return updated_batch_definition
 
     def delete_batch_definition(self, batch_definition: BatchDefinition[PartitionerT]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import random
 import shutil
+import string
 import urllib.parse
 import warnings
 from dataclasses import dataclass
@@ -2202,6 +2203,22 @@ def ephemeral_context_with_defaults() -> EphemeralDataContext:
     return get_context(project_config=project_config, mode="ephemeral")
 
 
+@pytest.fixture(
+    params=[
+        pytest.param("ephemeral_context_with_defaults", marks=pytest.mark.unit, id="ephemeral"),
+        pytest.param("empty_data_context", marks=pytest.mark.filesystem, id="file"),
+        pytest.param(
+            "empty_cloud_context_fluent",
+            marks=pytest.mark.cloud,
+            id="cloud",
+        ),
+    ]
+)
+def data_context(request: pytest.FixtureRequest) -> AbstractDataContext:
+    """Fixture to parameterize a test against each DataContext type."""
+    return request.getfixturevalue(request.param)
+
+
 @pytest.fixture
 def arbitrary_batch_definition(empty_data_context: AbstractDataContext) -> BatchDefinition:
     return (
@@ -2278,3 +2295,7 @@ def param_id(request: pytest.FixtureRequest) -> str:
     """
     raw_name: str = request.node.name
     return raw_name.split("[")[1].split("]")[0]
+
+
+def random_name() -> str:
+    return "".join([random.choice(string.ascii_letters) for _ in range(6)])

--- a/tests/datasource/fluent/data_asset/test_data_asset.py
+++ b/tests/datasource/fluent/data_asset/test_data_asset.py
@@ -1,9 +1,12 @@
+import random
+import string
 from typing import List
 
 import pytest
 
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.partitioners import ColumnPartitionerYearly
+from great_expectations.data_context import EphemeralDataContext, FileDataContext
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
@@ -470,3 +473,37 @@ def test_sort_batches__requires_keys(empty_data_asset, mocker):
 
     with pytest.raises(KeyError, match=expected_error):
         empty_data_asset.sort_batches([wheres_my_b, i_have_a_b], partitioner)
+
+
+class TestGetBatchDefinition:
+    def random_name(self) -> str:
+        return "".join([random.choice(string.ascii_letters) for _ in range(6)])
+
+    @pytest.mark.filesystem
+    def test_get_returns_id__filesystem(self, empty_data_context: FileDataContext):
+        self._test_get_returns_id(empty_data_context)
+
+    @pytest.mark.cloud
+    def test_get_returns_id__cloud(self, empty_cloud_context_fluent: CloudDataContext):
+        self._test_get_returns_id(empty_cloud_context_fluent)
+
+    @pytest.mark.unit
+    def test_get_returns_id__ephemeral(self, ephemeral_context_with_defaults: EphemeralDataContext):
+        self._test_get_returns_id(ephemeral_context_with_defaults)
+
+    def _test_get_returns_id(self, context: AbstractDataContext) -> None:
+        # arrange
+        resource_name = self.random_name()
+        ds = context.data_sources.add_pandas(
+            name=resource_name,
+        )
+        asset = ds.add_dataframe_asset(name=resource_name)
+        batch_def = asset.add_batch_definition_whole_dataframe(name=resource_name)
+
+        # act
+        refetched_batch_def = asset.get_batch_definition(resource_name)
+
+        # assert
+        assert batch_def.id
+        assert refetched_batch_def.id
+        assert batch_def.id == refetched_batch_def.id

--- a/tests/datasource/fluent/data_asset/test_data_asset.py
+++ b/tests/datasource/fluent/data_asset/test_data_asset.py
@@ -1,12 +1,9 @@
-import random
-import string
 from typing import List
 
 import pytest
 
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.partitioners import ColumnPartitionerYearly
-from great_expectations.data_context import EphemeralDataContext, FileDataContext
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
@@ -16,6 +13,7 @@ from great_expectations.data_context.data_context.cloud_data_context import (
 from great_expectations.datasource.fluent.fluent_base_model import FluentBaseModel
 from great_expectations.datasource.fluent.interfaces import Batch, DataAsset, Datasource
 from great_expectations.datasource.fluent.pandas_datasource import PandasDatasource
+from tests.conftest import random_name
 
 DATASOURCE_NAME = "my datasource for batch configs"
 EMPTY_DATA_ASSET_NAME = "my data asset for batch configs"
@@ -476,25 +474,10 @@ def test_sort_batches__requires_keys(empty_data_asset, mocker):
 
 
 class TestGetBatchDefinition:
-    def random_name(self) -> str:
-        return "".join([random.choice(string.ascii_letters) for _ in range(6)])
-
-    @pytest.mark.filesystem
-    def test_get_returns_id__filesystem(self, empty_data_context: FileDataContext):
-        self._test_get_returns_id(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_get_returns_id__cloud(self, empty_cloud_context_fluent: CloudDataContext):
-        self._test_get_returns_id(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_get_returns_id__ephemeral(self, ephemeral_context_with_defaults: EphemeralDataContext):
-        self._test_get_returns_id(ephemeral_context_with_defaults)
-
-    def _test_get_returns_id(self, context: AbstractDataContext) -> None:
+    def test_get_returns_id(self, data_context: AbstractDataContext) -> None:
         # arrange
-        resource_name = self.random_name()
-        ds = context.data_sources.add_pandas(
+        resource_name = random_name()
+        ds = data_context.data_sources.add_pandas(
             name=resource_name,
         )
         asset = ds.add_dataframe_asset(name=resource_name)


### PR DESCRIPTION
This PR fixes a bug where batch definitions fetched from `asset.get_batch_definition` sometimes come back without an ID.