### PR TITLE
[DOCS] hide broken table of contents

### DIFF
--- a/docs/docusaurus/docs/core/configure_project_settings/access_secrets_managers/access_secrets_managers.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/access_secrets_managers/access_secrets_managers.md
@@ -3,6 +3,7 @@ title: Access secrets managers
 description: Access credentials that are stored in AWS Secrets Manager, GCP Secret Manager, or Azure key vault.
 hide_feedback_survey: false
 hide_title: false
+hide_table_of_contents: true
 ---
 
 import TabItem from '@theme/TabItem';

--- a/docs/docusaurus/docs/core/configure_project_settings/toggle_analytics_events/toggle_analytics_events.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/toggle_analytics_events/toggle_analytics_events.md
@@ -3,6 +3,7 @@ title: Toggle analytics events
 description: Enable or disable the collection of analytics events within GX.
 hide_feedback_survey: false
 hide_title: false
+hide_table_of_contents: true
 ---
 
 


### PR DESCRIPTION
resolves https://greatexpectations.atlassian.net/browse/DOC-915 by hiding the table of contents on pages where it's not functioning in a helpful manner due to headers nested in tabbed content. 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
