### PR TITLE
[BUGFIX] on update data source don't delete assets

### DIFF
--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -569,6 +569,9 @@ class DataSourceManager:
             new_datasource._data_context = self._data_context
             new_datasource.test_connection()
             if datasource_name in self.all():
+                # We're updating a data source only, so don't overwrite existing assets.
+                existing_assets = self.all()[datasource_name].assets
+                new_datasource.assets = existing_assets
                 return_obj = self._data_context._update_fluent_datasource(datasource=new_datasource)
             else:
                 return_obj = self._data_context._add_fluent_datasource(datasource=new_datasource)


### PR DESCRIPTION
This PR updates `context.data_sources.add_or_update...` to only update the Datasource config itself, and not remove existing assets, which is current behavior. While as far as I can see this was a bug, changing it will break existing behavior. The issue is that we have not implemented `Datasource.update_asset`. Assets can never be updated, only created or deleted. We probably need to ship that change along with this one, so users who were relying on the buggy implementation have an alternative.