### PR TITLE
[DOCS] update action docs to include custom field example

### DIFF
--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
@@ -9,7 +9,7 @@ pytest --docs-tests -k "docs_example_create_a_custom_action" tests/integration/t
 
 # <snippet name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - full code example">
 
-from typing import Literal
+from typing import Literal, Union
 
 from typing_extensions import override
 
@@ -41,8 +41,9 @@ class MyCustomAction(ValidationAction):
     def run(
         self,
         checkpoint_result: CheckpointResult,
-        action_context: ActionContext
-        | None,  # Contains results from prior Actions in the same Checkpoint run.
+        action_context: Union[
+            ActionContext, None
+        ],  # Contains results from prior Actions in the same Checkpoint run.
     ) -> dict:
         # Domain-specific logic
         self._do_my_custom_action(checkpoint_result)

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
@@ -30,18 +30,26 @@ class MyCustomAction(ValidationAction):
     type: Literal["my_custom_action"] = "my_custom_action"
     # </snippet>
 
-    # 3. Override the `run()` method to perform the desired task.
+    # 3. Optionally add any additional fields your Action requires at runtime.
+    # <snippet name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - add custom fields">
+    my_custom_str_field: str
+    # </snippet>
+
+    # 4. Override the `run()` method to perform the desired task.
     # <snippet name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - override run">
     @override
     def run(
         self,
         checkpoint_result: CheckpointResult,
-        action_context: ActionContext,  # Contains results from prior Actions in the same Checkpoint run.
+        action_context: ActionContext
+        | None,  # Contains results from prior Actions in the same Checkpoint run.
     ) -> dict:
         # Domain-specific logic
         self._do_my_custom_action(checkpoint_result)
+        # Optionally, access custom fields you provide the action at runtime
+        extra_context = self.my_custom_str_field
         # Return information about the Action
-        return {"some": "info"}
+        return {"some": "info", "extra_context": extra_context}
 
     def _do_my_custom_action(self, checkpoint_result: CheckpointResult):
         # Perform custom logic based on the validation results.

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
@@ -30,7 +30,7 @@ class MyCustomAction(ValidationAction):
     type: Literal["my_custom_action"] = "my_custom_action"
     # </snippet>
 
-    # 3. Optionally add any additional fields your Action requires at runtime.
+    # 3. Optional. Add any additional fields your Action requires at runtime.
     # <snippet name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - add custom fields">
     my_custom_str_field: str
     # </snippet>

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py
@@ -47,7 +47,7 @@ class MyCustomAction(ValidationAction):
     ) -> dict:
         # Domain-specific logic
         self._do_my_custom_action(checkpoint_result)
-        # Optionally, access custom fields you provide the action at runtime
+        # Optional. Access custom fields you provide the Action at runtime.
         extra_context = self.my_custom_str_field
         # Return information about the Action
         return {"some": "info", "extra_context": extra_context}

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_custom_action.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_custom_action.md
@@ -47,6 +47,7 @@ To create a custom Action, you subclass the `ValidationAction` class, overriding
    ```
 
 3.  Optionally, add any additional fields your action requires at runtime. Actions are built on Pydantic models. Define the field name a class-level attribute on your Action, and annotate it with the correct type. When you instantiate the Action, pass the field value into the Action init method. Your Action will have access to these values within your custom `run` method via `self.<MY FIELD NAME>`.
+
    ```python title="Python" name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - add custom fields"
    ```
 

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_custom_action.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_custom_action.md
@@ -46,7 +46,11 @@ To create a custom Action, you subclass the `ValidationAction` class, overriding
    ```python title="Python" name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - set type" 
    ```
 
-3. Override the `run()` method with the logic for the Action.
+3.  Optionally, add any additional fields your action requires at runtime. Actions are built on Pydantic models. Define the field name a class-level attribute on your Action, and annotate it with the correct type. When you instantiate the Action, pass the field value into the Action init method. Your Action will have access to these values within your custom `run` method via `self.<MY FIELD NAME>`.
+   ```python title="Python" name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - add custom fields"
+   ```
+
+4. Override the `run()` method with the logic for the Action.
 
    ```python title="Python" name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - override run" 
    ```

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_custom_action.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/create_a_custom_action.md
@@ -46,7 +46,7 @@ To create a custom Action, you subclass the `ValidationAction` class, overriding
    ```python title="Python" name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - set type" 
    ```
 
-3.  Optionally, add any additional fields your action requires at runtime. Actions are built on Pydantic models. Define the field name a class-level attribute on your Action, and annotate it with the correct type. When you instantiate the Action, pass the field value into the Action init method. Your Action will have access to these values within your custom `run` method via `self.<MY FIELD NAME>`.
+3.  Optional. Add any additional fields your Action requires at runtime. Actions are built on Pydantic models. Define the field name as a class-level attribute on your Action, and annotate it with the correct type. When you instantiate the Action, pass the field value into the Action `init` method. Your Action will have access to these values within your custom `run` method through `self.<MY_FIELD_NAME>`.
 
    ```python title="Python" name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/create_a_custom_action.py - add custom fields"
    ```


### PR DESCRIPTION
This PR updates the custom action documentation to include an example of defining a user-defined field on the action model, allowing users to pass runtime values through to their custom `Action.run` logic, per [user feedback here](https://greatexpectationstalk.slack.com/archives/CUTCNHN82/p1740477786353189?thread_ts=1739814242.490439&cid=CUTCNHN82).