### PR TITLE
[MAINTENANCE] Type narrowing on compute_metrics with a single metric

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -113,6 +113,7 @@ if TYPE_CHECKING:
     )
 
 _T = TypeVar("_T")
+_MetricResultT = TypeVar("_MetricResultT", bound=MetricResult)
 
 
 class PartitionerSortingProtocol(Protocol):
@@ -1256,12 +1257,14 @@ class Batch:
         )
 
     @overload
-    def compute_metrics(self, metrics: Metric) -> MetricResult: ...
+    def compute_metrics(self, metrics: Metric[_MetricResultT]) -> _MetricResultT: ...
 
     @overload
     def compute_metrics(self, metrics: list[Metric]) -> list[MetricResult]: ...
 
-    def compute_metrics(self, metrics: Metric | list[Metric]) -> MetricResult | list[MetricResult]:
+    def compute_metrics(
+        self, metrics: Metric[_MetricResultT] | list[Metric]
+    ) -> _MetricResultT | list[MetricResult]:
         """Compute one or more metrics on this Batch.
 
         Args:


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
