### PR TITLE
Revert "[MAINTENANCE] Snowflake tests only run with snowflake flag"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -427,7 +427,6 @@ def pytest_collection_modifyitems(config, items):
             reason="need --docs-tests option to run",
         ),
         Category(mark="cloud", flag="--cloud", reason="need --cloud option to run"),
-        Category(mark="snowflake", flag="--snowflake", reason="need --snowflake option to run"),
     )
 
     for category in categories:


### PR DESCRIPTION
Reverts great-expectations/great_expectations#10605

We don't use the `--snowflake` flag when invoking tests. We instead us `-m "snowflake"` to run the tests with the snowflake marker. I'm going to revert this as tests are not currently running in CI. We can find a solution to not running the tests locally unless asked.