### PR TITLE
[FEATURE] Allow user to provide connection details to connect to Redshift

### DIFF
--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -1,39 +1,78 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING, Literal, Type, Union
 
-from great_expectations.compatibility import pydantic
+from great_expectations.compatibility.pydantic import AnyUrl, BaseModel, ConfigDict, root_validator, StrictInt, StrictStr
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.sql_datasource import SQLDatasource
 from great_expectations.execution_engine.redshift_execution_engine import RedshiftExecutionEngine
+
 
 if TYPE_CHECKING:
     from great_expectations.execution_engine.sqlalchemy_execution_engine import (
         SqlAlchemyExecutionEngine,
     )
 
-
-class RedshiftDsn(pydantic.AnyUrl):
+class RedshiftDsn(AnyUrl):
     allowed_schemes = {
         "redshift+psycopg2",
     }
 
+class RedshiftSSLModes(Enum):
+    DISABLE = "disable"
+    ALLOW = "allow"
+    PREFER = "prefer"
+    REQUIRE = "require"
+    VERIFY_CA = "verify-ca"
+    VERIFY_FULL = "verify-full"
+
+
+class RedshiftConnectionDetails(BaseModel):
+    """
+    Information needed to connect to a Redshift database.
+    Alternative to a connection string.
+    """
+    model_config = ConfigDict(strict=True)
+    username: StrictStr
+    password: Union[ConfigStr, StrictStr]
+    host: StrictStr
+    port: StrictInt
+    database: StrictStr
+    ssl_mode: RedshiftSSLModes
+
 
 class RedshiftDatasource(SQLDatasource):
-    """Adds a redshift datasource to the data context using psycopg2.
+    """Adds a Redshift datasource to the data context using psycopg2.
 
     Args:
-        name: The name of this redshift datasource.
-        connection_string: The SQLAlchemy connection string used to connect to the redshift
+        name: The name of this Redshift datasource.
+        connection_string: The SQLAlchemy connection string used to connect to the Redshift
             database. This will use a redshift with psycopg2. For example:
             "redshift+psycopg2://username@host.amazonaws.com:5439/database"
+        connection_details: A RedshiftConnectionDetails object defining the connection details. If connection_details
+            is used, connection_string cannot also be provided.
         assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose
             values are TableAsset or QueryAsset objects.
     """
 
     type: Literal["redshift"] = "redshift"  # type: ignore[assignment] # This is a hardcoded constant
     connection_string: Union[ConfigStr, RedshiftDsn]
+
+    @root_validator(pre=True, allow_reuse=True)
+    def _build_connection_string_from_connection_details(cls, values: dict) -> dict:
+        """
+        If connection_details is provided, use them to construct the connection_string.
+        """
+        connection_string, connection_details = values.get("connection_string"), values.get("connection_details")
+        if connection_details is not None and connection_string is not None:
+            raise ValueError("Cannot provide both connection_details and connection_string")
+        if connection_details is not None:
+            connection_string_from_details = f"redshift+psycopg2://{connection_details.username}:{connection_details.password}@{connection_details.host}:{connection_details.port}/{connection_details.database}?sslmode={connection_details.ssl_mode.value}"
+            values["connection_string"] = connection_string_from_details
+            del values["connection_details"]
+        return values
 
     @property
     @override

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -3,22 +3,30 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Type, Union
 
-from great_expectations.compatibility.pydantic import AnyUrl, BaseModel, ConfigDict, root_validator, StrictInt, StrictStr
+from great_expectations.compatibility.pydantic import (
+    AnyUrl,
+    BaseModel,
+    ConfigDict,
+    StrictInt,
+    StrictStr,
+    root_validator,
+)
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.sql_datasource import SQLDatasource
 from great_expectations.execution_engine.redshift_execution_engine import RedshiftExecutionEngine
-
 
 if TYPE_CHECKING:
     from great_expectations.execution_engine.sqlalchemy_execution_engine import (
         SqlAlchemyExecutionEngine,
     )
 
+
 class RedshiftDsn(AnyUrl):
     allowed_schemes = {
         "redshift+psycopg2",
     }
+
 
 class RedshiftSSLModes(Enum):
     DISABLE = "disable"
@@ -34,6 +42,7 @@ class RedshiftConnectionDetails(BaseModel):
     Information needed to connect to a Redshift database.
     Alternative to a connection string.
     """
+
     model_config = ConfigDict(strict=True)
     username: StrictStr
     password: Union[ConfigStr, StrictStr]
@@ -65,7 +74,10 @@ class RedshiftDatasource(SQLDatasource):
         """
         If connection_details is provided, use them to construct the connection_string.
         """
-        connection_string, connection_details = values.get("connection_string"), values.get("connection_details")
+        connection_string, connection_details = (
+            values.get("connection_string"),
+            values.get("connection_details"),
+        )
         if connection_details is not None and connection_string is not None:
             raise ValueError("Cannot provide both connection_details and connection_string")  # noqa: TRY003
         if connection_details is not None:

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -51,8 +51,8 @@ class RedshiftDatasource(SQLDatasource):
         connection_string: The SQLAlchemy connection string used to connect to the Redshift
             database. This will use a redshift with psycopg2. For example:
             "redshift+psycopg2://username@host.amazonaws.com:5439/database"
-        connection_details: A RedshiftConnectionDetails object defining the connection details. If connection_details
-            is used, connection_string cannot also be provided.
+        connection_details: A RedshiftConnectionDetails object defining the connection details.
+        If connection_details is used, connection_string cannot also be provided.
         assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose
             values are TableAsset or QueryAsset objects.
     """
@@ -67,7 +67,7 @@ class RedshiftDatasource(SQLDatasource):
         """
         connection_string, connection_details = values.get("connection_string"), values.get("connection_details")
         if connection_details is not None and connection_string is not None:
-            raise ValueError("Cannot provide both connection_details and connection_string")
+            raise ValueError("Cannot provide both connection_details and connection_string")  # noqa: TRY003
         if connection_details is not None:
             connection_string_from_details = f"redshift+psycopg2://{connection_details.username}:{connection_details.password}@{connection_details.host}:{connection_details.port}/{connection_details.database}?sslmode={connection_details.ssl_mode.value}"
             values["connection_string"] = connection_string_from_details

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Literal, Type, Union
 from great_expectations.compatibility.pydantic import (
     AnyUrl,
     BaseModel,
-    ConfigDict,
     StrictInt,
     StrictStr,
     root_validator,

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -43,7 +43,6 @@ class RedshiftConnectionDetails(BaseModel):
     Alternative to a connection string.
     """
 
-    model_config = ConfigDict(strict=True)
     username: StrictStr
     password: Union[ConfigStr, StrictStr]
     host: StrictStr

--- a/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "RedshiftDatasource",
-    "description": "Adds a redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the redshift\n        database. This will use a redshift with psycopg2. For example:\n        \"redshift+psycopg2://username@host.amazonaws.com:5439/database\"\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
+    "description": "Adds a Redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this Redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the Redshift\n        database. This will use a redshift with psycopg2. For example:\n        \"redshift+psycopg2://username@host.amazonaws.com:5439/database\"\n    connection_details: A RedshiftConnectionDetails object defining the connection details.\n    If connection_details is used, connection_string cannot also be provided.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
     "type": "object",
     "properties": {
         "type": {

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -4,9 +4,13 @@ import pytest
 from pytest_mock import MockerFixture
 
 from great_expectations.data_context import EphemeralDataContext
-from great_expectations.datasource.fluent.redshift_datasource import RedshiftDsn, RedshiftConnectionDetails
+from great_expectations.datasource.fluent.redshift_datasource import (
+    RedshiftConnectionDetails,
+    RedshiftDsn,
+)
 
 LOGGER = logging.getLogger(__name__)
+
 
 def build_connection_string(scheme, username, password, host, port, database, ssl_mode):
     return f"{scheme}://{username}:{password}@{host}:{port}/{database}?sslmode={ssl_mode}"
@@ -27,13 +31,15 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
 ):
     create_engine_spy = mocker.patch.object(sa, "create_engine")
 
-    username="username"
-    password="password"
-    host="host"
-    port=1234
-    database="database"
-    ssl_mode="allow"
-    connection_string = build_connection_string(scheme, username, password, host, port, database, ssl_mode)
+    username = "username"
+    password = "password"
+    host = "host"
+    port = 1234
+    database = "database"
+    ssl_mode = "allow"
+    connection_string = build_connection_string(
+        scheme, username, password, host, port, database, ssl_mode
+    )
 
     expected_kwargs = RedshiftDsn(
         connection_string,
@@ -41,16 +47,15 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
         user=username,
         password=password,
         host=host,
-        host_type='int_domain',
+        host_type="int_domain",
         port=port,
         path=f"/{database}",
-        query=f"sslmode={ssl_mode}"
+        query=f"sslmode={ssl_mode}",
     )
 
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
-        name="redshift_test",
-        connection_string=connection_string
+        name="redshift_test", connection_string=connection_string
     )
     data_source.get_engine()
 
@@ -67,13 +72,15 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
 ):
     create_engine_spy = mocker.patch.object(sa, "create_engine")
 
-    username="username"
-    password="password"
-    host="host"
-    port=1234
-    database="database"
-    ssl_mode="allow"
-    connection_string = build_connection_string(scheme, username, password, host, port, database, ssl_mode)
+    username = "username"
+    password = "password"
+    host = "host"
+    port = 1234
+    database = "database"
+    ssl_mode = "allow"
+    connection_string = build_connection_string(
+        scheme, username, password, host, port, database, ssl_mode
+    )
 
     connection_details = RedshiftConnectionDetails(
         username=username,
@@ -89,15 +96,14 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
         user=username,
         password=password,
         host=host,
-        host_type='int_domain',
+        host_type="int_domain",
         port=port,
         path=f"/{database}",
-        query=f"sslmode={ssl_mode}"
+        query=f"sslmode={ssl_mode}",
     )
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
-        name="redshift_test",
-        connection_details=connection_details
+        name="redshift_test", connection_details=connection_details
     )
     data_source.get_engine()
     create_engine_spy.assert_called_once_with(expected_kwargs)
@@ -110,12 +116,12 @@ def test_value_error_raised_if_invalid_connection_detail_inputs(
     ephemeral_context_with_defaults: EphemeralDataContext,
     scheme,
 ):
-    username="username"
-    password="password"
-    host="host"
-    port=1234
-    database="database"
-    ssl_mode="INVALID"
+    username = "username"
+    password = "password"
+    host = "host"
+    port = 1234
+    database = "database"
+    ssl_mode = "INVALID"
 
     with pytest.raises(ValueError):
         RedshiftConnectionDetails(

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -56,7 +56,8 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
 
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
-        name="redshift_test", connection_string=connection_string
+        name="redshift_test",
+        connection_string=connection_string
     )
     data_source.get_engine()
 
@@ -80,7 +81,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
     database = "database"
     ssl_mode = RedshiftSSLModes.ALLOW
     connection_string = build_connection_string(
-        scheme, username, password, host, port, database, ssl_mode
+        scheme, username, password, host, port, database, ssl_mode.value
     )
 
     connection_details = RedshiftConnectionDetails(
@@ -100,11 +101,12 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
         host_type="int_domain",
         port=port,
         path=f"/{database}",
-        query=f"sslmode={ssl_mode}",
+        query=f"sslmode={ssl_mode.value}",
     )
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
-        name="redshift_test", connection_details=connection_details
+        name="redshift_test",
+        connection_details=connection_details  # type: ignore[call-arg]
     )
     data_source.get_engine()
     create_engine_spy.assert_called_once_with(expected_kwargs)
@@ -131,5 +133,5 @@ def test_value_error_raised_if_invalid_connection_detail_inputs(
             host=host,
             port=port,
             database=database,
-            ssl_mode=ssl_mode,
+            ssl_mode=ssl_mode,  # type: ignore[arg-type] # Ignore this for purpose of the test
         )

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -1,0 +1,128 @@
+import logging
+
+import pytest
+from pytest_mock import MockerFixture
+
+from great_expectations.data_context import EphemeralDataContext
+from great_expectations.datasource.fluent.redshift_datasource import RedshiftDsn, RedshiftConnectionDetails
+
+LOGGER = logging.getLogger(__name__)
+
+def build_connection_string(scheme, username, password, host, port, database, ssl_mode):
+    return f"{scheme}://{username}:{password}@{host}:{port}/{database}?sslmode={ssl_mode}"
+
+
+@pytest.fixture
+def scheme():
+    return "redshift+psycopg2"
+
+
+@pytest.mark.unit
+@pytest.mark.redshift
+def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
+    sa,
+    mocker: MockerFixture,
+    ephemeral_context_with_defaults: EphemeralDataContext,
+    scheme,
+):
+    create_engine_spy = mocker.patch.object(sa, "create_engine")
+
+    username="username"
+    password="password"
+    host="host"
+    port=1234
+    database="database"
+    ssl_mode="allow"
+    connection_string = build_connection_string(scheme, username, password, host, port, database, ssl_mode)
+
+    expected_kwargs = RedshiftDsn(
+        connection_string,
+        scheme=scheme,
+        user=username,
+        password=password,
+        host=host,
+        host_type='int_domain',
+        port=port,
+        path=f"/{database}",
+        query=f"sslmode={ssl_mode}"
+    )
+
+    context = ephemeral_context_with_defaults
+    data_source = context.data_sources.add_redshift(
+        name="redshift_test",
+        connection_string=connection_string
+    )
+    data_source.get_engine()
+
+    create_engine_spy.assert_called_once_with(expected_kwargs)
+
+
+@pytest.mark.unit
+@pytest.mark.redshift
+def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
+    sa,
+    mocker: MockerFixture,
+    ephemeral_context_with_defaults: EphemeralDataContext,
+    scheme,
+):
+    create_engine_spy = mocker.patch.object(sa, "create_engine")
+
+    username="username"
+    password="password"
+    host="host"
+    port=1234
+    database="database"
+    ssl_mode="allow"
+    connection_string = build_connection_string(scheme, username, password, host, port, database, ssl_mode)
+
+    connection_details = RedshiftConnectionDetails(
+        username=username,
+        password=password,
+        host=host,
+        port=port,
+        database=database,
+        ssl_mode=ssl_mode,
+    )
+    expected_kwargs = RedshiftDsn(
+        connection_string,
+        scheme=scheme,
+        user=username,
+        password=password,
+        host=host,
+        host_type='int_domain',
+        port=port,
+        path=f"/{database}",
+        query=f"sslmode={ssl_mode}"
+    )
+    context = ephemeral_context_with_defaults
+    data_source = context.data_sources.add_redshift(
+        name="redshift_test",
+        connection_details=connection_details
+    )
+    data_source.get_engine()
+    create_engine_spy.assert_called_once_with(expected_kwargs)
+
+
+@pytest.mark.unit
+@pytest.mark.redshift
+def test_value_error_raised_if_invalid_connection_detail_inputs(
+    sa,
+    ephemeral_context_with_defaults: EphemeralDataContext,
+    scheme,
+):
+    username="username"
+    password="password"
+    host="host"
+    port=1234
+    database="database"
+    ssl_mode="INVALID"
+
+    with pytest.raises(ValueError):
+        RedshiftConnectionDetails(
+            username=username,
+            password=password,
+            host=host,
+            port=port,
+            database=database,
+            ssl_mode=ssl_mode,
+        )

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -56,8 +56,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
 
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
-        name="redshift_test",
-        connection_string=connection_string
+        name="redshift_test", connection_string=connection_string
     )
     data_source.get_engine()
 
@@ -106,7 +105,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
         name="redshift_test",
-        connection_details=connection_details  # type: ignore[call-arg]
+        connection_details=connection_details,  # type: ignore[call-arg]
     )
     data_source.get_engine()
     create_engine_spy.assert_called_once_with(expected_kwargs)

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -45,7 +45,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
     data_source = context.data_sources.add_redshift(
         name="redshift_test", connection_string=connection_string
     )
-    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine  # noqa: E501
+    data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 
     expected_kwargs = RedshiftDsn(
         connection_string,
@@ -84,7 +84,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
         name="redshift_test",
         connection_details=connection_details,  # type: ignore[call-arg]
     )
-    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine  # noqa: E501
+    data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 
     connection_string = build_connection_string(
         scheme, username, password, host, port, database, ssl_mode.value

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -37,27 +37,20 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
     port = 1234
     database = "database"
     ssl_mode = "allow"
+
+    context = ephemeral_context_with_defaults
     connection_string = build_connection_string(
         scheme, username, password, host, port, database, ssl_mode
     )
+    data_source = context.data_sources.add_redshift(
+        name="redshift_test", connection_string=connection_string
+    )
+    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine
 
     expected_kwargs = RedshiftDsn(
         connection_string,
         scheme=scheme,
-        user=username,
-        password=password,
-        host=host,
-        host_type="int_domain",
-        port=port,
-        path=f"/{database}",
-        query=f"sslmode={ssl_mode}",
     )
-
-    context = ephemeral_context_with_defaults
-    data_source = context.data_sources.add_redshift(
-        name="redshift_test", connection_string=connection_string
-    )
-    data_source.get_engine()
 
     create_engine_spy.assert_called_once_with(expected_kwargs)
 
@@ -77,10 +70,6 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
     port = 1234
     database = "database"
     ssl_mode = RedshiftSSLModes.ALLOW
-    connection_string = build_connection_string(
-        scheme, username, password, host, port, database, ssl_mode.value
-    )
-
     connection_details = RedshiftConnectionDetails(
         username=username,
         password=password,
@@ -89,23 +78,22 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
         database=database,
         ssl_mode=ssl_mode,
     )
-    expected_kwargs = RedshiftDsn(
-        connection_string,
-        scheme=scheme,
-        user=username,
-        password=password,
-        host=host,
-        host_type="int_domain",
-        port=port,
-        path=f"/{database}",
-        query=f"sslmode={ssl_mode.value}",
-    )
+
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
         name="redshift_test",
         connection_details=connection_details,  # type: ignore[call-arg]
     )
-    data_source.get_engine()
+    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine
+
+    connection_string = build_connection_string(
+        scheme, username, password, host, port, database, ssl_mode.value
+    )
+    expected_kwargs = RedshiftDsn(
+        connection_string,
+        scheme=scheme,
+    )
+
     create_engine_spy.assert_called_once_with(expected_kwargs)
 
 

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -23,7 +23,6 @@ def scheme():
 
 
 @pytest.mark.unit
-@pytest.mark.redshift
 def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
     sa,
     mocker: MockerFixture,
@@ -64,7 +63,6 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
 
 
 @pytest.mark.unit
-@pytest.mark.redshift
 def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
     sa,
     mocker: MockerFixture,
@@ -112,7 +110,6 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
 
 
 @pytest.mark.unit
-@pytest.mark.redshift
 def test_value_error_raised_if_invalid_connection_detail_inputs(
     sa,
     ephemeral_context_with_defaults: EphemeralDataContext,

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -7,6 +7,7 @@ from great_expectations.data_context import EphemeralDataContext
 from great_expectations.datasource.fluent.redshift_datasource import (
     RedshiftConnectionDetails,
     RedshiftDsn,
+    RedshiftSSLModes,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
     host = "host"
     port = 1234
     database = "database"
-    ssl_mode = "allow"
+    ssl_mode = RedshiftSSLModes.ALLOW
     connection_string = build_connection_string(
         scheme, username, password, host, port, database, ssl_mode
     )

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -45,7 +45,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
     data_source = context.data_sources.add_redshift(
         name="redshift_test", connection_string=connection_string
     )
-    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine
+    data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine
 
     expected_kwargs = RedshiftDsn(
         connection_string,
@@ -84,7 +84,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
         name="redshift_test",
         connection_details=connection_details,  # type: ignore[call-arg]
     )
-    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine
+    data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine
 
     connection_string = build_connection_string(
         scheme, username, password, host, port, database, ssl_mode.value

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -45,7 +45,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
     data_source = context.data_sources.add_redshift(
         name="redshift_test", connection_string=connection_string
     )
-    data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine
+    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 
     expected_kwargs = RedshiftDsn(
         connection_string,
@@ -84,7 +84,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
         name="redshift_test",
         connection_details=connection_details,  # type: ignore[call-arg]
     )
-    data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine
+    data_source.get_engine() # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 
     connection_string = build_connection_string(
         scheme, username, password, host, port, database, ssl_mode.value


### PR DESCRIPTION
In addition to a `connection_string`, we want to allow users to connect to Redshift by providing `connection_details`. 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
