### PR TITLE
[MAINTENANCE] Ignore warnings around pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,7 +450,7 @@ filterwarnings = [
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "once:pkg_resources is deprecated as an API:DeprecationWarning",
-    "ignore:pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.:UserWarning",
+    'ignore: pkg_resources is deprecated as an API\(.*\)',
 
     # ruamel, google, etc.
     "once:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,6 +450,8 @@ filterwarnings = [
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "once:pkg_resources is deprecated as an API:DeprecationWarning",
+    "ignore:pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.:UserWarning",
+
     # ruamel, google, etc.
     "once:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,7 +450,7 @@ filterwarnings = [
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "ignore: pkg_resources is deprecated as an API:DeprecationWarning",
-    'ignore: pkg_resources is deprecated as an API:UserWarning',
+    "ignore: pkg_resources is deprecated as an API:UserWarning",
 
     # ruamel, google, etc.
     "once:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -449,8 +449,8 @@ filterwarnings = [
     # the pkg_resources module distributed with setuptools has been deprecated
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
-    "once:pkg_resources is deprecated as an API:DeprecationWarning",
-    'ignore: pkg_resources is deprecated as an API\(.*\)',
+    "ignore: pkg_resources is deprecated as an API:DeprecationWarning",
+    'ignore: pkg_resources is deprecated as an API:UserWarning',
 
     # ruamel, google, etc.
     "once:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",


### PR DESCRIPTION
Ignores a deprecation warning that just popped up. GX-978 will address the underlying issue.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
