### PR TITLE
[MAINTENANCE] Implement ColumnValuesNotMatchRegexValues metric

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/__init__.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/__init__.py
@@ -23,3 +23,4 @@ from .column_values_between_count import ColumnValuesBetweenCount
 from .column_values_length_max import ColumnValuesLengthMax
 from .column_values_length_min import ColumnValuesLengthMin
 from .column_values_match_regex_values import ColumnValuesMatchRegexValues
+from .column_values_not_match_regex_values import ColumnValuesNotMatchRegexValues

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_not_match_regex_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_not_match_regex_values.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from great_expectations.compatibility.sqlalchemy import (
+    sqlalchemy as sa,
+)
+from great_expectations.core.metric_domain_types import MetricDomainTypes
+from great_expectations.execution_engine import SqlAlchemyExecutionEngine
+from great_expectations.expectations.metrics.column_aggregate_metric_provider import (
+    ColumnAggregateMetricProvider,
+)
+from great_expectations.expectations.metrics.metric_provider import metric_value
+from great_expectations.expectations.metrics.util import get_dialect_regex_expression
+
+logger = logging.getLogger(__name__)
+
+
+class ColumnValuesNotMatchRegexValues(ColumnAggregateMetricProvider):
+    metric_name = "column_values.not_match_regex_values"
+
+    @metric_value(engine=SqlAlchemyExecutionEngine)
+    def _sqlalchemy(  # FIXME CoP
+        cls,
+        execution_engine: SqlAlchemyExecutionEngine,
+        metric_domain_kwargs: dict,
+        metric_value_kwargs: dict,
+        metrics: dict[str, Any],
+        runtime_configuration: dict,
+    ) -> list[str]:
+        _dialect = execution_engine.dialect_module
+        assert _dialect is not None
+
+        (
+            selectable,
+            _,
+            accessor_domain_kwargs,
+        ) = execution_engine.get_compute_domain(metric_domain_kwargs, MetricDomainTypes.COLUMN)
+        column_name: str = accessor_domain_kwargs["column"]
+        column: sa.ColumnClause = sa.column(column_name)
+        regex = metric_value_kwargs["regex"]
+        limit = metric_value_kwargs["limit"]
+
+        regex_expression = get_dialect_regex_expression(column, regex, _dialect)
+        if regex_expression is None:
+            logger.warning(f"Regex is not supported for dialect {_dialect.name!s}")
+            raise NotImplementedError
+
+        # Find values that DO NOT match the regex
+        query = sa.select(column).where(sa.not_(regex_expression)).select_from(selectable)  # type: ignore[arg-type]
+        if isinstance(limit, int):
+            query = query.limit(limit)
+
+        rows = execution_engine.execute_query(query).fetchall()
+
+        return [row[0] for row in rows]

--- a/great_expectations/metrics/column/column_values_not_match_regex_values.py
+++ b/great_expectations/metrics/column/column_values_not_match_regex_values.py
@@ -1,0 +1,11 @@
+from great_expectations.metrics.column import ColumnMetric
+from great_expectations.metrics.metric_results import MetricResult
+
+
+class ColumnValuesNotMatchRegexValuesResult(MetricResult[list[str]]): ...
+
+
+class ColumnValuesNotMatchRegexValues(ColumnMetric[ColumnValuesNotMatchRegexValuesResult]):
+    name = "column_values.not_match_regex_values"
+    regex: str
+    limit: int = 20

--- a/tests/integration/metrics/column/test_column_values_not_match_regex_values.py
+++ b/tests/integration/metrics/column/test_column_values_not_match_regex_values.py
@@ -1,0 +1,76 @@
+import pandas as pd
+
+from great_expectations.datasource.fluent.interfaces import Batch
+from great_expectations.metrics.column.column_values_not_match_regex_values import (
+    ColumnValuesNotMatchRegexValues,
+    ColumnValuesNotMatchRegexValuesResult,
+)
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.metrics.conftest import SQL_DATA_SOURCES, SnowflakeDatasourceTestConfig
+
+COLUMN_NAME = "whatevs"
+BIG_NUMBER = 101
+MATCH_NONE_REGEX = "^$"  # Regex that matches nothing
+
+DATA_FRAME = pd.DataFrame({COLUMN_NAME: ["abc", "def", "ghi", "1ab2", None]})
+DATA_FRAME_WITH_LOTS_OF_VALUES = pd.DataFrame({COLUMN_NAME: ["A"] * BIG_NUMBER})
+
+SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
+    datasource
+    for datasource in SQL_DATA_SOURCES
+    if not isinstance(datasource, SnowflakeDatasourceTestConfig)
+]
+
+
+class TestColumnValuesNotMatchRegexValues:
+    @parameterize_batch_for_data_sources(
+        data_source_configs=SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE,
+        data=DATA_FRAME,
+    )
+    def test_partial_match_characters(self, batch_for_datasource: Batch) -> None:
+        metric = ColumnValuesNotMatchRegexValues(column=COLUMN_NAME, regex="ab")
+        metric_result = batch_for_datasource.compute_metrics(metric)
+
+        assert isinstance(metric_result, ColumnValuesNotMatchRegexValuesResult)
+        # Expect values that DO NOT contain 'ab'
+        assert sorted(metric_result.value) == ["def", "ghi"]
+
+    @parameterize_batch_for_data_sources(
+        data_source_configs=SQL_DATA_SOURCES,
+        data=DATA_FRAME,
+    )
+    def test_special_characters(self, batch_for_datasource: Batch) -> None:
+        metric = ColumnValuesNotMatchRegexValues(column=COLUMN_NAME, regex="^(a|d).+")
+        metric_result = batch_for_datasource.compute_metrics(metric)
+
+        assert isinstance(metric_result, ColumnValuesNotMatchRegexValuesResult)
+        # Expect values that DO NOT start with 'a' or 'd'
+        assert sorted(metric_result.value) == ["1ab2", "ghi"]
+
+    @parameterize_batch_for_data_sources(
+        data_source_configs=SQL_DATA_SOURCES,
+        data=DATA_FRAME_WITH_LOTS_OF_VALUES,
+    )
+    def test_default_limit(self, batch_for_datasource: Batch) -> None:
+        # Use a regex that matches nothing to get all values back
+        metric = ColumnValuesNotMatchRegexValues(column=COLUMN_NAME, regex=MATCH_NONE_REGEX)
+        metric_result = batch_for_datasource.compute_metrics(metric)
+
+        # Should return up to the default limit (20)
+        assert len(metric_result.value) == 20
+        assert all(val == "A" for val in metric_result.value)
+
+    @parameterize_batch_for_data_sources(
+        data_source_configs=SQL_DATA_SOURCES,
+        data=DATA_FRAME_WITH_LOTS_OF_VALUES,
+    )
+    def test_custom_limit(self, batch_for_datasource: Batch) -> None:
+        limit = 7
+        # Use a regex that matches nothing to get all values back
+        metric = ColumnValuesNotMatchRegexValues(
+            column=COLUMN_NAME, regex=MATCH_NONE_REGEX, limit=limit
+        )
+        metric_result = batch_for_datasource.compute_metrics(metric)
+
+        assert len(metric_result.value) == limit
+        assert all(val == "A" for val in metric_result.value)


### PR DESCRIPTION
Adds the `ColumnValuesNotMatchRegexValues` metric to the core metrics API. This metric retrieves a sample of column values that do not match the provided regex, complementing the existing `ColumnValuesMatchRegexValues` metric.




- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
