### PR TITLE
[BUGFIX] Compare type dict column name with actual column name with casefold. …

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -566,7 +566,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
         actual_column_type = [
             type_dict["type"]
             for type_dict in actual_column_types_list
-            if type_dict["name"] == column_name
+            if type_dict["name"].casefold() == column_name.casefold()
         ][0]
 
         if isinstance(execution_engine, PandasExecutionEngine):


### PR DESCRIPTION
…If the column name is passed as all caps or snake-case then the column matching will fail and it will raise an indexError which is hard to debug for users.
Steps to reproduce:

`import great_expectations as gx
import pandas as pd
import yaml
from great_expectations.expectations import ExpectColumnValuesToBeOfType

NAME_DATA_SOURCE = "pandas"
NAME_DATA_ASSET = "tutorial_data"
NAME_BATCH_DEF = "pandas_tutorial"
NAME_EXPECTATION_SUITE = "pandas_tutorial"
NAME_VALIDATION_DEF = "pandas_validation"
NAME_CHECKPOINT = "pandas"

# Create a small DataFrame
data = {
    "age": [25, 30, 35, 40]
}
config = yaml.safe_load(open("expectations.yml"))

df = pd.DataFrame(data)

context = gx.get_context()

data_source = context.data_sources.add_pandas(name=NAME_DATA_SOURCE)
data_asset = data_source.add_dataframe_asset(name=NAME_DATA_ASSET)
batch_definition = data_asset.add_batch_definition_whole_dataframe(NAME_BATCH_DEF)

expectation_suite = gx.ExpectationSuite(name="demo_expectation_suite")
expectation_suite = context.suites.add(expectation_suite)

expectations = ExpectColumnValuesToBeOfType(
    column="AGE",
    type_="int64"
)


expectation_suite.add_expectation(expectations)

batch_parameters = {"dataframe": df}
batch = batch_definition.get_batch(batch_parameters=batch_parameters)
validation_results = batch.validate(expectation_suite)

print(validation_results)`


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
