### PR TITLE
[MAINTENANCE] Remove slow test cases

### DIFF
--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -62,7 +62,6 @@ from great_expectations.execution_engine.sqlalchemy_dialect import (
 from great_expectations.expectations.expectation_configuration import ExpectationConfiguration
 
 if TYPE_CHECKING:
-    from _pytest.mark.structures import ParameterSet
     from typing_extensions import TypeAlias
 
     from great_expectations.checkpoint.checkpoint import CheckpointResult
@@ -765,26 +764,9 @@ def _raw_query_check_column_exists(
         return True
 
 
-_EXPECTATION_TYPES: Final[tuple[ParameterSet, ...]] = (
-    param("expect_column_to_exist", {}, id="expect_column_to_exist"),
-    param("expect_column_values_to_not_be_null", {}, id="expect_column_values_to_not_be_null"),
-    param(
-        "expect_column_values_to_match_regex",
-        {"regex": r".*"},
-        id="expect_column_values_to_match_regex",
-    ),
-    param(
-        "expect_column_values_to_match_like_pattern",
-        {"like_pattern": r"%"},
-        id="expect_column_values_to_match_like_pattern",
-    ),
-)
-
-
 @pytest.mark.filterwarnings(
     "once::DeprecationWarning"
 )  # snowflake `add_table_asset` raises warning on passing a schema
-@pytest.mark.parametrize("expectation_type, extra_exp_kwargs", _EXPECTATION_TYPES)
 class TestColumnExpectations:
     @pytest.mark.parametrize(
         "column_name",
@@ -816,8 +798,6 @@ class TestColumnExpectations:
         all_sql_datasources: SQLDatasource,
         table_factory: TableFactory,
         column_name: str | quoted_name,
-        expectation_type: str,
-        extra_exp_kwargs: dict[str, Any],
         request: pytest.FixtureRequest,
     ):
         """
@@ -835,8 +815,6 @@ class TestColumnExpectations:
         elif _fails_expectation(param_id):
             # apply marker this way so that xpasses can be seen in the report
             request.applymarker(pytest.mark.xfail(run=False))
-
-        print(f"expectations_type:\n  {expectation_type}")
 
         schema: str | None = (
             RAND_SCHEMA
@@ -874,7 +852,8 @@ class TestColumnExpectations:
         suite = context.suites.add(ExpectationSuite(name=f"{datasource.name}-{asset.name}"))
         suite.add_expectation_configuration(
             expectation_configuration=ExpectationConfiguration(
-                type=expectation_type, kwargs={"column": column_name, **extra_exp_kwargs}
+                type="expect_column_values_to_match_regex",
+                kwargs={"column": column_name, "regex": r".*"},
             )
         )
         suite.save()

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -10,7 +10,6 @@ import warnings
 from pprint import pformat as pf
 from typing import (
     TYPE_CHECKING,
-    Any,
     Final,
     Generator,
     Literal,
@@ -898,8 +897,6 @@ class TestColumnExpectations:
         all_sql_datasources: SQLDatasource,
         table_factory: TableFactory,
         column_name: str | quoted_name,
-        expectation_type: str,
-        extra_exp_kwargs: dict[str, Any],
         request: pytest.FixtureRequest,
     ):
         """
@@ -919,8 +916,6 @@ class TestColumnExpectations:
         elif _fails_expectation(param_id):
             # apply marker this way so that xpasses can be seen in the report
             request.applymarker(pytest.mark.xfail(run=False))
-
-        print(f"expectations_type:\n  {expectation_type}")
 
         schema: str | None = (
             RAND_SCHEMA
@@ -958,7 +953,8 @@ class TestColumnExpectations:
         suite = context.suites.add(ExpectationSuite(name=f"{datasource.name}-{asset.name}"))
         suite.add_expectation_configuration(
             expectation_configuration=ExpectationConfiguration(
-                type=expectation_type, kwargs={"column": column_name, **extra_exp_kwargs}
+                type="expect_column_values_to_match_regex",
+                kwargs={"column": column_name, "regex": r".*"},
             )
         )
         suite.save()
@@ -1019,8 +1015,6 @@ class TestColumnExpectations:
         all_sql_datasources: SQLDatasource,
         table_factory: TableFactory,
         column_name: str | quoted_name,
-        expectation_type: str,
-        extra_exp_kwargs: dict[str, Any],
         request: pytest.FixtureRequest,
     ):
         """
@@ -1042,8 +1036,6 @@ class TestColumnExpectations:
         if column_name.startswith('"') and column_name.endswith('"'):
             # databricks uses backticks for quoting
             column_name = quote_str(column_name[1:-1], dialect=dialect)
-
-        print(f"expectations_type:\n  {expectation_type}")
 
         schema: str | None = (
             RAND_SCHEMA
@@ -1089,7 +1081,8 @@ class TestColumnExpectations:
         suite = context.suites.add(ExpectationSuite(name=f"{datasource.name}-{asset.name}"))
         suite.add_expectation_configuration(
             expectation_configuration=ExpectationConfiguration(
-                type=expectation_type, kwargs={"column": column_name, **extra_exp_kwargs}
+                type="expect_column_values_to_match_regex",
+                kwargs={"column": column_name, "regex": r".*"},
             )
         )
         suite.save()


### PR DESCRIPTION
- This change was suggested by the author of the tests [here](https://github.com/great-expectations/great_expectations/pull/10857#issuecomment-2599136369).
- Databricks 3.12 marker tests reduced from over 1 hour -> 43 minutes
- These tests aren't meant to test against particular Expectations. They are for quoted identifiers in column names.

-------------------

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated