### PR TITLE
[MAINTENANCE] Fix flakey test and simplify another assertion

### DIFF
--- a/tests/integration/metrics/column/test_descriptive_stats.py
+++ b/tests/integration/metrics/column/test_descriptive_stats.py
@@ -1,6 +1,5 @@
-import math
-
 import pandas as pd
+import pytest
 
 from great_expectations.datasource.fluent.interfaces import Batch
 from great_expectations.metrics.column.descriptive_stats import (
@@ -30,7 +29,5 @@ class TestColumnDescriptiveStats:
         assert isinstance(metric_result, ColumnDescriptiveStatsResult)
         assert metric_result.value.min == 1
         assert metric_result.value.max == 5
-        assert metric_result.value.mean == 3
-        assert math.isclose(
-            metric_result.value.standard_deviation, 1.4907119849998598, rel_tol=1e-6, abs_tol=0.0
-        )
+        assert metric_result.value.mean == pytest.approx(3)
+        assert metric_result.value.standard_deviation == pytest.approx(1.4907119849998598)


### PR DESCRIPTION
The mean comparison was failing because of floating point math. Also updated the math.isclose call to also just use `pytest.approx` here, as that should be sufficient.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
