### PR TITLE
[DOCS] update schedule instructions

### DIFF
--- a/docs/docusaurus/docs/cloud/schedules/manage_schedules.md
+++ b/docs/docusaurus/docs/cloud/schedules/manage_schedules.md
@@ -31,6 +31,6 @@ To automate data quality checks for [API-managed Expectations](/cloud/expectatio
 
 3. In the Scheduling component, click **Edit schedule**.
 
-4. Pause the schedule using the **ON** / **OFF** toggle.
+4. Pause the schedule using the **ON**/**OFF** toggle.
 
 5. Click **Save**.

--- a/docs/docusaurus/docs/cloud/schedules/manage_schedules.md
+++ b/docs/docusaurus/docs/cloud/schedules/manage_schedules.md
@@ -17,7 +17,7 @@ To automate data quality checks for [API-managed Expectations](/cloud/expectatio
 
 2. In the **Data Assets** list, click the Data Asset name.
 
-3. In the Scheduling component, click the **Edit Schedule** icon.
+3. In the Scheduling component, click **Edit schedule**.
 
 4. Change the **Frequency** and/or the **Start time** for the first run of the new schedule.
 
@@ -29,4 +29,8 @@ To automate data quality checks for [API-managed Expectations](/cloud/expectatio
 
 2. In the **Data Assets** list, click the Data Asset name.
 
-3. Pause the schedule using the toggle in the Scheduling component.
+3. In the Scheduling component, click **Edit schedule**.
+
+4. Pause the schedule using the **ON** / **OFF** toggle.
+
+5. Click **Save**.


### PR DESCRIPTION
This issueless PR updates scheduling instructions to reflect the current UI. I'm not sure when the UI and the docs diverged but I first noticed the discrepancy within the last week or so. 


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
