### PR TITLE
[BUGFIX] Prevent sqlite metric impl from overwriting default sqlalchemy

### DIFF
--- a/great_expectations/execution_engine/sqlite_execution_engine.py
+++ b/great_expectations/execution_engine/sqlite_execution_engine.py
@@ -27,7 +27,7 @@ class ColumnStandardDeviation(BaseColumnStandardDeviation):
     """MetricProvider Class for Aggregate Standard Deviation metric for SQLite databases."""
 
     # We should change this decorator to compute this metric a completely new way
-    @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)
+    @column_aggregate_partial(engine=SqliteExecutionEngine)
     def _sqlalchemy(cls, column, _dialect, _metrics, **kwargs):
         """Sqlite Standard Deviation implementation"""
         mean = _metrics["column.mean"]

--- a/great_expectations/expectations/metrics/column_aggregate_metric_provider.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metric_provider.py
@@ -60,7 +60,7 @@ def column_aggregate_value(
     if issubclass(engine, PandasExecutionEngine):
 
         def wrapper(metric_fn: Callable):
-            @metric_value(engine=PandasExecutionEngine)
+            @metric_value(engine=engine)
             @wraps(metric_fn)
             def inner_func(  # noqa: PLR0913 # FIXME CoP
                 cls,
@@ -126,7 +126,7 @@ def column_aggregate_partial(engine: Type[ExecutionEngine], **kwargs):  # noqa: 
 
         def wrapper(metric_fn: Callable):
             @metric_partial(
-                engine=SqlAlchemyExecutionEngine,
+                engine=engine,
                 partial_fn_type=partial_fn_type,
                 domain_type=domain_type,
             )
@@ -188,7 +188,7 @@ def column_aggregate_partial(engine: Type[ExecutionEngine], **kwargs):  # noqa: 
 
         def wrapper(metric_fn: Callable):
             @metric_partial(
-                engine=SparkDFExecutionEngine,
+                engine=engine,
                 partial_fn_type=partial_fn_type,
                 domain_type=domain_type,
             )

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -311,7 +311,7 @@ def _get_metric_definition(metric_name: str) -> dict:
     try:
         return _registered_metrics[metric_name]
     except KeyError:
-        raise gx_exceptions.MetricProviderError(f"No definition found for {metric_name}")  # noqa: TRY003 # FIXME CoP
+        raise gx_exceptions.MetricProviderError(f"No metric named {metric_name} found.")  # noqa: TRY003 # FIXME CoP
 
 
 def get_sqlalchemy_metric_provider(

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -307,16 +307,30 @@ def register_metric(  # noqa: PLR0913 # FIXME CoP
     return res
 
 
+def _get_metric_definition(metric_name: str) -> dict:
+    try:
+        return _registered_metrics[metric_name]
+    except KeyError:
+        raise gx_exceptions.MetricProviderError(f"No definition found for {metric_name}")  # noqa: TRY003 # FIXME CoP
+
+
+def get_sqlalchemy_metric_provider(
+    metric_name: str,
+) -> Tuple[MetricProvider, Callable]:
+    """The default SqlAlchemy metric provider for a given metric."""
+    metric_definition = _get_metric_definition(metric_name)
+    try:
+        return metric_definition["providers"]["SqlAlchemyExecutionEngine"]
+    except KeyError:
+        raise gx_exceptions.MetricProviderError(  # noqa: TRY003 # FIXME CoP
+            f"No provider found for {metric_name} using SqlAlchemyExecutionEngine"
+        )
+
+
 def get_metric_provider(
     metric_name: str, execution_engine: ExecutionEngine
 ) -> Tuple[MetricProvider, Callable]:
-    try:
-        metric_definition = _registered_metrics[metric_name]
-    except KeyError:
-        raise gx_exceptions.MetricProviderError(  # noqa: TRY003 # FIXME CoP
-            f"No metric named {metric_name} found."
-        )
-
+    metric_definition = _get_metric_definition(metric_name)
     try:
         return metric_definition["providers"][type(execution_engine).__name__]
     except KeyError:

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -70,6 +70,7 @@ from great_expectations.execution_engine import (
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
+from great_expectations.execution_engine.sqlite_execution_engine import SqliteExecutionEngine
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfigurationSchema,
 )
@@ -447,6 +448,14 @@ BACKEND_TO_ENGINE_NAME_DICT = {
 }
 
 BACKEND_TO_ENGINE_NAME_DICT.update({name: "sqlalchemy" for name in SQL_DIALECT_NAMES})
+
+
+# The default exeuction engine is SqlAlchemyExecutionEngine so we set this and then override
+# with specific values.
+SQLALCHEMY_DIALECT_TO_ENGINE_CLASS_DICT = {
+    name: SqlAlchemyExecutionEngine for name in SQL_DIALECT_NAMES
+}
+SQLALCHEMY_DIALECT_TO_ENGINE_CLASS_DICT["sqlite"] = SqliteExecutionEngine
 
 
 def get_sqlite_connection_url(sqlite_db_path):
@@ -912,7 +921,8 @@ def build_sa_validator_with_data(  # noqa: C901, PLR0912, PLR0913, PLR0915 # FIX
     else:
         sql_insert_method = None
 
-    execution_engine = SqlAlchemyExecutionEngine(caching=caching, engine=engine)
+    execution_engine_class = SQLALCHEMY_DIALECT_TO_ENGINE_CLASS_DICT[engine.name]
+    execution_engine = execution_engine_class(caching=caching, engine=engine)
     batch_data = SqlAlchemyBatchData(execution_engine=execution_engine, table_name=table_name)
     with execution_engine.get_connection() as connection:
         _debug("Calling df.to_sql")

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -921,7 +921,7 @@ def build_sa_validator_with_data(  # noqa: C901, PLR0912, PLR0913, PLR0915 # FIX
     else:
         sql_insert_method = None
 
-    execution_engine_class = SQLALCHEMY_DIALECT_TO_ENGINE_CLASS_DICT[engine.name]
+    execution_engine_class = SQLALCHEMY_DIALECT_TO_ENGINE_CLASS_DICT[sa_engine_name]
     execution_engine = execution_engine_class(caching=caching, engine=engine)
     batch_data = SqlAlchemyBatchData(execution_engine=execution_engine, table_name=table_name)
     with execution_engine.get_connection() as connection:

--- a/tests/expectations/test_registry.py
+++ b/tests/expectations/test_registry.py
@@ -2,10 +2,16 @@ import pytest
 
 import great_expectations.exceptions as gx_exceptions
 import great_expectations.expectations as gxe
+from great_expectations.compatibility import sqlalchemy
+from great_expectations.execution_engine.sqlite_execution_engine import SqliteExecutionEngine
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
-from great_expectations.expectations.registry import get_expectation_impl
+from great_expectations.expectations.registry import (
+    get_expectation_impl,
+    get_metric_provider,
+    get_sqlalchemy_metric_provider,
+)
 
 # module level markers
 pytestmark = pytest.mark.unit
@@ -27,3 +33,25 @@ def test_registry_from_configuration():
 def test_registry_raises_error_when_invalid_expectation_requested():
     with pytest.raises(gx_exceptions.ExpectationNotFoundError):
         get_expectation_impl("expect_something_in_beta")
+
+
+def test_get_metric_provider_for_sqlalchemy_engine_subclass():
+    # This is a regression test to show that we can register a metric for
+    # a sqlalchemy engine subclass and it doesn't overwrite the default metric.
+    metric_name = "column.standard_deviation.aggregate_fn"
+
+    sa_metric_provider, sa_metric_provider_fn = get_sqlalchemy_metric_provider(
+        metric_name,
+    )
+
+    # get the sqlite metric provider
+    sqlite_metric_provider, sqlite_metric_provider_fn = get_metric_provider(
+        metric_name,
+        SqliteExecutionEngine(engine=sqlalchemy.create_engine("sqlite://")),
+    )
+    assert sa_metric_provider is not None
+    assert sqlite_metric_provider is not None
+    assert sa_metric_provider != sqlite_metric_provider
+    assert sa_metric_provider_fn is not None
+    assert sqlite_metric_provider_fn is not None
+    assert sa_metric_provider_fn != sqlite_metric_provider_fn


### PR DESCRIPTION
Note, this bug was never release onto pypi.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
