### PR TITLE
[FEATURE] ExpectQueryResultsToMatchSource renderer for single-column …

### DIFF
--- a/great_expectations/expectations/core/expect_query_results_to_match_source.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_source.py
@@ -309,7 +309,7 @@ class ExpectQueryResultsToMatchSource(BatchExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> list[RenderedAtomicContent]:
+    ) -> list[RenderedAtomicContent] | RenderedAtomicContent:
         details = cls._get_details_from_results(result)
 
         missing_rows: list[dict[str, Any]] = details["missing_rows"]

--- a/great_expectations/expectations/core/expect_query_results_to_match_source.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_source.py
@@ -9,6 +9,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.result_format import ResultFormat
 from great_expectations.expectations.expectation import (
     BatchExpectation,
+    parse_value_to_observed_type,
     render_suite_parameter_string,
 )
 from great_expectations.expectations.metadata_types import DataQualityIssues, SupportedDataSources
@@ -22,6 +23,7 @@ from great_expectations.render.components import (
     RenderedAtomicContent,
     RenderedAtomicValue,
 )
+from great_expectations.render.renderer.observed_value_renderer import ObservedValueRenderState
 from great_expectations.render.renderer.renderer import renderer
 from great_expectations.render.renderer_configuration import (
     AddParamArgs,
@@ -312,19 +314,127 @@ class ExpectQueryResultsToMatchSource(BatchExpectation):
 
         missing_rows: list[dict[str, Any]] = details["missing_rows"]
         unexpected_rows: list[dict[str, Any]] = details["unexpected_rows"]
+        missing_rows_cols = cls._get_column_names_from_result(missing_rows)
+        unexpected_rows_cols = cls._get_column_names_from_result(unexpected_rows)
         missing_rows_table = cls._create_observed_values_table(missing_rows)
         unexpected_rows_table = cls._create_observed_values_table(unexpected_rows)
 
-        return [
-            cls._create_table_rendered_atomic_content(
-                unexpected_rows_table,
-                label="Unexpected records",
-            ),
-            cls._create_table_rendered_atomic_content(
-                missing_rows_table,
-                label="Missing records",
-            ),
-        ]
+        if len(missing_rows_cols) == 1 and len(unexpected_rows_cols) == 1:
+            return cls._create_observed_values_set(
+                configuration=configuration,
+                result=result,
+                runtime_configuration=runtime_configuration,
+                source_col_name=missing_rows_cols[0],
+                target_col_name=unexpected_rows_cols[0],
+            )
+        else:
+            return [
+                cls._create_table_rendered_atomic_content(
+                    unexpected_rows_table,
+                    label="Unexpected records",
+                ),
+                cls._create_table_rendered_atomic_content(
+                    missing_rows_table,
+                    label="Missing records",
+                ),
+            ]
+
+    @classmethod
+    def _create_observed_values_set(
+        cls,
+        source_col_name: str,
+        target_col_name: str,
+        configuration: Optional[ExpectationConfiguration] = None,
+        result: Optional[ExpectationValidationResult] = None,
+        runtime_configuration: Optional[dict] = None,
+    ) -> RenderedAtomicContent:
+        result_details = cls._get_details_from_results(result)
+        source_values = [row[source_col_name] for row in result_details["missing_rows"]]
+        target_values = [row[target_col_name] for row in result_details["unexpected_rows"]]
+        renderer_configuration: RendererConfiguration = RendererConfiguration(
+            configuration=configuration,
+            result=result,
+            runtime_configuration=runtime_configuration,
+        )
+        source_param_name = "expected_value"
+        target_param_name = "observed_value"
+        expected_param_prefix = "exp__"
+        ov_param_prefix = "ov__"
+
+        renderer_configuration.add_param(
+            name=source_param_name,
+            param_type=RendererValueType.ARRAY,
+            value=source_values,
+        )
+        renderer_configuration = cls._add_array_params(
+            array_param_name=source_param_name,
+            param_prefix=expected_param_prefix,
+            renderer_configuration=renderer_configuration,
+        )
+
+        renderer_configuration.add_param(
+            name=target_param_name,
+            param_type=RendererValueType.ARRAY,
+            value=target_values,
+        )
+        renderer_configuration = cls._add_array_params(
+            array_param_name=target_param_name,
+            param_prefix=ov_param_prefix,
+            renderer_configuration=renderer_configuration,
+        )
+        observed_value_set = set(target_values)
+        sample_observed_value = next(iter(observed_value_set)) if observed_value_set else None
+        expected_value_set = {
+            parse_value_to_observed_type(observed_value=sample_observed_value, value=value)
+            for value in source_values
+        }
+
+        observed_values = (
+            (name, schema)
+            for name, schema in renderer_configuration.params
+            if name.startswith(ov_param_prefix)
+        )
+
+        expected_values = (
+            (name, schema)
+            for name, schema in renderer_configuration.params
+            if name.startswith(expected_param_prefix)
+        )
+
+        template_str_list = []
+        for name, schema in observed_values:
+            render_state = (
+                ObservedValueRenderState.EXPECTED.value
+                if schema.value in expected_value_set
+                else ObservedValueRenderState.UNEXPECTED.value
+            )
+            renderer_configuration.params.__dict__[name].render_state = render_state
+            template_str_list.append(f"${name}")
+
+        for name, schema in expected_values:
+            coerced_value = parse_value_to_observed_type(
+                observed_value=sample_observed_value,
+                value=schema.value,
+            )
+            if coerced_value not in observed_value_set:
+                renderer_configuration.params.__dict__[
+                    name
+                ].render_state = ObservedValueRenderState.MISSING.value
+                template_str_list.append(f"${name}")
+
+        renderer_configuration.template_str = " ".join(template_str_list)
+
+        value_obj = RenderedAtomicValue(
+            template=renderer_configuration.template_str,
+            params=renderer_configuration.params.dict(),
+            meta_notes=renderer_configuration.meta_notes,
+            schema={"type": "com.superconductive.rendered.string"},
+        )
+        return RenderedAtomicContent(
+            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
+            value=value_obj,
+            value_type="StringValueType",
+        )
 
     @classmethod
     def _get_details_from_results(

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_source.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_source.py
@@ -10,7 +10,9 @@ from great_expectations.render.components import (
     RenderedAtomicContent,
     RenderedAtomicValue,
 )
+from great_expectations.render.renderer.observed_value_renderer import ObservedValueRenderState
 from great_expectations.render.renderer_configuration import (
+    MetaNotesFormat,
     RendererSchema,
     RendererTableValue,
     RendererValueType,
@@ -588,4 +590,73 @@ def test_rendering_with_missing_and_unexpected(multi_source_batch: MultiSourceBa
             ),
             value_type="TableType",
         ),
+    ]
+
+
+@multi_source_batch_setup(
+    multi_source_test_configs=SQLITE_ONLY,
+    source_data=pd.DataFrame({"foo": [1, 2, 3, 3]}),
+    target_data=pd.DataFrame({"bar": [1, 4, 5, 5]}),
+)
+def test_rendering_with_one_column(multi_source_batch: MultiSourceBatch):
+    source_table = multi_source_batch.source_table_name
+    result = multi_source_batch.target_batch.validate(
+        gxe.ExpectQueryResultsToMatchSource(
+            source_data_source_name=multi_source_batch.source_data_source_name,
+            source_query=f"SELECT foo FROM {source_table}",
+            target_query="SELECT bar FROM {batch}",
+        )
+    )
+    result.render()
+
+    assert result.rendered_content == [
+        RenderedAtomicContent(
+            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
+            value_type="StringValueType",
+            value=RenderedAtomicValue(
+                schema={"type": "com.superconductive.rendered.string"},
+                meta_notes={"format": MetaNotesFormat.STRING, "content": []},
+                template="$ov__0 $ov__1 $ov__2 $exp__0 $exp__1 $exp__2",
+                params={
+                    "expected_value": {
+                        "schema": RendererSchema(type=RendererValueType.ARRAY),
+                        "value": [2, 3, 3],
+                    },
+                    "observed_value": {
+                        "schema": RendererSchema(type=RendererValueType.ARRAY),
+                        "value": [4, 5, 5],
+                    },
+                    "exp__0": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.MISSING,
+                        "value": 2,
+                    },
+                    "exp__1": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.MISSING,
+                        "value": 3,
+                    },
+                    "exp__2": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.MISSING,
+                        "value": 3,
+                    },
+                    "ov__0": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.UNEXPECTED,
+                        "value": 4,
+                    },
+                    "ov__1": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.UNEXPECTED,
+                        "value": 5,
+                    },
+                    "ov__2": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.UNEXPECTED,
+                        "value": 5,
+                    },
+                },
+            ),
+        )
     ]


### PR DESCRIPTION
…results

Special case renderer when we only have one column in target and source query.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
