### PR TITLE
[MAINTENANCE] Improve package autocompletion behavior

### DIFF
--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -6,11 +6,21 @@ from ._version import get_versions as _get_versions
 __version__ = _get_versions()["version"]
 del _get_versions
 
-# great_expectations.data_context must be imported first or we will have circular dependency issues
-import great_expectations.data_context  # isort:skip
-import great_expectations.core
+# Submodules must be imported first to avoid circular dependencies
+# with data_context being the first
+from . import data_context  # isort:skip
+from . import core
+from . import exceptions
+from . import expectations
+from . import checkpoint
 
+# Top-level functions/classes promoted to the gx namespace
 from great_expectations.data_context.data_context.context_factory import get_context
+from great_expectations.checkpoint import Checkpoint
+from great_expectations.core.expectation_suite import ExpectationSuite
+from great_expectations.core.result_format import ResultFormat
+from great_expectations.core.run_identifier import RunIdentifier
+from great_expectations.core.validation_definition import ValidationDefinition
 
 # # By placing this registry function in our top-level __init__,  we ensure that all
 # # GX workflows have populated expectation registries before they are used.
@@ -24,13 +34,3 @@ _register_core_expectations()
 
 del _register_core_metrics
 del _register_core_expectations
-
-from great_expectations import exceptions
-from great_expectations import expectations
-from great_expectations import checkpoint
-
-from great_expectations.checkpoint import Checkpoint
-from great_expectations.core.expectation_suite import ExpectationSuite
-from great_expectations.core.result_format import ResultFormat
-from great_expectations.core.run_identifier import RunIdentifier
-from great_expectations.core.validation_definition import ValidationDefinition


### PR DESCRIPTION
## Description

This PR addresses confusing autocompletion behavior in IDEs where importing `great_expectations as gx` would suggest `gx.great_expectations`, leading to potentially infinite nesting in suggestions (`gx.great_expectations.great_expectations...`). This makes the API difficult to navigate via autocompletion.

The goal, based on the original issue's acceptance criteria, was to make `gx.great_expectations` fail while ensuring the intended public API (`gx.data_context`, `gx.core`, `gx.get_context`, etc.) remains accessible and autocompletable.

## Solution

The solution implemented in `great_expectations/__init__.py` is to change the imports of the primary submodules (`data_context`, `core`, `exceptions`, `expectations`, `checkpoint`) from absolute imports (e.g., `import great_expectations.core`) to **relative imports** (e.g., `from . import core`).

Specific functions and classes intended for the top-level namespace (like `get_context`, `Checkpoint`, `ExpectationSuite`) are still imported via their absolute paths to make them available directly under `gx`.

## Effect of Changes

1.  **Autocompletion:** Using relative imports for submodules prevents the `great_expectations` package from explicitly importing itself by name within its own `__init__.py`. This successfully hides the recursive `gx.great_expectations` attribute from IDE autocompletion / static analysis tools.
2.  **Runtime Behavior:** A side effect of using relative imports in this manner is that the `gx.great_expectations` attribute is **no longer created at runtime**. Attempting to access `gx.great_expectations` will now correctly raise an `AttributeError`, fulfilling the acceptance criteria. This differs from the typical runtime behavior of Python packages that often include this self-reference.
3.  **Public API:** The intended public API remains accessible. Submodules like `gx.data_context` and `gx.core` are available because they are imported via `from . import ...`. Top-level functions/classes like `gx.get_context` and `gx.ExpectationSuite` are available because they are explicitly imported from their absolute paths.

## Verification

*   **Autocompletion:** Tested in the development environment; `gx.` no longer suggests `great_expectations`. Intended attributes like `data_context`, `core`, `get_context` are still suggested.
*   **Runtime:** The following minimal script demonstrates the key runtime changes. Reviewers can run this locally:

    ```python
    import great_expectations as gx
    import sys

    print(f"Python version: {sys.version}")
    print(f"Great Expectations version: {gx.__version__}")

    # 1. Verify gx.great_expectations now raises AttributeError
    try:
        _ = gx.great_expectations
        print("[FAILED] gx.great_expectations still exists at runtime.")
    except AttributeError:
        print("[SUCCESS] gx.great_expectations correctly raises AttributeError.")
    except Exception as e:
        print(f"[ERROR] Unexpected error accessing gx.great_expectations: {e}")

    # 2. Verify intended submodules are accessible
    try:
        _ = gx.data_context
        _ = gx.core
        print("[SUCCESS] Submodules like gx.data_context and gx.core are accessible.")
    except AttributeError as e:
        print(f"[FAILED] Could not access intended submodules: {e}")

    # 3. Verify intended top-level imports are accessible
    try:
        _ = gx.get_context
        _ = gx.ExpectationSuite
        print("[SUCCESS] Top-level imports like gx.get_context and gx.ExpectationSuite are accessible.")
    except AttributeError as e:
        print(f"[FAILED] Could not access intended top-level imports: {e}")

    ```

This PR modifies the package's internal import structure to improve the developer experience by cleaning up autocompletion and aligning runtime behavior with the desired outcome.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
