### PR TITLE
[MAINTENANCE] Improve `MetricErrorResult` and `Batch.compute_metrics()` API typing

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -62,8 +62,6 @@ from great_expectations.metrics.metric_name import MetricNameSuffix
 from great_expectations.metrics.metric_results import (
     MetricErrorResult,
     MetricErrorResultValue,
-    MetricInternalErrorResult,
-    MetricInternalErrorResultValue,
     MetricResult,
 )
 from great_expectations.validator.metrics_calculator import (
@@ -1331,12 +1329,12 @@ class Batch:
                 results.append(MetricErrorResult(id=metric_id_for_batch, value=value))
             else:
                 results.append(
-                    MetricInternalErrorResult(
+                    MetricErrorResult(
                         id=metric_id_for_batch,
-                        value=MetricInternalErrorResultValue(
-                            msg=f"Metric {metric.name} not found in results: "
-                            "{list(metrics_calculator_results.keys())} or errors: "
-                            "{list(metrics_calculator_errors.keys())}"
+                        value=MetricErrorResultValue(
+                            exception_message=f"Metric {metric.name} not found in results: "
+                            f"{list(metrics_calculator_results.keys())} or errors: "
+                            f"{list(metrics_calculator_errors.keys())}",
                         ),
                     )
                 )

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -1281,6 +1281,7 @@ class Batch:
             For metrics without a defined MetricResult generic type,
             the base MetricResult class will be returned.
             For metrics that raise an exception, a MetricErrorResult will be returned.
+
         Examples:
             >>> batch.compute_metrics(BatchRowCount())
             BatchRowCountResult(id=..., value=1000)

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -61,6 +61,7 @@ from great_expectations.metrics.metric import MetaMetric, Metric
 from great_expectations.metrics.metric_name import MetricNameSuffix
 from great_expectations.metrics.metric_results import (
     MetricErrorResult,
+    MetricErrorResultValue,
     MetricInternalErrorResult,
     MetricInternalErrorResultValue,
     MetricResult,
@@ -1279,7 +1280,7 @@ class Batch:
             in the same order as the input metrics were received.
             For metrics without a defined MetricResult generic type,
             the base MetricResult class will be returned.
-
+            For metrics that raise an exception, a MetricErrorResult will be returned.
         Examples:
             >>> batch.compute_metrics(BatchRowCount())
             BatchRowCountResult(id=..., value=1000)
@@ -1319,7 +1320,13 @@ class Batch:
                 )
                 results.append(MetricResultType(id=metric_id_for_batch, value=value))
             elif metric_id_for_batch in metrics_calculator_errors:
-                value = metrics_calculator_errors[metric_id_for_batch]
+                metrics_calculator_error = metrics_calculator_errors[metric_id_for_batch]
+                value = MetricErrorResultValue(
+                    exception_message=metrics_calculator_error["exception_info"].exception_message,
+                    exception_traceback=metrics_calculator_error[
+                        "exception_info"
+                    ].exception_traceback,
+                )
                 results.append(MetricErrorResult(id=metric_id_for_batch, value=value))
             else:
                 results.append(

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -1257,14 +1257,16 @@ class Batch:
         )
 
     @overload
-    def compute_metrics(self, metrics: Metric[_MetricResultT]) -> _MetricResultT: ...
+    def compute_metrics(
+        self, metrics: Metric[_MetricResultT]
+    ) -> _MetricResultT | MetricErrorResult: ...
 
     @overload
-    def compute_metrics(self, metrics: list[Metric]) -> list[MetricResult]: ...
+    def compute_metrics(self, metrics: list[Metric]) -> list[MetricResult | MetricErrorResult]: ...
 
     def compute_metrics(
         self, metrics: Metric[_MetricResultT] | list[Metric]
-    ) -> _MetricResultT | list[MetricResult]:
+    ) -> _MetricResultT | MetricErrorResult | list[MetricResult | MetricErrorResult]:
         """Compute one or more metrics on this Batch.
 
         Args:

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -1261,11 +1261,11 @@ class Batch:
     ) -> _MetricResultT | MetricErrorResult: ...
 
     @overload
-    def compute_metrics(self, metrics: list[Metric]) -> list[MetricResult | MetricErrorResult]: ...
+    def compute_metrics(self, metrics: list[Metric]) -> list[MetricResult]: ...
 
     def compute_metrics(
         self, metrics: Metric[_MetricResultT] | list[Metric]
-    ) -> _MetricResultT | MetricErrorResult | list[MetricResult | MetricErrorResult]:
+    ) -> _MetricResultT | MetricErrorResult | list[MetricResult]:
         """Compute one or more metrics on this Batch.
 
         Args:

--- a/great_expectations/metrics/metric_results.py
+++ b/great_expectations/metrics/metric_results.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar, Union
 import pandas as pd
 
 from great_expectations.compatibility.pydantic import BaseModel, GenericModel
-from great_expectations.validator.exception_info import ExceptionInfo
 from great_expectations.validator.metric_configuration import (
     MetricConfigurationID,
 )
@@ -23,8 +22,9 @@ class MetricResult(GenericModel, Generic[_MetricResultValue]):
         arbitrary_types_allowed = True
 
 
-class MetricErrorResultValue(TypedDict):
-    exception_info: ExceptionInfo
+class MetricErrorResultValue(BaseModel):
+    exception_message: str
+    exception_traceback: str
 
 
 class MetricErrorResult(MetricResult[MetricErrorResultValue]): ...

--- a/great_expectations/metrics/metric_results.py
+++ b/great_expectations/metrics/metric_results.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union
 
 import pandas as pd
 
@@ -24,17 +24,10 @@ class MetricResult(GenericModel, Generic[_MetricResultValue]):
 
 class MetricErrorResultValue(BaseModel):
     exception_message: str
-    exception_traceback: str
+    exception_traceback: Union[str, None] = None
 
 
 class MetricErrorResult(MetricResult[MetricErrorResultValue]): ...
-
-
-class MetricInternalErrorResultValue(TypedDict):
-    msg: str
-
-
-class MetricInternalErrorResult(MetricResult[MetricInternalErrorResultValue]): ...
 
 
 class ConditionValuesValueError(ValueError):

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -1,30 +1,26 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
     MetricConfigurationID,
 )
-from great_expectations.validator.validation_graph import ValidationGraph
+from great_expectations.validator.validation_graph import (
+    MetricsCalculatorErrorResultValue,
+    ValidationGraph,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
     from typing_extensions import TypeAlias
 
     from great_expectations.execution_engine import ExecutionEngine
-    from great_expectations.validator.exception_info import ExceptionInfo
 
 logger = logging.getLogger(__name__)
 logging.captureWarnings(True)
-
-
-class MetricsCalculatorErrorResultValue(TypedDict):
-    metric_configuration: MetricConfiguration
-    exception_info: ExceptionInfo
-    num_failures: int
 
 
 _MetricsDict: TypeAlias = Dict[MetricConfigurationID, MetricValue]

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict
 
-from great_expectations.metrics.metric_results import (
-    MetricErrorResultValue,
-)
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
@@ -18,15 +15,22 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from great_expectations.execution_engine import ExecutionEngine
+    from great_expectations.validator.exception_info import ExceptionInfo
 
 logger = logging.getLogger(__name__)
 logging.captureWarnings(True)
 
 
+class MetricsCalculatorErrorResultValue(TypedDict):
+    metric_configuration: MetricConfiguration
+    exception_info: ExceptionInfo
+    num_failures: int
+
+
 _MetricsDict: TypeAlias = Dict[MetricConfigurationID, MetricValue]
 _AbortedMetricsInfoDict: TypeAlias = Dict[
     MetricConfigurationID,
-    MetricErrorResultValue,
+    MetricsCalculatorErrorResultValue,
 ]
 
 

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypedDict,
     Union,
 )
 
@@ -23,9 +24,6 @@ from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
     MetricConfigurationID,
 )
-from great_expectations.validator.metrics_calculator import (
-    MetricsCalculatorErrorResultValue,
-)
 
 if TYPE_CHECKING:
     from great_expectations.core import IDDict
@@ -38,6 +36,12 @@ if TYPE_CHECKING:
     from great_expectations.validator.metrics_calculator import (
         _AbortedMetricsInfoDict,
     )
+
+
+class MetricsCalculatorErrorResultValue(TypedDict):
+    metric_configuration: MetricConfiguration
+    exception_info: ExceptionInfo
+    num_failures: int
 
 
 __all__ = [

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -14,7 +14,6 @@ from typing import (
 )
 
 from tqdm.auto import tqdm
-from typing_extensions import TypedDict
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility.typing_extensions import override
@@ -24,35 +23,22 @@ from great_expectations.validator.metric_configuration import (
     MetricConfiguration,
     MetricConfigurationID,
 )
+from great_expectations.validator.metrics_calculator import (
+    MetricsCalculatorErrorResultValue,
+)
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
     from great_expectations.core import IDDict
     from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.expectations.expectation_configuration import (
         ExpectationConfiguration,
     )
     from great_expectations.expectations.metrics.metric_provider import MetricProvider
-    from great_expectations.metrics.metric_results import (
-        MetricErrorResultValue,
-    )
     from great_expectations.validator.computed_metric import MetricValue
     from great_expectations.validator.metrics_calculator import (
         _AbortedMetricsInfoDict,
     )
 
-
-class DeprecatedMetricErrorResultValue(TypedDict):
-    metric_configuration: MetricConfiguration
-    exception_info: ExceptionInfo
-    num_failures: int
-
-
-_DeprecatedAbortedMetricsInfoDict: TypeAlias = Dict[
-    MetricConfigurationID,
-    DeprecatedMetricErrorResultValue,
-]
 
 __all__ = [
     "ExpectationValidationGraph",
@@ -249,7 +235,7 @@ class ValidationGraph:
         else:
             catch_exceptions = False
 
-        failed_metric_info: _DeprecatedAbortedMetricsInfoDict = {}
+        failed_metric_info: _AbortedMetricsInfoDict = {}
         aborted_metrics_info: _AbortedMetricsInfoDict = {}
 
         ready_metrics: Set[MetricConfiguration]
@@ -314,10 +300,12 @@ class ValidationGraph:
                             failed_metric_info[failed_metric.id]["num_failures"] += 1
                             failed_metric_info[failed_metric.id]["exception_info"] = exception_info
                         else:
-                            failed_metric_info[failed_metric.id] = DeprecatedMetricErrorResultValue(
-                                metric_configuration=failed_metric,
-                                exception_info=exception_info,
-                                num_failures=1,
+                            failed_metric_info[failed_metric.id] = (
+                                MetricsCalculatorErrorResultValue(
+                                    metric_configuration=failed_metric,
+                                    exception_info=exception_info,
+                                    num_failures=1,
+                                )
                             )
 
                 else:
@@ -423,7 +411,7 @@ class ExpectationValidationGraph:
         metric_info = self._filter_metric_info_in_graph(metric_info=metric_info)
         metric_exception_info: Dict[str, Union[MetricConfiguration, ExceptionInfo, int]] = {}
         metric_id: MetricConfigurationID
-        metric_info_item: MetricErrorResultValue
+        metric_info_item: MetricsCalculatorErrorResultValue
         for metric_id, metric_info_item in metric_info.items():
             metric_exception_info[str(metric_id)] = metric_info_item["exception_info"]
 

--- a/tests/integration/metrics/column/test_values_match_regex_values.py
+++ b/tests/integration/metrics/column/test_values_match_regex_values.py
@@ -53,6 +53,7 @@ class TestColumnValuesMatchRegexValues:
         metric = ColumnValuesMatchRegexValues(column=COLUMN_NAME, regex=MATCH_ALL_REGEX)
         metric_result = batch_for_datasource.compute_metrics(metric)
 
+        assert isinstance(metric_result, ColumnValuesMatchRegexValuesResult)
         assert len(metric_result.value) == 20
 
     @parameterize_batch_for_data_sources(
@@ -66,4 +67,5 @@ class TestColumnValuesMatchRegexValues:
         )
         metric_result = batch_for_datasource.compute_metrics(metric)
 
+        assert isinstance(metric_result, ColumnValuesMatchRegexValuesResult)
         assert len(metric_result.value) == limit

--- a/tests/integration/metrics/column/test_values_not_match_regex_values.py
+++ b/tests/integration/metrics/column/test_values_not_match_regex_values.py
@@ -56,6 +56,7 @@ class TestColumnValuesNotMatchRegexValues:
         metric = ColumnValuesNotMatchRegexValues(column=COLUMN_NAME, regex=MATCH_NONE_REGEX)
         metric_result = batch_for_datasource.compute_metrics(metric)
 
+        assert isinstance(metric_result, ColumnValuesNotMatchRegexValuesResult)
         # Should return up to the default limit (20)
         assert len(metric_result.value) == 20
         assert all(val == "A" for val in metric_result.value)
@@ -72,5 +73,6 @@ class TestColumnValuesNotMatchRegexValues:
         )
         metric_result = batch_for_datasource.compute_metrics(metric)
 
+        assert isinstance(metric_result, ColumnValuesNotMatchRegexValuesResult)
         assert len(metric_result.value) == limit
         assert all(val == "A" for val in metric_result.value)

--- a/tests/integration/metrics/test_error_result.py
+++ b/tests/integration/metrics/test_error_result.py
@@ -1,0 +1,47 @@
+import pandas
+
+from great_expectations.metrics.column.mean import ColumnMean
+from great_expectations.metrics.metric_results import MetricErrorResult
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import (
+    BigQueryDatasourceTestConfig,
+    DatabricksDatasourceTestConfig,
+    DataSourceTestConfig,
+    MSSQLDatasourceTestConfig,
+    PandasDataFrameDatasourceTestConfig,
+    PostgreSQLDatasourceTestConfig,
+    SnowflakeDatasourceTestConfig,
+    SparkFilesystemCsvDatasourceTestConfig,
+    SqliteDatasourceTestConfig,
+)
+
+DATA_FRAME = pandas.DataFrame(
+    {
+        "id": [1, 2, 3, 4],
+        "number": [1, 2, 3, 4],
+    },
+)
+
+DATA_SOURCES: list[DataSourceTestConfig] = [
+    BigQueryDatasourceTestConfig(),
+    MSSQLDatasourceTestConfig(),
+    PostgreSQLDatasourceTestConfig(),
+    SnowflakeDatasourceTestConfig(),
+    PandasDataFrameDatasourceTestConfig(),
+    SparkFilesystemCsvDatasourceTestConfig(),
+    DatabricksDatasourceTestConfig(),
+    SqliteDatasourceTestConfig(),
+]
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=DATA_SOURCES,
+    data=DATA_FRAME,
+)
+def test_error_result(batch_for_datasource) -> None:
+    batch = batch_for_datasource
+    metric = ColumnMean(column="non_existent_column")
+    metric_result = batch.compute_metrics(metric)
+    assert isinstance(metric_result, MetricErrorResult)
+    assert metric_result.value.exception_message is not None
+    assert metric_result.value.exception_traceback is not None

--- a/tests/integration/metrics/test_error_result.py
+++ b/tests/integration/metrics/test_error_result.py
@@ -3,7 +3,7 @@ import pandas
 from great_expectations.metrics.column.mean import ColumnMean
 from great_expectations.metrics.metric_results import MetricErrorResult
 from tests.integration.conftest import parameterize_batch_for_data_sources
-from tests.integration.test_utils.data_source_config import ALL_DATA_SOURCES
+from tests.metrics.conftest import ALL_DATA_SOURCES
 
 DATA_FRAME = pandas.DataFrame(
     {

--- a/tests/integration/metrics/test_error_result.py
+++ b/tests/integration/metrics/test_error_result.py
@@ -1,6 +1,6 @@
 import pandas
 
-from great_expectations.metrics.column.mean import ColumnMean
+from great_expectations.metrics.column.distinct_values import ColumnDistinctValues
 from great_expectations.metrics.metric_results import MetricErrorResult
 from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.metrics.conftest import ALL_DATA_SOURCES
@@ -19,7 +19,7 @@ DATA_FRAME = pandas.DataFrame(
 )
 def test_error_result(batch_for_datasource) -> None:
     batch = batch_for_datasource
-    metric = ColumnMean(column="non_existent_column")
+    metric = ColumnDistinctValues(column="non_existent_column")
     metric_result = batch.compute_metrics(metric)
     assert isinstance(metric_result, MetricErrorResult)
     assert metric_result.value.exception_message is not None

--- a/tests/integration/metrics/test_error_result.py
+++ b/tests/integration/metrics/test_error_result.py
@@ -3,17 +3,7 @@ import pandas
 from great_expectations.metrics.column.mean import ColumnMean
 from great_expectations.metrics.metric_results import MetricErrorResult
 from tests.integration.conftest import parameterize_batch_for_data_sources
-from tests.integration.test_utils.data_source_config import (
-    BigQueryDatasourceTestConfig,
-    DatabricksDatasourceTestConfig,
-    DataSourceTestConfig,
-    MSSQLDatasourceTestConfig,
-    PandasDataFrameDatasourceTestConfig,
-    PostgreSQLDatasourceTestConfig,
-    SnowflakeDatasourceTestConfig,
-    SparkFilesystemCsvDatasourceTestConfig,
-    SqliteDatasourceTestConfig,
-)
+from tests.integration.test_utils.data_source_config import ALL_DATA_SOURCES
 
 DATA_FRAME = pandas.DataFrame(
     {
@@ -22,20 +12,9 @@ DATA_FRAME = pandas.DataFrame(
     },
 )
 
-DATA_SOURCES: list[DataSourceTestConfig] = [
-    BigQueryDatasourceTestConfig(),
-    MSSQLDatasourceTestConfig(),
-    PostgreSQLDatasourceTestConfig(),
-    SnowflakeDatasourceTestConfig(),
-    PandasDataFrameDatasourceTestConfig(),
-    SparkFilesystemCsvDatasourceTestConfig(),
-    DatabricksDatasourceTestConfig(),
-    SqliteDatasourceTestConfig(),
-]
-
 
 @parameterize_batch_for_data_sources(
-    data_source_configs=DATA_SOURCES,
+    data_source_configs=ALL_DATA_SOURCES,
     data=DATA_FRAME,
 )
 def test_error_result(batch_for_datasource) -> None:

--- a/tests/metrics/test_metric_results.py
+++ b/tests/metrics/test_metric_results.py
@@ -3,6 +3,7 @@ import pytest
 from great_expectations.metrics.metric_results import (
     ColumnType,
     MetricErrorResult,
+    MetricErrorResultValue,
     TableColumnsResult,
     TableColumnTypesResult,
     UnexpectedCountResult,
@@ -93,13 +94,10 @@ class TestMetricResultInstantiation:
             metric_domain_kwargs_id="8a975130e802d66f85ab0cac8d10fbec",
             metric_value_kwargs_id=(),
         )
-        metric_value = {
-            "exception_info": {
-                "exception_traceback": "Traceback (most recent call last)...",
-                "exception_message": "Error: The column does not exist.",
-                "raised_exception": True,
-            },
-        }
+        metric_value = MetricErrorResultValue(
+            exception_traceback="Traceback (most recent call last)...",
+            exception_message="Error: The column does not exist.",
+        )
         metric_result = MetricErrorResult(
             id=metric_id,
             value=metric_value,


### PR DESCRIPTION
- Update `Batch.compute_metrics()` API typing to include `MetricErrorResult`
- Simplify `MetricErrorResult`
- Consolidate error types
--------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
