### PR TITLE
[MAINTENANCE] limit pyspark to <4.0 due to breaking changes in types

### DIFF
--- a/reqs/requirements-dev-spark.txt
+++ b/reqs/requirements-dev-spark.txt
@@ -1,1 +1,1 @@
-pyspark>=2.3.2  # spark
+pyspark>=2.3.2,<4.0  # spark

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 36
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 38
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -206,6 +206,11 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-pagerduty.txt", "pypd", (("==", "1.1.0"),)),
+        (
+            "requirements-dev-spark.txt",
+            "pyspark",
+            (("<", "4.0"), (">=", "2.3.2")),
+        ),
         ("requirements-dev-snowflake.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-sqlalchemy.txt", "pandas", (("<", "2.2.0"),)),
@@ -242,6 +247,11 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev.txt", "posthog", (("<", "4"), (">", "3"))),
         ("requirements-dev.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),
+        (
+            "requirements-dev.txt",
+            "pyspark",
+            (("<", "4.0"), (">=", "2.3.2")),
+        ),
         ("requirements-dev.txt", "pypd", (("==", "1.1.0"),)),
         ("requirements-dev.txt", "sqlalchemy", (("<", "2.0.0"),)),
         ("requirements-dev.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),


### PR DESCRIPTION
[pyspark 4.0](https://pypi.org/project/pyspark/4.0.0/) was released today.  It introduces breaking type changes.  This pr will restrict the versions GX uses to be <4.0 and still >=2.3.2 as as previously the case.

Future work will be needed to support 4.0

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
