### PR TITLE
[MAINTENANCE] Remove unneeded tests

### DIFF
--- a/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_canonical_expectations.py
@@ -124,33 +124,3 @@ def test_expect_column_max_to_be_between(batch_for_datasource) -> None:
     expectation = gxe.ExpectColumnMaxToBeBetween(column="a", min_value=2, max_value=2)
     result = batch_for_datasource.validate(expectation)
     assert result.success
-
-
-@parameterize_batch_for_data_sources(
-    data_source_configs=ALL_DATA_SOURCES,
-    data=pd.DataFrame({"a": [1, 2]}),
-)
-def test_expect_column_to_exist(batch_for_datasource):
-    expectation = gxe.ExpectColumnToExist(column="a")
-    result = batch_for_datasource.validate(expectation)
-    assert result.success
-
-
-@parameterize_batch_for_data_sources(
-    data_source_configs=ALL_DATA_SOURCES,
-    data=pd.DataFrame({"a": [1, 2]}),
-)
-def test_expect_column_values_to_not_be_null(batch_for_datasource):
-    expectation = gxe.ExpectColumnValuesToNotBeNull(column="a")
-    result = batch_for_datasource.validate(expectation)
-    assert result.success
-
-
-@parameterize_batch_for_data_sources(
-    data_source_configs=ALL_DATA_SOURCES,
-    data=pd.DataFrame({"a": [1, 2, 3, 4]}),
-)
-def test_expect_column_mean_to_be_between(batch_for_datasource):
-    expectation = gxe.ExpectColumnMeanToBeBetween(column="a", min_value=2, max_value=3)
-    result = batch_for_datasource.validate(expectation)
-    assert result.success


### PR DESCRIPTION
I'm doing this now because we appear to have like 1 too many mysql tests running, triggering the bug documented here: https://greatexpectations.atlassian.net/browse/GX-519

We have dedicated tests files for each of these removed tests. This file in general should probably be removed in place of a file that just aggregates the different subset of test configs, but that's a job for someone later 😄 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
