### PR TITLE
[Docs] fix link to removed content

### DIFF
--- a/docs/docusaurus/docs/cloud/connect/connect_snowflake.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_snowflake.md
@@ -68,7 +68,7 @@ Depending on your Snowflake permissions, you may need to ask an admin on your te
 :::tip To connect with key-pair authentication, use the GX Cloud API
 To connect to a Snowflake Data Source using key-pair authentication instead of a password, do the following using the GX Cloud API: 
 
-1. [Create a Cloud Data Context](/core/set_up_a_gx_environment/create_a_data_context.md?context_type=gx_cloud).
+1. [Create a Cloud Data Context](/cloud/connect/connect_python.md#create-a-data-context).
 2. Pass your private key when you [create a Data Source](/core/connect_to_data/sql_data/sql_data.md) in the Cloud Data Context.
 
 Then, you can use the GX Cloud UI to [add a Data Asset](/cloud/data_assets/manage_data_assets.md#add-a-data-asset-from-an-existing-data-source) from that Data Source.


### PR DESCRIPTION
This issueless PR is a follow-up to https://github.com/great-expectations/great_expectations/pull/11207 

It adjusts a link to account for content being removed in the earlier PR

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
