### PR TITLE
[BUGFIX] Respect context_root_dir in get_context

### DIFF
--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -172,7 +172,7 @@ class ProjectManager:
     ) -> AbstractDataContext:
         project_config = self._prepare_project_config(project_config)
 
-        if mode == "file" and context_root_dir is not None and not project_root_dir:
+        if mode == "file" and not context_root_dir and not project_root_dir:
             project_root_dir = Path.cwd()
 
         param_lookup: dict[ContextModes | None, dict] = {

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -172,7 +172,7 @@ class ProjectManager:
     ) -> AbstractDataContext:
         project_config = self._prepare_project_config(project_config)
 
-        if mode == "file" and context_root_dir is None and not project_root_dir:
+        if mode == "file" and context_root_dir is not None and not project_root_dir:
             project_root_dir = Path.cwd()
 
         param_lookup: dict[ContextModes | None, dict] = {

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -172,6 +172,9 @@ class ProjectManager:
     ) -> AbstractDataContext:
         project_config = self._prepare_project_config(project_config)
 
+        if mode == "file" and context_root_dir is None and not project_root_dir:
+            project_root_dir = Path.cwd()
+
         param_lookup: dict[ContextModes | None, dict] = {
             "ephemeral": dict(
                 project_config=project_config,
@@ -181,7 +184,7 @@ class ProjectManager:
             "file": dict(
                 project_config=project_config,
                 context_root_dir=context_root_dir,
-                project_root_dir=project_root_dir or Path.cwd(),
+                project_root_dir=project_root_dir,
                 runtime_environment=runtime_environment,
                 user_agent_str=user_agent_str,
             ),

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -460,6 +460,21 @@ def get_context(
 @overload
 def get_context(
     project_config: DataContextConfig | Mapping | None = ...,
+    context_root_dir: PathStr = ...,  # If context_root_dir is provided, project_root_dir shouldn't be  # noqa: E501 # FIXME CoP
+    project_root_dir: None = ...,
+    runtime_environment: dict | None = ...,
+    cloud_base_url: None = ...,
+    cloud_access_token: None = ...,
+    cloud_organization_id: None = ...,
+    cloud_mode: Literal[False] | None = ...,
+    user_agent_str: str | None = ...,
+    mode: Literal["file"] | None = ...,
+) -> FileDataContext: ...
+
+
+@overload
+def get_context(
+    project_config: DataContextConfig | Mapping | None = ...,
     context_root_dir: None = ...,
     project_root_dir: None = ...,
     runtime_environment: dict | None = ...,

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -98,8 +98,10 @@ class FileDataContext(SerializableDataContext):
         # The former corresponds to the root of the user's project while the latter
         # encapsulates any config (in the form of a great_expectations/ directory).
         project_root_dir = pathlib.Path(self._context_root_directory).parent
+        relative_context_dir = pathlib.Path(self._context_root_directory).name
         self._scaffold(
             project_root_dir=project_root_dir,
+            context_root_dir_name=relative_context_dir,
         )
 
     @override

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -144,13 +144,17 @@ class SerializableDataContext(AbstractDataContext):
     def _scaffold(
         cls,
         project_root_dir: Optional[PathStr] = None,
+        context_root_dir_name: Optional[str] = None,
     ) -> pathlib.Path:
         if not project_root_dir:
             project_root_dir = pathlib.Path.cwd()
         else:
             project_root_dir = pathlib.Path(project_root_dir)
 
-        gx_dir = project_root_dir / cls.GX_DIR
+        if context_root_dir_name is None:
+            context_root_dir_name = cls.GX_DIR
+
+        gx_dir = project_root_dir / context_root_dir_name
         gx_dir.mkdir(parents=True, exist_ok=True)
         cls._scaffold_directories(gx_dir)
 

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -266,6 +266,21 @@ def test_get_context_with_custom_context_root_dir_scaffolds_filesystem(tmp_path:
 
 
 @pytest.mark.filesystem
+def test_get_context_with_mode_and_custom_context_root_dir_scaffolds_filesystem(
+    tmp_path: pathlib.Path,
+):
+    root = tmp_path / "root"
+    context_root_dir = root.joinpath("hello_world")
+    assert not context_root_dir.exists()
+
+    context = gx.get_context(mode="file", context_root_dir=context_root_dir)
+
+    assert isinstance(context, FileDataContext)
+    assert context_root_dir.exists()
+    assert (context_root_dir / FileDataContext.GITIGNORE).read_text() == "\nuncommitted/"
+
+
+@pytest.mark.filesystem
 def test_get_context_with_context_root_dir_scaffolds_existing_gitignore(clear_env_vars, tmp_path):
     context_root_dir = tmp_path / FileDataContext.GX_DIR
     context_root_dir.mkdir()

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -253,6 +253,19 @@ def test_get_context_with_context_root_dir_scaffolds_filesystem(tmp_path: pathli
 
 
 @pytest.mark.filesystem
+def test_get_context_with_custom_context_root_dir_scaffolds_filesystem(tmp_path: pathlib.Path):
+    root = tmp_path / "root"
+    context_root_dir = root.joinpath("hello_world")
+    assert not context_root_dir.exists()
+
+    context = gx.get_context(context_root_dir=context_root_dir)
+
+    assert isinstance(context, FileDataContext)
+    assert context_root_dir.exists()
+    assert (context_root_dir / FileDataContext.GITIGNORE).read_text() == "\nuncommitted/"
+
+
+@pytest.mark.filesystem
 def test_get_context_with_context_root_dir_scaffolds_existing_gitignore(clear_env_vars, tmp_path):
     context_root_dir = tmp_path / FileDataContext.GX_DIR
     context_root_dir.mkdir()

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -281,6 +281,25 @@ def test_get_context_with_mode_and_custom_context_root_dir_scaffolds_filesystem(
 
 
 @pytest.mark.filesystem
+def test_errors_if_context_root_dir_and_project_root_dir_are_both_provided_for_file_context(
+    tmp_path: pathlib.Path,
+):
+    root = tmp_path / "root"
+    context_root_dir = root.joinpath("hello_world")
+    assert not context_root_dir.exists()
+
+    with pytest.raises(
+        TypeError,
+        match="'project_root_dir' and 'context_root_dir' are conflicting args; please only provide one",  # noqa: E501
+    ):
+        gx.get_context(  # type: ignore[call-overload]
+            mode="file",
+            context_root_dir=context_root_dir,
+            project_root_dir=context_root_dir.parent,
+        )
+
+
+@pytest.mark.filesystem
 def test_get_context_with_context_root_dir_scaffolds_existing_gitignore(clear_env_vars, tmp_path):
     context_root_dir = tmp_path / FileDataContext.GX_DIR
     context_root_dir.mkdir()


### PR DESCRIPTION
## Changes
* Updates scaffolding code to respect `context_root_dir` if provided
* Updates the signature overload for `get_context` to allow specifying `mode="file"` and `context_root_dir`
* Adds some basic tests.
Also manually double checked that it's respected on reloading context.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
