### PR TITLE
[BUGFIX] Handle set rendering cases for `ExpectQueryResultsToMatchComparison`

### DIFF
--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -607,18 +607,16 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         ]
         output_rows: list[list[RendererTableValue]] = []
         for row in rows:
+            output_row_values = []
             for col_name in col_names:
                 if row[col_name] is not None:
-                    output_rows.append(
-                        [
-                            RendererTableValue(
-                                schema=RendererSchema(
-                                    type=RendererValueType.from_value(row[col_name])
-                                ),
-                                value=row[col_name],
-                            )
-                        ]
+                    output_row_values.append(
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.from_value(row[col_name])),
+                            value=row[col_name],
+                        )
                     )
+            output_rows.append(output_row_values)
 
         return [header_row, *output_rows]
 

--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -2,17 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from functools import cmp_to_key
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Literal, Optional, Tuple, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override

--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 from collections import Counter
 from functools import cmp_to_key
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Literal, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
@@ -322,7 +332,9 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         missing_rows_table = cls._create_observed_values_table(missing_rows)
         unexpected_rows_table = cls._create_observed_values_table(unexpected_rows)
 
-        if (
+        if len(missing_rows) == 0 and len(unexpected_rows) == 0:
+            return []
+        elif (
             len(missing_rows) == 1
             and len(unexpected_rows) == 1
             and len(missing_rows_cols) == 1
@@ -335,13 +347,13 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
                 result=result,
                 runtime_configuration=runtime_configuration,
             )
-        elif len(missing_rows_cols) == 1 and len(unexpected_rows_cols) == 1:
+        elif len(missing_rows_cols) <= 1 and len(unexpected_rows_cols) <= 1:
             return cls._create_observed_values_set(
+                comparison_col_name=missing_rows_cols[0] if missing_rows_cols else None,
+                base_col_name=unexpected_rows_cols[0] if unexpected_rows_cols else None,
                 configuration=configuration,
                 result=result,
                 runtime_configuration=runtime_configuration,
-                comparison_col_name=missing_rows_cols[0],
-                base_col_name=unexpected_rows_cols[0],
             )
         else:
             return [
@@ -414,15 +426,23 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
     @classmethod
     def _create_observed_values_set(
         cls,
-        comparison_col_name: str,
-        base_col_name: str,
+        comparison_col_name: Optional[str] = None,
+        base_col_name: Optional[str] = None,
         configuration: Optional[ExpectationConfiguration] = None,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> RenderedAtomicContent:
         result_details = cls._get_details_from_results(result)
-        comparison_values = [row[comparison_col_name] for row in result_details["missing_rows"]]
-        base_values = [row[base_col_name] for row in result_details["unexpected_rows"]]
+        comparison_values = (
+            [row[comparison_col_name] for row in result_details["missing_rows"]]
+            if comparison_col_name
+            else []
+        )
+        base_values = (
+            [row[base_col_name] for row in result_details["unexpected_rows"]]
+            if base_col_name
+            else []
+        )
         renderer_configuration: RendererConfiguration = RendererConfiguration(
             configuration=configuration,
             result=result,

--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -442,12 +442,20 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
     ) -> RenderedAtomicContent:
         result_details = cls._get_details_from_results(result)
         comparison_values = (
-            [row[comparison_col_name] for row in result_details["missing_rows"]]
+            [
+                row[comparison_col_name]
+                for row in result_details["missing_rows"]
+                if row[comparison_col_name] is not None
+            ]
             if comparison_col_name
             else []
         )
         base_values = (
-            [row[base_col_name] for row in result_details["unexpected_rows"]]
+            [
+                row[base_col_name]
+                for row in result_details["unexpected_rows"]
+                if row[base_col_name] is not None
+            ]
             if base_col_name
             else []
         )
@@ -599,15 +607,18 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         ]
         output_rows: list[list[RendererTableValue]] = []
         for row in rows:
-            output_rows.append(
-                [
-                    RendererTableValue(
-                        schema=RendererSchema(type=RendererValueType.from_value(row[col_name])),
-                        value=row[col_name],
+            for col_name in col_names:
+                if row[col_name] is not None:
+                    output_rows.append(
+                        [
+                            RendererTableValue(
+                                schema=RendererSchema(
+                                    type=RendererValueType.from_value(row[col_name])
+                                ),
+                                value=row[col_name],
+                            )
+                        ]
                     )
-                    for col_name in col_names
-                ]
-            )
 
         return [header_row, *output_rows]
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -710,3 +710,134 @@ def test_rendering_with_one_value(multi_source_batch: MultiSourceBatch):
             ),
         ),
     ]
+
+
+@multi_source_batch_setup(
+    multi_source_test_configs=SQLITE_ONLY,
+    comparison_data=pd.DataFrame({"foo": [1, 2, 3]}),
+    base_data=pd.DataFrame({"foo": [1, 2, 3]}),
+)
+def test_rendering_empty_missing_and_unexpected(multi_source_batch: MultiSourceBatch):
+    """Test rendering when both missing_rows and unexpected_rows are empty."""
+    source_table = multi_source_batch.comparison_table_name
+    result = multi_source_batch.base_batch.validate(
+        gxe.ExpectQueryResultsToMatchComparison(
+            comparison_data_source_name=multi_source_batch.comparison_data_source_name,
+            comparison_query=f"SELECT foo FROM {source_table}",
+            base_query="SELECT foo FROM {batch}",
+        )
+    )
+    result.render()
+
+    # When both missing_rows and unexpected_rows are empty, should return empty list
+    assert result.rendered_content == []
+
+
+@multi_source_batch_setup(
+    multi_source_test_configs=SQLITE_ONLY,
+    comparison_data=pd.DataFrame({"foo": [1, 2, 3]}),
+    base_data=pd.DataFrame({"bar": []}),  # Empty base data
+)
+def test_rendering_only_missing_rows_single_column(multi_source_batch: MultiSourceBatch):
+    """Test rendering when only missing_rows exist with single column."""
+    source_table = multi_source_batch.comparison_table_name
+    result = multi_source_batch.base_batch.validate(
+        gxe.ExpectQueryResultsToMatchComparison(
+            comparison_data_source_name=multi_source_batch.comparison_data_source_name,
+            comparison_query=f"SELECT foo FROM {source_table}",
+            base_query="SELECT bar FROM {batch} WHERE 1=0",  # Force empty result
+        )
+    )
+    result.render()
+
+    assert result.rendered_content == [
+        RenderedAtomicContent(
+            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
+            value_type="StringValueType",
+            value=RenderedAtomicValue(
+                schema={"type": "com.superconductive.rendered.string"},
+                meta_notes={"format": MetaNotesFormat.STRING, "content": []},
+                template="$exp__0 $exp__1 $exp__2",
+                params={
+                    "expected_value": {
+                        "schema": RendererSchema(type=RendererValueType.ARRAY),
+                        "value": [1, 2, 3],
+                    },
+                    "observed_value": {
+                        "schema": RendererSchema(type=RendererValueType.ARRAY),
+                        "value": [],
+                    },
+                    "exp__0": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.MISSING,
+                        "value": 1,
+                    },
+                    "exp__1": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.MISSING,
+                        "value": 2,
+                    },
+                    "exp__2": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.MISSING,
+                        "value": 3,
+                    },
+                },
+            ),
+        )
+    ]
+
+
+@multi_source_batch_setup(
+    multi_source_test_configs=SQLITE_ONLY,
+    comparison_data=pd.DataFrame({"foo": []}),  # Empty comparison data
+    base_data=pd.DataFrame({"bar": [1, 2, 3]}),
+)
+def test_rendering_only_unexpected_rows_single_column(multi_source_batch: MultiSourceBatch):
+    """Test rendering when only unexpected_rows exist with single column."""
+    source_table = multi_source_batch.comparison_table_name
+    result = multi_source_batch.base_batch.validate(
+        gxe.ExpectQueryResultsToMatchComparison(
+            comparison_data_source_name=multi_source_batch.comparison_data_source_name,
+            comparison_query=f"SELECT foo FROM {source_table} WHERE 1=0",  # Force empty result
+            base_query="SELECT bar FROM {batch}",
+        )
+    )
+    result.render()
+
+    assert result.rendered_content == [
+        RenderedAtomicContent(
+            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
+            value_type="StringValueType",
+            value=RenderedAtomicValue(
+                schema={"type": "com.superconductive.rendered.string"},
+                meta_notes={"format": MetaNotesFormat.STRING, "content": []},
+                template="$ov__0 $ov__1 $ov__2",
+                params={
+                    "expected_value": {
+                        "schema": RendererSchema(type=RendererValueType.ARRAY),
+                        "value": [],
+                    },
+                    "observed_value": {
+                        "schema": RendererSchema(type=RendererValueType.ARRAY),
+                        "value": [1, 2, 3],
+                    },
+                    "ov__0": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.UNEXPECTED,
+                        "value": 1,
+                    },
+                    "ov__1": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.UNEXPECTED,
+                        "value": 2,
+                    },
+                    "ov__2": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "render_state": ObservedValueRenderState.UNEXPECTED,
+                        "value": 3,
+                    },
+                },
+            ),
+        )
+    ]

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -482,34 +482,7 @@ def test_rendering_no_differences(multi_source_batch: MultiSourceBatch):
     )
     result.render()
 
-    assert result.rendered_content == [
-        RenderedAtomicContent(
-            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
-            value=RenderedAtomicValue(
-                template="Unexpected records: $row_count",
-                params={
-                    "row_count": {
-                        "schema": RendererSchema(type=RendererValueType.NUMBER),
-                        "value": 0,
-                    }
-                },
-            ),
-            value_type="TableType",
-        ),
-        RenderedAtomicContent(
-            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
-            value=RenderedAtomicValue(
-                template="Missing records: $row_count",
-                params={
-                    "row_count": {
-                        "schema": RendererSchema(type=RendererValueType.NUMBER),
-                        "value": 0,
-                    }
-                },
-            ),
-            value_type="TableType",
-        ),
-    ]
+    assert result.rendered_content == []
 
 
 @multi_source_batch_setup(
@@ -710,27 +683,6 @@ def test_rendering_with_one_value(multi_source_batch: MultiSourceBatch):
             ),
         ),
     ]
-
-
-@multi_source_batch_setup(
-    multi_source_test_configs=SQLITE_ONLY,
-    comparison_data=pd.DataFrame({"foo": [1, 2, 3]}),
-    base_data=pd.DataFrame({"foo": [1, 2, 3]}),
-)
-def test_rendering_empty_missing_and_unexpected(multi_source_batch: MultiSourceBatch):
-    """Test rendering when both missing_rows and unexpected_rows are empty."""
-    source_table = multi_source_batch.comparison_table_name
-    result = multi_source_batch.base_batch.validate(
-        gxe.ExpectQueryResultsToMatchComparison(
-            comparison_data_source_name=multi_source_batch.comparison_data_source_name,
-            comparison_query=f"SELECT foo FROM {source_table}",
-            base_query="SELECT foo FROM {batch}",
-        )
-    )
-    result.render()
-
-    # When both missing_rows and unexpected_rows are empty, should return empty list
-    assert result.rendered_content == []
 
 
 @multi_source_batch_setup(

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -688,7 +688,7 @@ def test_rendering_with_one_value(multi_source_batch: MultiSourceBatch):
 @multi_source_batch_setup(
     multi_source_test_configs=SQLITE_ONLY,
     comparison_data=pd.DataFrame({"foo": [1, 2, 3]}),
-    base_data=pd.DataFrame({"bar": []}),  # Empty base data
+    base_data=pd.DataFrame({"bar": []}),
 )
 def test_rendering_only_missing_rows_single_column(multi_source_batch: MultiSourceBatch):
     """Test rendering when only missing_rows exist with single column."""
@@ -697,7 +697,7 @@ def test_rendering_only_missing_rows_single_column(multi_source_batch: MultiSour
         gxe.ExpectQueryResultsToMatchComparison(
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT foo FROM {source_table}",
-            base_query="SELECT bar FROM {batch} WHERE 1=0",  # Force empty result
+            base_query="SELECT bar FROM {batch}",
         )
     )
     result.render()
@@ -742,7 +742,7 @@ def test_rendering_only_missing_rows_single_column(multi_source_batch: MultiSour
 
 @multi_source_batch_setup(
     multi_source_test_configs=SQLITE_ONLY,
-    comparison_data=pd.DataFrame({"foo": []}),  # Empty comparison data
+    comparison_data=pd.DataFrame({"foo": []}),
     base_data=pd.DataFrame({"bar": [1, 2, 3]}),
 )
 def test_rendering_only_unexpected_rows_single_column(multi_source_batch: MultiSourceBatch):
@@ -751,7 +751,7 @@ def test_rendering_only_unexpected_rows_single_column(multi_source_batch: MultiS
     result = multi_source_batch.base_batch.validate(
         gxe.ExpectQueryResultsToMatchComparison(
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
-            comparison_query=f"SELECT foo FROM {source_table} WHERE 1=0",  # Force empty result
+            comparison_query=f"SELECT foo FROM {source_table}",
             base_query="SELECT bar FROM {batch}",
         )
     )


### PR DESCRIPTION
Handle set rendering cases for `ExpectQueryResultsToMatchComparison`

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated