### PR TITLE
[MAINTENANCE] Update image-size peer dependency

### DIFF
--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -31,7 +31,6 @@
     "docusaurus-gtm-plugin": "0.0.2",
     "docusaurus-plugin-sass": "0.2.2",
     "dotenv": "^16.4.1",
-    "image-size": "1.2.1",
     "plugin-image-zoom": "ataft/plugin-image-zoom",
     "posthog-docusaurus": "^2.0.4",
     "react": "^18.2.0",

--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -31,6 +31,7 @@
     "docusaurus-gtm-plugin": "0.0.2",
     "docusaurus-plugin-sass": "0.2.2",
     "dotenv": "^16.4.1",
+    "image-size": "1.2.1",
     "plugin-image-zoom": "ataft/plugin-image-zoom",
     "posthog-docusaurus": "^2.0.4",
     "react": "^18.2.0",
@@ -70,5 +71,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "resolutions": {
+    "image-size": "1.2.1"
   }
 }

--- a/docs/docusaurus/yarn.lock
+++ b/docs/docusaurus/yarn.lock
@@ -7449,10 +7449,10 @@ ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-image-size@^1.0.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.2.0.tgz#312af27a2ff4ff58595ad00b9344dd684c910df6"
-  integrity sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==
+image-size@1.2.1, image-size@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.2.1.tgz#ee118aedfe666db1a6ee12bed5821cde3740276d"
+  integrity sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==
   dependencies:
     queue "6.0.2"
 


### PR DESCRIPTION

Upgrade image-size peer depedency to remediate [vulnerability](https://github.com/advisories/ghsa-m5qc-5hw7-8vg7).

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
