### PR TITLE
[FEATURE] Changes to Redshift `connection_string` validator to support a dict type

### DIFF
--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -84,7 +84,6 @@ class RedshiftDatasource(SQLDatasource):
         connection_string = f"redshift+psycopg2://{connection_details.user}:{connection_details.password}@{connection_details.host}:{connection_details.port}/{connection_details.database}?sslmode={connection_details.sslmode.value}"
         return connection_string
 
-
     @property
     @override
     def execution_engine_type(self) -> Type[SqlAlchemyExecutionEngine]:

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Type, Union
 
-from pydantic.v1 import validator
-
 from great_expectations.compatibility.pydantic import (
     AnyUrl,
     BaseModel,
+    validator,
 )
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.config_str import ConfigStr

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -56,8 +56,8 @@ class RedshiftDatasource(SQLDatasource):
         name: The name of this Redshift datasource.
         connection_string: The SQLAlchemy connection string used to connect to the Redshift
             database. This will use a redshift with psycopg2. For example:
-            "redshift+psycopg2://usern@host.amazonaws.com:5439/database". Alternatively,
-             a RedshiftConnectionDetails object can be used.
+            "redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode".
+            Alternatively, a RedshiftConnectionDetails object can be used.
         If connection_details is used, connection_string cannot also be provided.
         assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose
             values are TableAsset or QueryAsset objects.

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -37,7 +37,6 @@ class RedshiftSSLModes(Enum):
 class RedshiftConnectionDetails(BaseModel):
     """
     Information needed to connect to a Redshift database.
-    Alternative to a connection string.
     """
 
     user: str
@@ -53,9 +52,8 @@ class RedshiftDatasource(SQLDatasource):
 
     Args:
         name: The name of this Redshift datasource.
-        connection_string: The SQLAlchemy connection string used to connect to the Redshift
-            database. This will use a redshift with psycopg2. For example:
-            "redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode".
+        connection_string: The SQLAlchemy connection string used to connect to the Redshift database.
+            For example: "redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode".
             Alternatively, a RedshiftConnectionDetails object can be used.
         If connection_details is used, connection_string cannot also be provided.
         assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose
@@ -63,14 +61,14 @@ class RedshiftDatasource(SQLDatasource):
     """
 
     type: Literal["redshift"] = "redshift"  # type: ignore[assignment] # This is a hardcoded constant
-    connection_string: Union[RedshiftConnectionDetails, ConfigStr, RedshiftDsn]  # type: ignore[assignment] # Deviation from parent class as individual args are supported for connection
+    connection_string: Union[ConfigStr, dict, RedshiftConnectionDetails, RedshiftDsn]
 
     @validator("connection_string", pre=True)
     def _build_connection_string_from_connection_details(
-        cls, connection_string: str | dict | RedshiftConnectionDetails
+        cls, connection_string: dict | RedshiftConnectionDetails | str
     ) -> str:
         """
-        If dict of connection details is provided, construct the connection_string.
+        If dict or RedshiftConnectionDetails object is provided, construct the formatted connection string.
         """
         if isinstance(connection_string, str):
             return connection_string

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -63,7 +63,7 @@ class RedshiftDatasource(SQLDatasource):
     """
 
     type: Literal["redshift"] = "redshift"  # type: ignore[assignment] # This is a hardcoded constant
-    connection_string: Union[RedshiftConnectionDetails, ConfigStr, RedshiftDsn]
+    connection_string: Union[RedshiftConnectionDetails, ConfigStr, RedshiftDsn]  # type: ignore[assignment] # Deviation from parent class as individual args are supported for connection
 
     @validator("connection_string", pre=True)
     def _build_connection_string_from_connection_details(
@@ -77,10 +77,13 @@ class RedshiftDatasource(SQLDatasource):
 
         if isinstance(connection_string, dict):
             connection_details = RedshiftConnectionDetails(**connection_string)
-        if isinstance(connection_string, RedshiftConnectionDetails):
+        elif isinstance(connection_string, RedshiftConnectionDetails):
             connection_details = connection_string
+        else:
+            raise ValueError("Invalid connection_string type: ", type(connection_string))
         connection_string = f"redshift+psycopg2://{connection_details.user}:{connection_details.password}@{connection_details.host}:{connection_details.port}/{connection_details.database}?sslmode={connection_details.sslmode.value}"
         return connection_string
+
 
     @property
     @override

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -80,7 +80,7 @@ class RedshiftDatasource(SQLDatasource):
         elif isinstance(connection_string, RedshiftConnectionDetails):
             connection_details = connection_string
         else:
-            raise ValueError("Invalid connection_string type: ", type(connection_string))
+            raise TypeError("Invalid connection_string type: ", type(connection_string))  # noqa: TRY003
         connection_string = f"redshift+psycopg2://{connection_details.user}:{connection_details.password}@{connection_details.host}:{connection_details.port}/{connection_details.database}?sslmode={connection_details.sslmode.value}"
         return connection_string
 

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -67,7 +67,9 @@ class RedshiftDatasource(SQLDatasource):
     connection_string: Union[RedshiftConnectionDetails, ConfigStr, RedshiftDsn]
 
     @validator("connection_string", pre=True)
-    def _build_connection_string_from_connection_details(cls, connection_string: str | dict | RedshiftConnectionDetails) -> str:
+    def _build_connection_string_from_connection_details(
+        cls, connection_string: str | dict | RedshiftConnectionDetails
+    ) -> str:
         """
         If dict of connection details is provided, construct the connection_string.
         """

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Type, Union
 
+from pydantic.v1 import validator
+
 from great_expectations.compatibility.pydantic import (
     AnyUrl,
     BaseModel,
-    StrictInt,
-    StrictStr,
-    root_validator,
 )
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.config_str import ConfigStr
@@ -42,12 +41,12 @@ class RedshiftConnectionDetails(BaseModel):
     Alternative to a connection string.
     """
 
-    username: StrictStr
-    password: Union[ConfigStr, StrictStr]
-    host: StrictStr
-    port: StrictInt
-    database: StrictStr
-    ssl_mode: RedshiftSSLModes
+    user: str
+    password: Union[ConfigStr, str]
+    host: str
+    port: int
+    database: str
+    sslmode: RedshiftSSLModes
 
 
 class RedshiftDatasource(SQLDatasource):
@@ -57,32 +56,30 @@ class RedshiftDatasource(SQLDatasource):
         name: The name of this Redshift datasource.
         connection_string: The SQLAlchemy connection string used to connect to the Redshift
             database. This will use a redshift with psycopg2. For example:
-            "redshift+psycopg2://username@host.amazonaws.com:5439/database"
-        connection_details: A RedshiftConnectionDetails object defining the connection details.
+            "redshift+psycopg2://usern@host.amazonaws.com:5439/database". Alternatively,
+             a RedshiftConnectionDetails object can be used.
         If connection_details is used, connection_string cannot also be provided.
         assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose
             values are TableAsset or QueryAsset objects.
     """
 
     type: Literal["redshift"] = "redshift"  # type: ignore[assignment] # This is a hardcoded constant
-    connection_string: Union[ConfigStr, RedshiftDsn]
+    connection_string: Union[RedshiftConnectionDetails, ConfigStr, RedshiftDsn]
 
-    @root_validator(pre=True, allow_reuse=True)
-    def _build_connection_string_from_connection_details(cls, values: dict) -> dict:
+    @validator("connection_string", pre=True)
+    def _build_connection_string_from_connection_details(cls, connection_string: str | dict | RedshiftConnectionDetails) -> str:
         """
-        If connection_details is provided, use them to construct the connection_string.
+        If dict of connection details is provided, construct the connection_string.
         """
-        connection_string, connection_details = (
-            values.get("connection_string"),
-            values.get("connection_details"),
-        )
-        if connection_details is not None and connection_string is not None:
-            raise ValueError("Cannot provide both connection_details and connection_string")  # noqa: TRY003
-        if connection_details is not None:
-            connection_string_from_details = f"redshift+psycopg2://{connection_details.username}:{connection_details.password}@{connection_details.host}:{connection_details.port}/{connection_details.database}?sslmode={connection_details.ssl_mode.value}"
-            values["connection_string"] = connection_string_from_details
-            del values["connection_details"]
-        return values
+        if isinstance(connection_string, str):
+            return connection_string
+
+        if isinstance(connection_string, dict):
+            connection_details = RedshiftConnectionDetails(**connection_string)
+        if isinstance(connection_string, RedshiftConnectionDetails):
+            connection_details = connection_string
+        connection_string = f"redshift+psycopg2://{connection_details.user}:{connection_details.password}@{connection_details.host}:{connection_details.port}/{connection_details.database}?sslmode={connection_details.sslmode.value}"
+        return connection_string
 
     @property
     @override

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -52,9 +52,9 @@ class RedshiftDatasource(SQLDatasource):
 
     Args:
         name: The name of this Redshift datasource.
-        connection_string: The SQLAlchemy connection string used to connect to the Redshift database.
-            For example: "redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode".
-            Alternatively, a RedshiftConnectionDetails object can be used.
+        connection_string: The SQLAlchemy connection string used to connect to the Redshift database
+            For example:
+            "redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode".
         If connection_details is used, connection_string cannot also be provided.
         assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose
             values are TableAsset or QueryAsset objects.
@@ -68,7 +68,8 @@ class RedshiftDatasource(SQLDatasource):
         cls, connection_string: dict | RedshiftConnectionDetails | str
     ) -> str:
         """
-        If dict or RedshiftConnectionDetails object is provided, construct the formatted connection string.
+        If a dict or RedshiftConnectionDetails object is provided, construct the formatted
+        connection string.
         """
         if isinstance(connection_string, str):
             return connection_string

--- a/great_expectations/datasource/fluent/redshift_datasource.py
+++ b/great_expectations/datasource/fluent/redshift_datasource.py
@@ -61,7 +61,7 @@ class RedshiftDatasource(SQLDatasource):
     """
 
     type: Literal["redshift"] = "redshift"  # type: ignore[assignment] # This is a hardcoded constant
-    connection_string: Union[ConfigStr, dict, RedshiftConnectionDetails, RedshiftDsn]
+    connection_string: Union[ConfigStr, dict, RedshiftConnectionDetails, RedshiftDsn]  # type: ignore[assignment] # Deviation from parent class as individual args are supported for connection
 
     @validator("connection_string", pre=True)
     def _build_connection_string_from_connection_details(

--- a/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "RedshiftDatasource",
-    "description": "Adds a Redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this Redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the Redshift\n        database. This will use a redshift with psycopg2. For example:\n        \"redshift+psycopg2://username@host.amazonaws.com:5439/database\"\n    connection_details: A RedshiftConnectionDetails object defining the connection details.\n    If connection_details is used, connection_string cannot also be provided.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
+    "description": "Adds a Redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this Redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the Redshift\n        database. This will use a redshift with psycopg2. For example:\n        \"redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode\".\n        Alternatively, a RedshiftConnectionDetails object can be used.\n    If connection_details is used, connection_string cannot also be provided.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
     "type": "object",
     "properties": {
         "type": {
@@ -46,6 +46,9 @@
         "connection_string": {
             "title": "Connection String",
             "anyOf": [
+                {
+                    "$ref": "#/definitions/RedshiftConnectionDetails"
+                },
                 {
                     "type": "string",
                     "writeOnly": true,
@@ -535,6 +538,71 @@
                 "query"
             ],
             "additionalProperties": false
+        },
+        "RedshiftSSLModes": {
+            "title": "RedshiftSSLModes",
+            "description": "An enumeration.",
+            "enum": [
+                "disable",
+                "allow",
+                "prefer",
+                "require",
+                "verify-ca",
+                "verify-full"
+            ]
+        },
+        "RedshiftConnectionDetails": {
+            "title": "RedshiftConnectionDetails",
+            "description": "Information needed to connect to a Redshift database.\nAlternative to a connection string.",
+            "type": "object",
+            "properties": {
+                "user": {
+                    "title": "User",
+                    "type": "string"
+                },
+                "password": {
+                    "title": "Password",
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "writeOnly": true,
+                            "format": "password",
+                            "description": "Contains config templates to be substituted at runtime. Runtime values will never be serialized.",
+                            "pattern": ".*(?<!\\\\)\\$\\{(.*?)\\}|(?<!\\\\)\\$([_a-zA-Z][_a-zA-Z0-9]*).*",
+                            "examples": [
+                                "hello_${NAME}",
+                                "${MY_CFG_VAR}"
+                            ]
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "host": {
+                    "title": "Host",
+                    "type": "string"
+                },
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
+                },
+                "database": {
+                    "title": "Database",
+                    "type": "string"
+                },
+                "sslmode": {
+                    "$ref": "#/definitions/RedshiftSSLModes"
+                }
+            },
+            "required": [
+                "user",
+                "password",
+                "host",
+                "port",
+                "database",
+                "sslmode"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "RedshiftDatasource",
-    "description": "Adds a Redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this Redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the Redshift\n        database. This will use a redshift with psycopg2. For example:\n        \"redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode\".\n        Alternatively, a RedshiftConnectionDetails object can be used.\n    If connection_details is used, connection_string cannot also be provided.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
+    "description": "Adds a Redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this Redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the Redshift database.\n        For example: \"redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode\".\n        Alternatively, a RedshiftConnectionDetails object can be used.\n    If connection_details is used, connection_string cannot also be provided.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
     "type": "object",
     "properties": {
         "type": {
@@ -47,9 +47,6 @@
             "title": "Connection String",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/RedshiftConnectionDetails"
-                },
-                {
                     "type": "string",
                     "writeOnly": true,
                     "format": "password",
@@ -59,6 +56,12 @@
                         "hello_${NAME}",
                         "${MY_CFG_VAR}"
                     ]
+                },
+                {
+                    "type": "object"
+                },
+                {
+                    "$ref": "#/definitions/RedshiftConnectionDetails"
                 },
                 {
                     "type": "string",
@@ -553,7 +556,7 @@
         },
         "RedshiftConnectionDetails": {
             "title": "RedshiftConnectionDetails",
-            "description": "Information needed to connect to a Redshift database.\nAlternative to a connection string.",
+            "description": "Information needed to connect to a Redshift database.",
             "type": "object",
             "properties": {
                 "user": {

--- a/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/RedshiftDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "RedshiftDatasource",
-    "description": "Adds a Redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this Redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the Redshift database.\n        For example: \"redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode\".\n        Alternatively, a RedshiftConnectionDetails object can be used.\n    If connection_details is used, connection_string cannot also be provided.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
+    "description": "Adds a Redshift datasource to the data context using psycopg2.\n\nArgs:\n    name: The name of this Redshift datasource.\n    connection_string: The SQLAlchemy connection string used to connect to the Redshift database\n        For example:\n        \"redshift+psycopg2://user:password@host.amazonaws.com:5439/database?sslmode=sslmode\".\n    If connection_details is used, connection_string cannot also be provided.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
     "type": "object",
     "properties": {
         "type": {

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -66,7 +66,7 @@ def test_create_engine_is_called_with_expected_kwargs(
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
         name="redshift_test",
-        connection_string=connection_input,  # type: ignore[arg-type]
+        connection_string=connection_input,
     )
     data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -82,7 +82,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string_ob
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
         name="redshift_test",
-        connection_string=connection_details,  # type: ignore[call-arg]
+        connection_string=connection_details,  # type: ignore[arg-type]
     )
     data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -13,84 +13,65 @@ from great_expectations.datasource.fluent.redshift_datasource import (
 LOGGER = logging.getLogger(__name__)
 
 
-def build_connection_string(scheme, user, password, host, port, database, sslmode):
-    return f"{scheme}://{user}:{password}@{host}:{port}/{database}?sslmode={sslmode}"
-
-
 @pytest.fixture
 def scheme():
     return "redshift+psycopg2"
 
 
 @pytest.mark.unit
-def test_create_engine_is_called_with_expected_kwargs_using_connection_string_string_type(
+@pytest.mark.parametrize(
+    "connection_input,expected_connection_string",
+    [
+        pytest.param(
+        "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
+            "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
+            id="string type"
+        ),
+        pytest.param(
+    {
+                "user": "user",
+                "password": "password",
+                "host": "host",
+                "port": 1234,
+                "database": "database",
+                "sslmode": RedshiftSSLModes.ALLOW
+            },
+            "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
+            id="dict type"
+        ),
+        pytest.param(
+    RedshiftConnectionDetails(
+                user="user",
+                password="password",
+                host="host",
+                port=1234,
+                database="database",
+                sslmode=RedshiftSSLModes.ALLOW
+            ),
+            "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
+            id="dict type"
+        ),
+    ],
+)
+def test_create_engine_is_called_with_expected_kwargs(
+    connection_input,
+    expected_connection_string,
     sa,
     mocker: MockerFixture,
     ephemeral_context_with_defaults: EphemeralDataContext,
     scheme,
 ):
     create_engine_spy = mocker.patch.object(sa, "create_engine")
-
-    user = "user"
-    password = "password"
-    host = "host"
-    port = 1234
-    database = "database"
-    sslmode = "allow"
-
-    context = ephemeral_context_with_defaults
-    connection_string = build_connection_string(
-        scheme, user, password, host, port, database, sslmode
-    )
-    data_source = context.data_sources.add_redshift(
-        name="redshift_test", connection_string=connection_string
-    )
-    data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine  # noqa: E501
-
-    expected_kwargs = RedshiftDsn(
-        connection_string,
-        scheme=scheme,
-    )
-
-    create_engine_spy.assert_called_once_with(expected_kwargs)
-
-
-@pytest.mark.unit
-def test_create_engine_is_called_with_expected_kwargs_using_connection_string_object_type(
-    sa,
-    mocker: MockerFixture,
-    ephemeral_context_with_defaults: EphemeralDataContext,
-    scheme,
-):
-    create_engine_spy = mocker.patch.object(sa, "create_engine")
-
-    user = "user"
-    password = "password"
-    host = "host"
-    port = 1234
-    database = "database"
-    sslmode = RedshiftSSLModes.ALLOW
-    connection_details = RedshiftConnectionDetails(
-        user=user,
-        password=password,
-        host=host,
-        port=port,
-        database=database,
-        sslmode=sslmode,
-    )
 
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
         name="redshift_test",
-        connection_string=connection_details,  # type: ignore[arg-type]
+        connection_string=connection_input,  # type: ignore[arg-type]
     )
     data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 
-    connection_string = build_connection_string(
-        scheme, user, password, host, port, database, sslmode.value
-    )
     expected_kwargs = RedshiftDsn(
-        connection_string,
+        expected_connection_string,
         scheme=scheme,
     )
 

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -23,33 +23,33 @@ def scheme():
     "connection_input,expected_connection_string",
     [
         pytest.param(
-        "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
             "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
-            id="string type"
+            "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
+            id="string type",
         ),
         pytest.param(
-    {
+            {
                 "user": "user",
                 "password": "password",
                 "host": "host",
                 "port": 1234,
                 "database": "database",
-                "sslmode": RedshiftSSLModes.ALLOW
+                "sslmode": RedshiftSSLModes.ALLOW,
             },
             "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
-            id="dict type"
+            id="dict type",
         ),
         pytest.param(
-    RedshiftConnectionDetails(
+            RedshiftConnectionDetails(
                 user="user",
                 password="password",
                 host="host",
                 port=1234,
                 database="database",
-                sslmode=RedshiftSSLModes.ALLOW
+                sslmode=RedshiftSSLModes.ALLOW,
             ),
             "redshift+psycopg2://user:password@host:1234/database?sslmode=allow",
-            id="dict type"
+            id="dict type",
         ),
     ],
 )

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -13,8 +13,8 @@ from great_expectations.datasource.fluent.redshift_datasource import (
 LOGGER = logging.getLogger(__name__)
 
 
-def build_connection_string(scheme, username, password, host, port, database, ssl_mode):
-    return f"{scheme}://{username}:{password}@{host}:{port}/{database}?sslmode={ssl_mode}"
+def build_connection_string(scheme, user, password, host, port, database, sslmode):
+    return f"{scheme}://{user}:{password}@{host}:{port}/{database}?sslmode={sslmode}"
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def scheme():
 
 
 @pytest.mark.unit
-def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
+def test_create_engine_is_called_with_expected_kwargs_using_connection_string_string_type(
     sa,
     mocker: MockerFixture,
     ephemeral_context_with_defaults: EphemeralDataContext,
@@ -31,16 +31,16 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
 ):
     create_engine_spy = mocker.patch.object(sa, "create_engine")
 
-    username = "username"
+    user = "user"
     password = "password"
     host = "host"
     port = 1234
     database = "database"
-    ssl_mode = "allow"
+    sslmode = "allow"
 
     context = ephemeral_context_with_defaults
     connection_string = build_connection_string(
-        scheme, username, password, host, port, database, ssl_mode
+        scheme, user, password, host, port, database, sslmode
     )
     data_source = context.data_sources.add_redshift(
         name="redshift_test", connection_string=connection_string
@@ -56,7 +56,7 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_string(
 
 
 @pytest.mark.unit
-def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
+def test_create_engine_is_called_with_expected_kwargs_using_connection_string_object_type(
     sa,
     mocker: MockerFixture,
     ephemeral_context_with_defaults: EphemeralDataContext,
@@ -64,30 +64,30 @@ def test_create_engine_is_called_with_expected_kwargs_using_connection_details(
 ):
     create_engine_spy = mocker.patch.object(sa, "create_engine")
 
-    username = "username"
+    user = "user"
     password = "password"
     host = "host"
     port = 1234
     database = "database"
-    ssl_mode = RedshiftSSLModes.ALLOW
+    sslmode = RedshiftSSLModes.ALLOW
     connection_details = RedshiftConnectionDetails(
-        username=username,
+        user=user,
         password=password,
         host=host,
         port=port,
         database=database,
-        ssl_mode=ssl_mode,
+        sslmode=sslmode,
     )
 
     context = ephemeral_context_with_defaults
     data_source = context.data_sources.add_redshift(
         name="redshift_test",
-        connection_details=connection_details,  # type: ignore[call-arg]
+        connection_string=connection_details,  # type: ignore[call-arg]
     )
     data_source.get_engine()  # we will verify that the correct connection details are used when getting the engine  # noqa: E501
 
     connection_string = build_connection_string(
-        scheme, username, password, host, port, database, ssl_mode.value
+        scheme, user, password, host, port, database, sslmode.value
     )
     expected_kwargs = RedshiftDsn(
         connection_string,
@@ -103,19 +103,19 @@ def test_value_error_raised_if_invalid_connection_detail_inputs(
     ephemeral_context_with_defaults: EphemeralDataContext,
     scheme,
 ):
-    username = "username"
+    user = "user"
     password = "password"
     host = "host"
     port = 1234
     database = "database"
-    ssl_mode = "INVALID"
+    sslmode = "INVALID"
 
     with pytest.raises(ValueError):
         RedshiftConnectionDetails(
-            username=username,
+            user=user,
             password=password,
             host=host,
             port=port,
             database=database,
-            ssl_mode=ssl_mode,  # type: ignore[arg-type] # Ignore this for purpose of the test
+            sslmode=sslmode,  # type: ignore[arg-type] # Ignore this for purpose of the test
         )


### PR DESCRIPTION
Updates to the `RedshiftDatasource` validator to support when the `connection_string` is a `dict` type. 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
