### PR TITLE
[DOCS] reflect change on metrics page, clarify perms

### DIFF
--- a/docs/docusaurus/docs/cloud/users/manage_users.md
+++ b/docs/docusaurus/docs/cloud/users/manage_users.md
@@ -17,7 +17,7 @@ The following table lists GX Cloud roles and responsibilities.
 | Role          | Responsibilities                                  |
 |---------------|---------------------------------------------------|
 | Viewer        | View Validation Results           |
-| Editor        | Create Data Assets<br/>Create and edit Expectations<br/>Create access tokens |
+| Editor        | Create Data Sources<br/>Create Data Assets<br/>Create and edit Expectations<br/>Create access tokens |
 | Admin         | Full access<br/>Perform all GX Cloud administrative functions including user and role assignment |
 
 ## Invite a user

--- a/docs/docusaurus/docs/cloud/validations/manage_validations.md
+++ b/docs/docusaurus/docs/cloud/validations/manage_validations.md
@@ -30,7 +30,7 @@ To run a validation for an [API-managed Expectation](/cloud/expectations/manage_
 
 ## Run a Validation on a subset of a Data Asset
 
-If you've [defined a Batch](/cloud/expectations/manage_expectations.md#optional-define-a-batch), you can run a Validation on the latest Batch of data, or you can select a specific year, year and month, or year, month, and day period for the Validation. If a Batch is defined, Batch information appears on the Data Asset **Metrics** page and on the **Validations** page in the **Batches & run history** pane.
+If you've [defined a Batch](/cloud/expectations/manage_expectations.md#optional-define-a-batch), you can run a Validation on the latest Batch of data, or you can select a specific year, year and month, or year, month, and day period for the Validation. If a Batch is defined, Batch information appears on the **Validations** page in the **Batches & run history** pane.
 
 To run a Validation for a specific Batch, do the following:
 


### PR DESCRIPTION
This issueless PR addresses a couple things I saw go by in slack

- Unclear whether [editors can create Data Sources](https://greatexpectationslabs.slack.com/archives/C088KRZTR2A/p1743031111493159)
- [Asset info card removed from the metrics tab](https://greatexpectationslabs.slack.com/archives/C088KRZTR2A/p1743033781714389)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
