### PR TITLE
[DOCS] temporarily remove link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,14 +369,6 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: cd docs/docusaurus && yarn install && bash ../build_docs
 
-      - name: Run broken link checker
-        uses: lycheeverse/lychee-action@v2
-        with:
-          # We decided to exclude all external HTTP requests but the ones that under the domain greatexpectations.io
-          # The reason is to avoid having network errors such as pages that throw 429 after too many requests (like Github)
-          # and to prevent other possible errors related to user agent or lychee capturing hrefs from metadata that don't resolve to a specific page (preconnects in JS)
-          args: "--exclude='http.*' --include='^https://(.+\\.)?greatexpectations\\.io/' 'docs/docusaurus/build/**/*.html'"
-
   docs-tests:
     needs: [check-actor-permissions]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Temporary workaround for known issue https://greatexpectations.atlassian.net/browse/DOC-979 which is blocking PR https://github.com/great-expectations/great_expectations/pull/10927

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
