### PR TITLE
[MAINTENANCE] Temporarily pin gx-redshift for python 3.9

### DIFF
--- a/reqs/requirements-dev-gx-redshift.txt
+++ b/reqs/requirements-dev-gx-redshift.txt
@@ -1,2 +1,3 @@
-gx-sqlalchemy-redshift
+gx-sqlalchemy-redshift; python_version > "3.9"
+gx-sqlalchemy-redshift==0.8.17; python_version == "3.9"
 psycopg2-binary>=2.7.6

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 36
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 39
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -204,9 +204,19 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-contrib.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev-dremio.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
+        (
+            "requirements-dev-gx-redshift.txt",
+            "gx-sqlalchemy-redshift",
+            (("==", "0.8.17"),),
+        ),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-pagerduty.txt", "pypd", (("==", "1.1.0"),)),
         ("requirements-dev-snowflake.txt", "pandas", (("<", "2.2.0"),)),
+        (
+            "requirements-dev-sqlalchemy.txt",
+            "gx-sqlalchemy-redshift",
+            (("==", "0.8.17"),),
+        ),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-sqlalchemy.txt", "pandas", (("<", "2.2.0"),)),
         (
@@ -237,6 +247,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements-dev.txt", "docstring-parser", (("==", "0.16"),)),
+        ("requirements-dev.txt", "gx-sqlalchemy-redshift", (("==", "0.8.17"),)),
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev.txt", "pandas", (("<", "2.2.0"),)),


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
