### PR TITLE
[BUGFIX] Fix LRU cache initialization in Config Substitutur

### DIFF
--- a/great_expectations/core/config_substitutor.py
+++ b/great_expectations/core/config_substitutor.py
@@ -41,7 +41,7 @@ class _ConfigurationSubstitutor:
     def __init__(self) -> None:
         # Using the @lru_cache decorator on method calls can create memory leaks - an attr is preferred here.  # noqa: E501 # FIXME CoP
         # Ref: https://stackoverflow.com/a/68550238
-        self._secret_store_cache = lru_cache(maxsize=None)(self._substitute_value_from_secret_store)
+        self._substitute_value_from_secret_store = lru_cache(maxsize=None)(self._substitute_value_from_secret_store)
 
     def substitute_all_config_variables(
         self,

--- a/great_expectations/core/config_substitutor.py
+++ b/great_expectations/core/config_substitutor.py
@@ -41,7 +41,9 @@ class _ConfigurationSubstitutor:
     def __init__(self) -> None:
         # Using the @lru_cache decorator on method calls can create memory leaks - an attr is preferred here.  # noqa: E501 # FIXME CoP
         # Ref: https://stackoverflow.com/a/68550238
-        self._substitute_value_from_secret_store = lru_cache(maxsize=None)(self._substitute_value_from_secret_store)
+        self._substitute_value_from_secret_store = lru_cache(maxsize=None)(
+            self._substitute_value_from_secret_store
+        )
 
     def substitute_all_config_variables(
         self,


### PR DESCRIPTION
Correctly apply lru_cache to _substitute_value_from_secret_store method to enable caching functionality.

The old version did apply the caching to a new method name that was never used. The proposed change overwrites the _substitute_value_from_secret_store with a function using the cache and therefore is identical to using the @lru_cache decorator, but without the already identified memory leak problem.

Fixes https://github.com/great-expectations/great_expectations/issues/11139

 Description of PR changes above includes a link to https://github.com/great-expectations/great_expectations/issues/11139
 PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
 Code is linted - run invoke lint (uses ruff format + ruff check)
 Appropriate tests and docs have been updated



- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated
