### PR TITLE
[MAINTENANCE] Update renderer labels

### DIFF
--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -367,11 +367,11 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
             return [
                 cls._create_table_rendered_atomic_content(
                     unexpected_rows_table,
-                    label="Unexpected records",
+                    label="Unexpected rows found in current table",
                 ),
                 cls._create_table_rendered_atomic_content(
                     missing_rows_table,
-                    label="Missing records",
+                    label="Expected rows not found in current table",
                 ),
             ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -646,6 +646,7 @@ filterwarnings = [
     "module: The GenericFunction 'flatten' is already registered and is going to be overridden:sqlalchemy.exc.SAWarning",
     # pyOpenSSL 25.0.1 starting raising this warning only for connecting to snowflake but no other datasources.
     "ignore: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception",
+    "ignore: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.:pytest_benchmark.logger.PytestBenchmarkWarning",
 
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -647,6 +647,7 @@ filterwarnings = [
     # pyOpenSSL 25.0.1 starting raising this warning only for connecting to snowflake but no other datasources.
     "ignore: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception",
     "ignore: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.:pytest_benchmark.logger.PytestBenchmarkWarning",
+    "ignore: No data was collected\\. \\(no-data-collected\\):coverage.exceptions.CoverageWarning",
 
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -884,7 +884,7 @@ def test_rendering_table_with_multiple_uuid():
 
         assert result.rendered_content == [
             _create_table_rendered_atomic_content(
-                template="Unexpected records: $row_count",
+                template="Unexpected rows found in current table: $row_count",
                 params={
                     "row_count": {
                         "schema": RendererSchema(type=RendererValueType.NUMBER),
@@ -899,7 +899,7 @@ def test_rendering_table_with_multiple_uuid():
                 ],
             ),
             _create_table_rendered_atomic_content(
-                template="Missing records: $row_count",
+                template="Expected rows not found in current table: $row_count",
                 params={
                     "row_count": {
                         "schema": RendererSchema(type=RendererValueType.NUMBER),

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -515,7 +515,7 @@ def test_rendering_with_missing_and_unexpected(multi_source_batch: MultiSourceBa
         RenderedAtomicContent(
             name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
             value=RenderedAtomicValue(
-                template="Unexpected records: $row_count",
+                template="Unexpected rows found in current table: $row_count",
                 params={
                     "row_count": {
                         "schema": RendererSchema(type=RendererValueType.NUMBER),
@@ -545,7 +545,7 @@ def test_rendering_with_missing_and_unexpected(multi_source_batch: MultiSourceBa
         RenderedAtomicContent(
             name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
             value=RenderedAtomicValue(
-                template="Missing records: $row_count",
+                template="Expected rows not found in current table: $row_count",
                 params={
                     "row_count": {
                         "schema": RendererSchema(type=RendererValueType.NUMBER),


### PR DESCRIPTION
Update diagnostic renderer labels for `ExpectQueryResultsToMatchComparison`

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
