### PR TITLE
[BUGFIX] use existing LRU cache for secrets store

### DIFF
--- a/great_expectations/core/config_substitutor.py
+++ b/great_expectations/core/config_substitutor.py
@@ -136,7 +136,7 @@ class _ConfigurationSubstitutor:
 
         # 2. Replace the "$"'s that had been escaped
         template_str = template_str.replace(dollar_sign_escape_string, "$")
-        template_str = self._substitute_value_from_secret_store(template_str)
+        template_str = self._secret_store_cache(template_str)
         return template_str
 
     def _substitute_value_from_secret_store(self, value: str) -> str:


### PR DESCRIPTION
This PR implements a bugfix suggested in https://github.com/great-expectations/great_expectations/pull/11140 by @ThiloSchneider-fraport, and resolves https://github.com/great-expectations/great_expectations/issues/11139.


