### PR TITLE
[MAINTENANCE] Improve PostHog pageview tracking in docs

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -28,7 +28,10 @@ module.exports = {
       'posthog-docusaurus',
       {
         apiKey: config.parsed.POSTHOG_API_KEY,
-        enableInDevelopment: false
+        enableInDevelopment: false,
+        autocapture: {
+          capture_pageview: false
+        },
       }
     ]
   ],

--- a/docs/docusaurus/src/components/NavigationTracker/index.js
+++ b/docs/docusaurus/src/components/NavigationTracker/index.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from '@docusaurus/router';
+
+export default function NavigationTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.posthog) {
+      window.posthog.capture('$pageview');
+    }
+  }, [location]);
+
+  return null;
+} 

--- a/docs/docusaurus/src/theme/Root/index.js
+++ b/docs/docusaurus/src/theme/Root/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import NavigationTracker from '../../components/NavigationTracker';
+
+export default function Root({children}) {
+  return (
+    <>
+      {children}
+      <BrowserOnly>
+        {() => <NavigationTracker />}
+      </BrowserOnly>
+    </>
+  );
+} 


### PR DESCRIPTION
Disable automatic pageview capture to prevent duplicates
Add custom NavigationTracker component for SPA navigation


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
