### PR TITLE
[MAINTENANCE] refactor to use data_context fixture

### DIFF
--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -421,45 +421,21 @@ class TestCheckpointFactoryAnalytics:
 class TestCheckpointFactoryAddOrUpdate:
     CHECKPOINT_NAME = "checkpoint A"
 
-    @pytest.mark.filesystem
-    def test_add_empty_new_checkpoint__filesystem(self, empty_data_context):
-        return self._test_add_empty_new_checkpoint(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_empty_new_checkpoint__cloud(self, empty_cloud_context_fluent):
-        return self._test_add_empty_new_checkpoint(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_empty_new_checkpoint__ephemeral(self, ephemeral_context_with_defaults):
-        return self._test_add_empty_new_checkpoint(ephemeral_context_with_defaults)
-
-    def _test_add_empty_new_checkpoint(self, context: AbstractDataContext):
+    def test_add_empty_new_checkpoint(self, data_context: AbstractDataContext) -> None:
         # arrange
         checkpoint = Checkpoint(name=self.CHECKPOINT_NAME, validation_definitions=[])
 
         # act
-        created_checkpoint = context.checkpoints.add_or_update(checkpoint=checkpoint)
+        created_checkpoint = data_context.checkpoints.add_or_update(checkpoint=checkpoint)
 
         # assert
         assert created_checkpoint.id
-        context.checkpoints.get(self.CHECKPOINT_NAME)
+        data_context.checkpoints.get(self.CHECKPOINT_NAME)
 
-    @pytest.mark.filesystem
-    def test_add_new_checkpoint_with_validations__filesystem(self, empty_data_context):
-        return self._test_add_new_checkpoint_with_validations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_new_checkpoint_with_validations__cloud(self, empty_cloud_context_fluent):
-        return self._test_add_new_checkpoint_with_validations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_new_checkpoint_with_validations__ephemeral(self, ephemeral_context_with_defaults):
-        return self._test_add_new_checkpoint_with_validations(ephemeral_context_with_defaults)
-
-    def _test_add_new_checkpoint_with_validations(self, context: AbstractDataContext):
+    def test_add_new_checkpoint_with_validations(self, data_context: AbstractDataContext) -> None:
         # arrange
         batch_def = (
-            context.data_sources.add_pandas("data source A")
+            data_context.data_sources.add_pandas("data source A")
             .add_dataframe_asset("asset A")
             .add_batch_definition_whole_dataframe("batch def A")
         )
@@ -481,7 +457,7 @@ class TestCheckpointFactoryAddOrUpdate:
         )
 
         # act
-        created_checkpoint = context.checkpoints.add_or_update(checkpoint=checkpoint)
+        created_checkpoint = data_context.checkpoints.add_or_update(checkpoint=checkpoint)
 
         # assert
         assert created_checkpoint.id
@@ -494,30 +470,16 @@ class TestCheckpointFactoryAddOrUpdate:
             val_def_dict["id"] = ANY
             assert val_def_dict == created_val_def.dict()
 
-    @pytest.mark.filesystem
-    def test_update_existing_checkpoint_adds_validations__filesystem(self, empty_data_context):
-        return self._test_update_existing_checkpoint_adds_validations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_update_existing_checkpoint_adds_validations__cloud(self, empty_cloud_context_fluent):
-        return self._test_update_existing_checkpoint_adds_validations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_update_existing_checkpoint_adds_validations__ephemeral(
-        self, ephemeral_context_with_defaults
-    ):
-        return self._test_update_existing_checkpoint_adds_validations(
-            ephemeral_context_with_defaults
-        )
-
-    def _test_update_existing_checkpoint_adds_validations(self, context: AbstractDataContext):
+    def test_update_existing_checkpoint_adds_validations(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # arrange
-        context.checkpoints.add(
+        data_context.checkpoints.add(
             checkpoint=Checkpoint(name=self.CHECKPOINT_NAME, validation_definitions=[])
         )
 
         batch_def = (
-            context.data_sources.add_pandas("data source A")
+            data_context.data_sources.add_pandas("data source A")
             .add_dataframe_asset("asset A")
             .add_batch_definition_whole_dataframe("batch def A")
         )
@@ -538,7 +500,7 @@ class TestCheckpointFactoryAddOrUpdate:
         )
 
         # act
-        created_checkpoint = context.checkpoints.add_or_update(checkpoint=checkpoint)
+        created_checkpoint = data_context.checkpoints.add_or_update(checkpoint=checkpoint)
 
         # assert
         assert created_checkpoint.id
@@ -551,33 +513,17 @@ class TestCheckpointFactoryAddOrUpdate:
             val_def_dict["id"] = ANY
             assert val_def_dict == created_val_def.dict()
 
-    @pytest.mark.filesystem
-    def test_update_existing_checkpoint_updates_validations__filesystem(self, empty_data_context):
-        return self._test_update_existing_checkpoint_updates_validations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_update_existing_checkpoint_updates_validations__cloud(
-        self, empty_cloud_context_fluent
-    ):
-        return self._test_update_existing_checkpoint_updates_validations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_update_existing_checkpoint_updates_validations__ephemeral(
-        self, ephemeral_context_with_defaults
-    ):
-        return self._test_update_existing_checkpoint_updates_validations(
-            ephemeral_context_with_defaults
-        )
-
-    def _test_update_existing_checkpoint_updates_validations(self, context: AbstractDataContext):
+    def test_update_existing_checkpoint_updates_validations(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # arrange
         batch_def = (
-            context.data_sources.add_pandas("data source A")
+            data_context.data_sources.add_pandas("data source A")
             .add_dataframe_asset("asset A")
             .add_batch_definition_whole_dataframe("batch def A")
         )
-        existing_suite = context.suites.add(ExpectationSuite(name="suite A"))
-        existing_val_def = context.validation_definitions.add(
+        existing_suite = data_context.suites.add(ExpectationSuite(name="suite A"))
+        existing_val_def = data_context.validation_definitions.add(
             ValidationDefinition(
                 name="val def A",
                 data=batch_def,
@@ -585,7 +531,7 @@ class TestCheckpointFactoryAddOrUpdate:
             )
         )
 
-        context.checkpoints.add(
+        data_context.checkpoints.add(
             checkpoint=Checkpoint(
                 name=self.CHECKPOINT_NAME, validation_definitions=[existing_val_def]
             )
@@ -593,7 +539,7 @@ class TestCheckpointFactoryAddOrUpdate:
         new_suite_name = "suite C"
 
         # act
-        created_checkpoint = context.checkpoints.add_or_update(
+        created_checkpoint = data_context.checkpoints.add_or_update(
             checkpoint=Checkpoint(
                 name=self.CHECKPOINT_NAME,
                 validation_definitions=[
@@ -609,43 +555,27 @@ class TestCheckpointFactoryAddOrUpdate:
         for val_def in created_checkpoint.validation_definitions:
             assert val_def.suite.name == new_suite_name
 
-    @pytest.mark.filesystem
-    def test_update_existing_checkpoint_deletes_validations__filesystem(self, empty_data_context):
-        return self._test_update_existing_checkpoint_deletes_validations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_update_existing_checkpoint_deletes_validations__cloud(
-        self, empty_cloud_context_fluent
-    ):
-        return self._test_update_existing_checkpoint_deletes_validations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_update_existing_checkpoint_deletes_validations__ephemeral(
-        self, ephemeral_context_with_defaults
-    ):
-        return self._test_update_existing_checkpoint_deletes_validations(
-            ephemeral_context_with_defaults
-        )
-
-    def _test_update_existing_checkpoint_deletes_validations(self, context: AbstractDataContext):
+    def test_update_existing_checkpoint_deletes_validations(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # arrange
         batch_def = (
-            context.data_sources.add_pandas("data source A")
+            data_context.data_sources.add_pandas("data source A")
             .add_dataframe_asset("asset A")
             .add_batch_definition_whole_dataframe("batch def A")
         )
         SUITE_NAME = "suite A"
         VALIDATION_DEFINITION_NAME = "val def A"
-        existing_suite_1 = context.suites.add(ExpectationSuite(name=SUITE_NAME))
-        existing_suite_2 = context.suites.add(ExpectationSuite(name="suite B"))
-        existing_val_def_1 = context.validation_definitions.add(
+        existing_suite_1 = data_context.suites.add(ExpectationSuite(name=SUITE_NAME))
+        existing_suite_2 = data_context.suites.add(ExpectationSuite(name="suite B"))
+        existing_val_def_1 = data_context.validation_definitions.add(
             ValidationDefinition(
                 name=VALIDATION_DEFINITION_NAME,
                 data=batch_def,
                 suite=existing_suite_1,
             ),
         )
-        existing_val_def_2 = context.validation_definitions.add(
+        existing_val_def_2 = data_context.validation_definitions.add(
             ValidationDefinition(
                 name="val def B",
                 data=batch_def,
@@ -653,7 +583,7 @@ class TestCheckpointFactoryAddOrUpdate:
             )
         )
 
-        context.checkpoints.add(
+        data_context.checkpoints.add(
             checkpoint=Checkpoint(
                 name=self.CHECKPOINT_NAME,
                 validation_definitions=[existing_val_def_1, existing_val_def_2],
@@ -661,7 +591,7 @@ class TestCheckpointFactoryAddOrUpdate:
         )
 
         # act
-        created_checkpoint = context.checkpoints.add_or_update(
+        created_checkpoint = data_context.checkpoints.add_or_update(
             checkpoint=Checkpoint(
                 name=self.CHECKPOINT_NAME,
                 validation_definitions=[
@@ -679,22 +609,10 @@ class TestCheckpointFactoryAddOrUpdate:
         assert created_checkpoint.validation_definitions[0].name == VALIDATION_DEFINITION_NAME
         assert created_checkpoint.validation_definitions[0].suite.name == SUITE_NAME
 
-    @pytest.mark.filesystem
-    def test_add_or_update_is_idempotent__filesystem(self, empty_data_context):
-        return self._test_add_or_update_is_idempotent(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_or_update_is_idempotent__cloud(self, empty_cloud_context_fluent):
-        return self._test_add_or_update_is_idempotent(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_or_update_is_idempotent__ephemeral(self, ephemeral_context_with_defaults):
-        return self._test_add_or_update_is_idempotent(ephemeral_context_with_defaults)
-
-    def _test_add_or_update_is_idempotent(self, context: AbstractDataContext):
+    def test_add_or_update_is_idempotent(self, data_context: AbstractDataContext) -> None:
         # arrange
         batch_def = (
-            context.data_sources.add_pandas("data source A")
+            data_context.data_sources.add_pandas("data source A")
             .add_dataframe_asset("asset A")
             .add_batch_definition_whole_dataframe("batch def A")
         )
@@ -702,7 +620,7 @@ class TestCheckpointFactoryAddOrUpdate:
         VALIDATION_DEFINITION_NAME = "val def A"
 
         # act
-        created_checkpoint_1 = context.checkpoints.add_or_update(
+        created_checkpoint_1 = data_context.checkpoints.add_or_update(
             checkpoint=Checkpoint(
                 name=self.CHECKPOINT_NAME,
                 validation_definitions=[
@@ -714,7 +632,7 @@ class TestCheckpointFactoryAddOrUpdate:
                 ],
             )
         )
-        created_checkpoint_2 = context.checkpoints.add_or_update(
+        created_checkpoint_2 = data_context.checkpoints.add_or_update(
             checkpoint=Checkpoint(
                 name=self.CHECKPOINT_NAME,
                 validation_definitions=[

--- a/tests/core/factory/test_suite_factory.py
+++ b/tests/core/factory/test_suite_factory.py
@@ -334,43 +334,19 @@ def test_suite_factory_all_with_bad_pydantic_config(
 
 
 class TestSuiteFactoryAddOrUpdate:
-    @pytest.mark.filesystem
-    def test_add_empty_new_suite__filesystem(self, empty_data_context):
-        self._test_add_empty_new_suite(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_empty_new_suite__cloud(self, empty_cloud_context_fluent):
-        self._test_add_empty_new_suite(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_empty_new_suite__ephemeral(self, ephemeral_context_with_defaults):
-        self._test_add_empty_new_suite(ephemeral_context_with_defaults)
-
-    def _test_add_empty_new_suite(self, context: AbstractDataContext):
+    def test_add_empty_new_suite(self, data_context: AbstractDataContext) -> None:
         # arrange
         suite_name = "suite A"
         suite = ExpectationSuite(name=suite_name)
 
         # act
-        created_suite = context.suites.add_or_update(suite=suite)
+        created_suite = data_context.suites.add_or_update(suite=suite)
 
         # assert
         assert created_suite.id
-        context.suites.get(suite_name)
+        data_context.suites.get(suite_name)
 
-    @pytest.mark.filesystem
-    def test_add_new_suite_with_expectations_filesystem(self, empty_data_context):
-        self._test_add_new_suite_with_expectations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_new_suite_with_expectations__cloud(self, empty_cloud_context_fluent):
-        self._test_add_new_suite_with_expectations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_new_suite_with_expectations__ephemeral(self, ephemeral_context_with_defaults):
-        self._test_add_new_suite_with_expectations(ephemeral_context_with_defaults)
-
-    def _test_add_new_suite_with_expectations(self, context: AbstractDataContext):
+    def test_add_new_suite_with_expectations(self, data_context: AbstractDataContext) -> None:
         # arrange
         suite_name = "suite A"
         expectations = [
@@ -390,31 +366,19 @@ class TestSuiteFactoryAddOrUpdate:
         )
 
         # act
-        created_suite = context.suites.add_or_update(suite=suite)
+        created_suite = data_context.suites.add_or_update(suite=suite)
 
         # assert
         assert created_suite.id
-        context.suites.get(suite_name)
+        data_context.suites.get(suite_name)
         for exp, created_exp in zip(expectations, created_suite.expectations):
             assert created_exp.id
             exp.id = ANY
             assert exp == created_exp
 
-    @pytest.mark.filesystem
-    def test_update_existing_suite_adds_expectations__filesystem(self, empty_data_context):
-        self._test_update_existing_suite_adds_expectations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_update_existing_suite_adds_expectations__cloud(self, empty_cloud_context_fluent):
-        self._test_update_existing_suite_adds_expectations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_update_existing_suite_adds_expectations__ephemeral(
-        self, ephemeral_context_with_defaults
-    ):
-        self._test_update_existing_suite_adds_expectations(ephemeral_context_with_defaults)
-
-    def _test_update_existing_suite_adds_expectations(self, context: AbstractDataContext):
+    def test_update_existing_suite_adds_expectations(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # arrange
         suite_name = "suite A"
         expectations = [
@@ -432,10 +396,10 @@ class TestSuiteFactoryAddOrUpdate:
             name=suite_name,
             expectations=[copy(exp) for exp in expectations],
         )
-        existing_suite = context.suites.add(suite=ExpectationSuite(name=suite_name))
+        existing_suite = data_context.suites.add(suite=ExpectationSuite(name=suite_name))
 
         # act
-        updated_suite = context.suites.add_or_update(suite=suite)
+        updated_suite = data_context.suites.add_or_update(suite=suite)
 
         # assert
         assert updated_suite.id == existing_suite.id
@@ -444,21 +408,9 @@ class TestSuiteFactoryAddOrUpdate:
             exp.id = ANY
             assert exp == created_exp
 
-    @pytest.mark.filesystem
-    def test_update_existing_suite_updates_expectations__filesystem(self, empty_data_context):
-        self._test_update_existing_suite_updates_expectations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_update_existing_suite_updates_expectations__cloud(self, empty_cloud_context_fluent):
-        self._test_update_existing_suite_updates_expectations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_update_existing_suite_updates_expectations__ephemeral(
-        self, ephemeral_context_with_defaults
-    ):
-        self._test_update_existing_suite_updates_expectations(ephemeral_context_with_defaults)
-
-    def _test_update_existing_suite_updates_expectations(self, context: AbstractDataContext):
+    def _test_update_existing_suite_updates_expectations(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # arrange
         suite_name = "suite A"
         expectations = [
@@ -472,7 +424,7 @@ class TestSuiteFactoryAddOrUpdate:
                 value_set=["a", "b", "c"],
             ),
         ]
-        existing_suite = context.suites.add(
+        existing_suite = data_context.suites.add(
             suite=ExpectationSuite(
                 name=suite_name,
                 expectations=[copy(exp) for exp in expectations],
@@ -487,7 +439,7 @@ class TestSuiteFactoryAddOrUpdate:
         )
 
         # act
-        updated_suite = context.suites.add_or_update(suite=suite)
+        updated_suite = data_context.suites.add_or_update(suite=suite)
 
         # assert
         assert updated_suite.id == existing_suite.id
@@ -501,21 +453,9 @@ class TestSuiteFactoryAddOrUpdate:
             # expectations have been deleted and re added, not updated
             assert old_exp.id != new_exp.id
 
-    @pytest.mark.filesystem
-    def test_update_existing_suite_deletes_expectations__filesystem(self, empty_data_context):
-        self._test_update_existing_suite_deletes_expectations(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_update_existing_suite_deletes_expectations__cloud(self, empty_cloud_context_fluent):
-        self._test_update_existing_suite_deletes_expectations(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_update_existing_suite_deletes_expectations__ephemeral(
-        self, ephemeral_context_with_defaults
-    ):
-        self._test_update_existing_suite_deletes_expectations(ephemeral_context_with_defaults)
-
-    def _test_update_existing_suite_deletes_expectations(self, context: AbstractDataContext):
+    def test_update_existing_suite_deletes_expectations(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # arrange
         suite_name = "suite A"
         expectations = [
@@ -529,7 +469,7 @@ class TestSuiteFactoryAddOrUpdate:
                 value_set=["a", "b", "c"],
             ),
         ]
-        existing_suite = context.suites.add(
+        existing_suite = data_context.suites.add(
             suite=ExpectationSuite(
                 name=suite_name,
                 expectations=[copy(exp) for exp in expectations],
@@ -544,25 +484,13 @@ class TestSuiteFactoryAddOrUpdate:
         )
 
         # act
-        updated_suite = context.suites.add_or_update(suite=suite)
+        updated_suite = data_context.suites.add_or_update(suite=suite)
 
         # assert
         assert updated_suite.id == existing_suite.id
         assert updated_suite.expectations == []
 
-    @pytest.mark.filesystem
-    def test_add_or_update_is_idempotent__filesystem(self, empty_data_context):
-        self._test_add_or_update_is_idempotent(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_or_update_is_idempotent__cloud(self, empty_cloud_context_fluent):
-        self._test_add_or_update_is_idempotent(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_or_update_is_idempotent__ephemeral(self, ephemeral_context_with_defaults):
-        self._test_add_or_update_is_idempotent(ephemeral_context_with_defaults)
-
-    def _test_add_or_update_is_idempotent(self, context: AbstractDataContext):
+    def test_add_or_update_is_idempotent(self, data_context: AbstractDataContext) -> None:
         # arrange
         suite_name = "suite A"
         expectations = [
@@ -582,24 +510,16 @@ class TestSuiteFactoryAddOrUpdate:
         )
 
         # act
-        suite_1 = context.suites.add_or_update(suite=suite)
-        suite_2 = context.suites.add_or_update(suite=suite)
-        suite_3 = context.suites.add_or_update(suite=suite)
+        suite_1 = data_context.suites.add_or_update(suite=suite)
+        suite_2 = data_context.suites.add_or_update(suite=suite)
+        suite_3 = data_context.suites.add_or_update(suite=suite)
 
         # assert
         assert suite_1 == suite_2 == suite_3
 
 
 class TestSuiteFactoryAnalytics:
-    @pytest.mark.filesystem
-    def test_suite_factory_add_emits_event_filesystem(self, empty_data_context):
-        self._test_suite_factory_add_emits_event(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_suite_factory_add_emits_event_cloud(self, empty_cloud_context_fluent):
-        self._test_suite_factory_add_emits_event(empty_cloud_context_fluent)
-
-    def _test_suite_factory_add_emits_event(self, context):
+    def test_suite_factory_add_emits_event(self, data_context: AbstractDataContext) -> None:
         # Arrange
         name = "test-suite"
         suite = ExpectationSuite(name=name)
@@ -608,32 +528,24 @@ class TestSuiteFactoryAnalytics:
         with mock.patch(
             "great_expectations.core.factory.suite_factory.submit_event", autospec=True
         ) as mock_submit:
-            _ = context.suites.add(suite=suite)
+            _ = data_context.suites.add(suite=suite)
 
         # Assert
         mock_submit.assert_called_once_with(
             event=ExpectationSuiteCreatedEvent(expectation_suite_id=suite.id)
         )
 
-    @pytest.mark.filesystem
-    def test_suite_factory_delete_emits_event_filesystem(self, empty_data_context):
-        self._test_suite_factory_delete_emits_event(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_suite_factory_delete_emits_event_cloud(self, empty_cloud_context_fluent):
-        self._test_suite_factory_delete_emits_event(empty_cloud_context_fluent)
-
-    def _test_suite_factory_delete_emits_event(self, context):
+    def test_suite_factory_delete_emits_event(self, data_context: AbstractDataContext) -> None:
         # Arrange
         name = "test-suite"
         suite = ExpectationSuite(name=name)
-        suite = context.suites.add(suite=suite)
+        suite = data_context.suites.add(suite=suite)
 
         # Act
         with mock.patch(
             "great_expectations.core.factory.suite_factory.submit_event", autospec=True
         ) as mock_submit:
-            context.suites.delete(name=name)
+            data_context.suites.delete(name=name)
 
         # Assert
         mock_submit.assert_called_once_with(

--- a/tests/core/factory/test_validation_definition_factory.py
+++ b/tests/core/factory/test_validation_definition_factory.py
@@ -1,8 +1,6 @@
 import json
 import pathlib
-import random
 import re
-import string
 from unittest import mock
 from unittest.mock import ANY as ANY_TEST_ARG
 
@@ -28,7 +26,6 @@ from great_expectations.data_context.data_context.abstract_data_context import (
 from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
-from great_expectations.data_context.data_context.ephemeral_data_context import EphemeralDataContext
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
 )
@@ -36,6 +33,7 @@ from great_expectations.data_context.store.validation_definition_store import (
     ValidationDefinitionStore,
 )
 from great_expectations.exceptions import DataContextError
+from tests.conftest import random_name
 
 
 @pytest.fixture
@@ -471,18 +469,15 @@ def test_validation_definition_factory_round_trip(
 
 
 class TestValidationDefinitionFactoryAddOrUpdate:
-    def random_name(self) -> str:
-        return "".join([random.choice(string.ascii_letters) for _ in range(6)])
-
     def _build_batch_definition(self, context: AbstractDataContext):
-        name = self.random_name()
+        name = random_name()
         ds = context.data_sources.add_pandas(name=name)
         asset = ds.add_csv_asset(name=name, filepath_or_buffer=pathlib.Path("data.csv"))
         return asset.add_batch_definition(name=name)
 
     def _build_suite(self) -> ExpectationSuite:
         return ExpectationSuite(
-            name=self.random_name(),
+            name=random_name(),
             expectations=[
                 gxe.ExpectColumnValuesToBeBetween(
                     column="passenger_count", min_value=0, max_value=10
@@ -490,60 +485,28 @@ class TestValidationDefinitionFactoryAddOrUpdate:
             ],
         )
 
-    @pytest.mark.filesystem
-    def test_add_new_validation__filesystem(self, empty_data_context: FileDataContext):
-        self._test_add_new_validation(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_new_validation__cloud(self, empty_cloud_context_fluent: CloudDataContext):
-        self._test_add_new_validation(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_new_validation__ephemeral(
-        self, ephemeral_context_with_defaults: EphemeralDataContext
-    ):
-        self._test_add_new_validation(ephemeral_context_with_defaults)
-
-    def _test_add_new_validation(self, context: AbstractDataContext):
+    def test_add_new_validation(self, data_context: AbstractDataContext) -> None:
         # arrange
-        vd_name = self.random_name()
-        batch_def = self._build_batch_definition(context)
+        vd_name = random_name()
+        batch_def = self._build_batch_definition(data_context)
         suite = self._build_suite()
         vd = ValidationDefinition(
             name=vd_name,
             data=batch_def,
-            suite=context.suites.add(suite),
+            suite=data_context.suites.add(suite),
         )
 
         # act
-        created_vd = context.validation_definitions.add_or_update(validation=vd)
+        created_vd = data_context.validation_definitions.add_or_update(validation=vd)
 
         # assert
         assert created_vd.id
-        context.validation_definitions.get(vd_name)
+        data_context.validation_definitions.get(vd_name)
 
-    @pytest.mark.filesystem
-    def test_add_new_validation_with_new_suite__filesystem(
-        self, empty_data_context: FileDataContext
-    ):
-        self._test_add_new_validation_with_new_suite(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_new_validation_with_new_suite__cloud(
-        self, empty_cloud_context_fluent: CloudDataContext
-    ):
-        self._test_add_new_validation_with_new_suite(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_new_validation_with_new_suite__ephemeral(
-        self, ephemeral_context_with_defaults: EphemeralDataContext
-    ):
-        self._test_add_new_validation_with_new_suite(ephemeral_context_with_defaults)
-
-    def _test_add_new_validation_with_new_suite(self, context: AbstractDataContext):
+    def test_add_new_validation_with_new_suite(self, data_context: AbstractDataContext) -> None:
         # arrange
-        vd_name = self.random_name()
-        batch_def = self._build_batch_definition(context)
+        vd_name = random_name()
+        batch_def = self._build_batch_definition(data_context)
         suite = self._build_suite()
         vd = ValidationDefinition(
             name=vd_name,
@@ -552,182 +515,116 @@ class TestValidationDefinitionFactoryAddOrUpdate:
         )
 
         # act
-        created_vd = context.validation_definitions.add_or_update(validation=vd)
+        created_vd = data_context.validation_definitions.add_or_update(validation=vd)
 
         # assert
         assert created_vd.id
-        context.validation_definitions.get(vd_name)
+        data_context.validation_definitions.get(vd_name)
 
-    @pytest.mark.filesystem
-    def test_update_expectation_suite__filesystem(self, empty_data_context: FileDataContext):
-        self._test_update_expectation_suite(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_update_expectation_suite__cloud(self, empty_cloud_context_fluent: CloudDataContext):
-        self._test_update_expectation_suite(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_update_expectation_suite__ephemeral(
-        self, ephemeral_context_with_defaults: EphemeralDataContext
-    ):
-        self._test_update_expectation_suite(ephemeral_context_with_defaults)
-
-    def _test_update_expectation_suite(self, context: AbstractDataContext):
+    def test_update_expectation_suite(self, data_context: AbstractDataContext) -> None:
         # arrange
-        vd_name = self.random_name()
-        batch_def = self._build_batch_definition(context)
+        vd_name = random_name()
+        batch_def = self._build_batch_definition(data_context)
         suite = self._build_suite()
         vd = ValidationDefinition(
             name=vd_name,
             data=batch_def,
-            suite=context.suites.add(suite),
+            suite=data_context.suites.add(suite),
         )
-        existing_vd = context.validation_definitions.add(validation=vd)
+        existing_vd = data_context.validation_definitions.add(validation=vd)
 
         # act
         vd.suite.expectations = [
             gxe.ExpectColumnMaxToBeBetween(column="passenger_count", min_value=0, max_value=5)
         ]
 
-        updated_vd = context.validation_definitions.add_or_update(validation=vd)
+        updated_vd = data_context.validation_definitions.add_or_update(validation=vd)
 
         # assert
         assert updated_vd.id == existing_vd.id
         assert len(updated_vd.suite.expectations) == 1 and isinstance(
             updated_vd.suite.expectations[0], gxe.ExpectColumnMaxToBeBetween
         )
-        context.validation_definitions.get(vd_name)
+        data_context.validation_definitions.get(vd_name)
 
-    @pytest.mark.filesystem
-    def test_replace_expectation_suite__filesystem(self, empty_data_context: FileDataContext):
-        self._test_replace_expectation_suite(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_replace_expectation_suite__cloud(self, empty_cloud_context_fluent: CloudDataContext):
-        self._test_replace_expectation_suite(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_replace_expectation_suite__ephemeral(
-        self, ephemeral_context_with_defaults: EphemeralDataContext
-    ):
-        self._test_replace_expectation_suite(ephemeral_context_with_defaults)
-
-    def _test_replace_expectation_suite(self, context: AbstractDataContext):
+    def test_replace_expectation_suite(self, data_context: AbstractDataContext) -> None:
         # arrange
-        vd_name = self.random_name()
-        batch_def = self._build_batch_definition(context)
-        suite = context.suites.add(self._build_suite())
+        vd_name = random_name()
+        batch_def = self._build_batch_definition(data_context)
+        suite = data_context.suites.add(self._build_suite())
         vd = ValidationDefinition(
             name=vd_name,
             data=batch_def,
             suite=suite,
         )
-        existing_vd = context.validation_definitions.add(validation=vd)
+        existing_vd = data_context.validation_definitions.add(validation=vd)
 
         # act
-        new_suite = context.suites.add(self._build_suite())
+        new_suite = data_context.suites.add(self._build_suite())
         new_vd = ValidationDefinition(
             name=vd_name,
             data=batch_def,
             suite=new_suite,
         )
-        updated_vd = context.validation_definitions.add_or_update(validation=new_vd)
+        updated_vd = data_context.validation_definitions.add_or_update(validation=new_vd)
 
         # assert
         assert updated_vd.suite.id != existing_vd.suite.id  # New suite should have a different ID
         assert updated_vd.data.id == existing_vd.data.id
         assert updated_vd.id == existing_vd.id
-        context.validation_definitions.get(vd_name)
+        data_context.validation_definitions.get(vd_name)
 
-    @pytest.mark.filesystem
     @pytest.mark.xfail(
         raises=ValidationError,
         reason="GX-481: Changing a BatchDefinition breaks loading a Validation Definition.",
         strict=True,
     )
-    def test_update_batch_definition__filesystem(self, empty_data_context: FileDataContext):
-        self._test_update_batch_definition(empty_data_context)
-
-    @pytest.mark.cloud
-    @pytest.mark.xfail(
-        raises=ValidationError,
-        reason="GX-481: Changing a BatchDefinition breaks loading a Validation Definition.",
-        strict=True,
-    )
-    def test_update_batch_definition__cloud(self, empty_cloud_context_fluent: CloudDataContext):
-        self._test_update_batch_definition(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    @pytest.mark.xfail(
-        raises=ValidationError,
-        reason="GX-481: Changing a BatchDefinition breaks loading a Validation Definition.",
-        strict=True,
-    )
-    def test_update_batch_definition__ephemeral(
-        self, ephemeral_context_with_defaults: EphemeralDataContext
-    ):
-        self._test_update_batch_definition(ephemeral_context_with_defaults)
-
-    def _test_update_batch_definition(self, context: AbstractDataContext):
+    def test_update_batch_definition(self, data_context: AbstractDataContext) -> None:
         # arrange
-        vd_name = self.random_name()
-        batch_def = self._build_batch_definition(context)
-        suite = context.suites.add(self._build_suite())
+        vd_name = random_name()
+        batch_def = self._build_batch_definition(data_context)
+        suite = data_context.suites.add(self._build_suite())
         vd = ValidationDefinition(
             name=vd_name,
             data=batch_def,
             suite=suite,
         )
-        context.validation_definitions.add(validation=vd)
+        data_context.validation_definitions.add(validation=vd)
 
         # act
-        new_batch_def_name = self.random_name()
+        new_batch_def_name = random_name()
         batch_def.name = new_batch_def_name
         new_vd = ValidationDefinition(
             name=vd_name,
             data=batch_def,
             suite=suite,
         )
-        updated_vd = context.validation_definitions.add_or_update(validation=new_vd)
+        updated_vd = data_context.validation_definitions.add_or_update(validation=new_vd)
 
         # assert
         assert updated_vd.data.name == new_batch_def_name
-        context.validation_definitions.get(vd_name)
+        data_context.validation_definitions.get(vd_name)
 
-    @pytest.mark.filesystem
-    def test_replace_batch_definition__filesystem(self, empty_data_context: FileDataContext):
-        self._test_replace_batch_definition(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_replace_batch_definition__cloud(self, empty_cloud_context_fluent: CloudDataContext):
-        self._test_replace_batch_definition(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_replace_batch_definition__ephemeral(
-        self, ephemeral_context_with_defaults: EphemeralDataContext
-    ):
-        self._test_replace_batch_definition(ephemeral_context_with_defaults)
-
-    def _test_replace_batch_definition(self, context: AbstractDataContext):
+    def test_replace_batch_definition(self, data_context: AbstractDataContext) -> None:
         # arrange
-        vd_name = self.random_name()
-        batch_def = self._build_batch_definition(context)
-        suite = context.suites.add(self._build_suite())
+        vd_name = random_name()
+        batch_def = self._build_batch_definition(data_context)
+        suite = data_context.suites.add(self._build_suite())
         vd = ValidationDefinition(
             name=vd_name,
             data=batch_def,
             suite=suite,
         )
-        existing_vd = context.validation_definitions.add(validation=vd)
+        existing_vd = data_context.validation_definitions.add(validation=vd)
 
         # act
-        new_batch_def = self._build_batch_definition(context)
+        new_batch_def = self._build_batch_definition(data_context)
         new_vd = ValidationDefinition(
             name=vd_name,
             data=new_batch_def,
             suite=suite,
         )
-        updated_vd = context.validation_definitions.add_or_update(validation=new_vd)
+        updated_vd = data_context.validation_definitions.add_or_update(validation=new_vd)
 
         # assert
         assert updated_vd.suite.id == existing_vd.suite.id
@@ -737,26 +634,12 @@ class TestValidationDefinitionFactoryAddOrUpdate:
         assert updated_vd.data.id  # should not be None
         assert updated_vd.data.id == new_batch_def.id
         assert updated_vd.id == existing_vd.id
-        context.validation_definitions.get(vd_name)
+        data_context.validation_definitions.get(vd_name)
 
-    @pytest.mark.filesystem
-    def test_add_or_update_is_idempotent__filesystem(self, empty_data_context: FileDataContext):
-        self._test_add_or_update_is_idempotent(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_add_or_update_is_idempotent__cloud(self, empty_cloud_context_fluent: CloudDataContext):
-        self._test_add_or_update_is_idempotent(empty_cloud_context_fluent)
-
-    @pytest.mark.unit
-    def test_add_or_update_is_idempotent__ephemeral(
-        self, ephemeral_context_with_defaults: EphemeralDataContext
-    ):
-        self._test_add_or_update_is_idempotent(ephemeral_context_with_defaults)
-
-    def _test_add_or_update_is_idempotent(self, context: AbstractDataContext):
+    def test_add_or_update_is_idempotent(self, data_context: AbstractDataContext) -> None:
         # arrange
-        vd_name = self.random_name()
-        batch_def = self._build_batch_definition(context)
+        vd_name = random_name()
+        batch_def = self._build_batch_definition(data_context)
         suite = self._build_suite()
         vd = ValidationDefinition(
             name=vd_name,
@@ -765,29 +648,23 @@ class TestValidationDefinitionFactoryAddOrUpdate:
         )
 
         # act
-        vd_1 = context.validation_definitions.add_or_update(validation=vd)
-        vd_2 = context.validation_definitions.add_or_update(validation=vd)
-        vd_3 = context.validation_definitions.add_or_update(validation=vd)
+        vd_1 = data_context.validation_definitions.add_or_update(validation=vd)
+        vd_2 = data_context.validation_definitions.add_or_update(validation=vd)
+        vd_3 = data_context.validation_definitions.add_or_update(validation=vd)
 
         # assert
         assert vd_1 == vd_2 == vd_3
 
 
 class TestValidationDefinitionFactoryAnalytics:
-    @pytest.mark.filesystem
-    def test_validation_definition_factory_add_emits_event_filesystem(self, empty_data_context):
-        self._test_validation_definition_factory_add_emits_event(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_validation_definition_factory_add_emits_event_cloud(self, empty_cloud_context_fluent):
-        self._test_validation_definition_factory_add_emits_event(empty_cloud_context_fluent)
-
-    def _test_validation_definition_factory_add_emits_event(self, context):
+    def test_validation_definition_factory_add_emits_event(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # Arrange
-        ds = context.data_sources.add_pandas("my_datasource")
+        ds = data_context.data_sources.add_pandas("my_datasource")
         asset = ds.add_csv_asset("my_asset", "data.csv")
         batch_def = asset.add_batch_definition("my_batch_definition")
-        suite = context.suites.add(ExpectationSuite(name="my_suite"))
+        suite = data_context.suites.add(ExpectationSuite(name="my_suite"))
 
         validation_definition = ValidationDefinition(
             name="validation_def", data=batch_def, suite=suite
@@ -798,7 +675,7 @@ class TestValidationDefinitionFactoryAnalytics:
             "great_expectations.core.factory.validation_definition_factory.submit_event",
             autospec=True,
         ) as mock_submit:
-            _ = context.validation_definitions.add(validation=validation_definition)
+            _ = data_context.validation_definitions.add(validation=validation_definition)
 
         # Assert
         mock_submit.assert_called_once_with(
@@ -807,25 +684,17 @@ class TestValidationDefinitionFactoryAnalytics:
             )
         )
 
-    @pytest.mark.filesystem
-    def test_validation_definition_factory_delete_emits_event_filesystem(self, empty_data_context):
-        self._test_validation_definition_factory_delete_emits_event(empty_data_context)
-
-    @pytest.mark.cloud
-    def test_validation_definition_factory_delete_emits_event_cloud(
-        self, empty_cloud_context_fluent
-    ):
-        self._test_validation_definition_factory_delete_emits_event(empty_cloud_context_fluent)
-
-    def _test_validation_definition_factory_delete_emits_event(self, context):
+    def test_validation_definition_factory_delete_emits_event(
+        self, data_context: AbstractDataContext
+    ) -> None:
         # Arrange
-        ds = context.data_sources.add_pandas("my_datasource")
+        ds = data_context.data_sources.add_pandas("my_datasource")
         asset = ds.add_csv_asset("my_asset", "data.csv")
         batch_def = asset.add_batch_definition("my_batch_definition")
-        suite = context.suites.add(ExpectationSuite(name="my_suite"))
+        suite = data_context.suites.add(ExpectationSuite(name="my_suite"))
 
         name = "validation_def"
-        validation_definition = context.validation_definitions.add(
+        validation_definition = data_context.validation_definitions.add(
             validation=ValidationDefinition(name=name, data=batch_def, suite=suite)
         )
 
@@ -834,7 +703,7 @@ class TestValidationDefinitionFactoryAnalytics:
             "great_expectations.core.factory.validation_definition_factory.submit_event",
             autospec=True,
         ) as mock_submit:
-            context.validation_definitions.delete(name=name)
+            data_context.validation_definitions.delete(name=name)
 
         # Assert
         mock_submit.assert_called_once_with(

--- a/tests/core/factory/test_validation_definition_factory.py
+++ b/tests/core/factory/test_validation_definition_factory.py
@@ -662,7 +662,7 @@ class TestValidationDefinitionFactoryAnalytics:
     ) -> None:
         # Arrange
         ds = data_context.data_sources.add_pandas("my_datasource")
-        asset = ds.add_csv_asset("my_asset", "data.csv")
+        asset = ds.add_csv_asset("my_asset", pathlib.Path("data.csv"))
         batch_def = asset.add_batch_definition("my_batch_definition")
         suite = data_context.suites.add(ExpectationSuite(name="my_suite"))
 
@@ -689,7 +689,7 @@ class TestValidationDefinitionFactoryAnalytics:
     ) -> None:
         # Arrange
         ds = data_context.data_sources.add_pandas("my_datasource")
-        asset = ds.add_csv_asset("my_asset", "data.csv")
+        asset = ds.add_csv_asset("my_asset", pathlib.Path("data.csv"))
         batch_def = asset.add_batch_definition("my_batch_definition")
         suite = data_context.suites.add(ExpectationSuite(name="my_suite"))
 


### PR DESCRIPTION
This PR updates a number of tests to use a new `data_context` fixture that previously were written as separate tests.