### PR TITLE
[MAINTENANCE] Add validation for ExpectColumnProportionOfNonNullValues

### DIFF
--- a/great_expectations/expectations/__init__.py
+++ b/great_expectations/expectations/__init__.py
@@ -13,6 +13,7 @@ from .core import (
     ExpectColumnPairValuesAToBeGreaterThanB,
     ExpectColumnPairValuesToBeEqual,
     ExpectColumnPairValuesToBeInSet,
+    ExpectColumnProportionOfNonNullValuesToBeBetween,
     ExpectColumnProportionOfUniqueValuesToBeBetween,
     ExpectColumnQuantileValuesToBeBetween,
     ExpectColumnStdevToBeBetween,

--- a/great_expectations/expectations/core/expect_column_proportion_of_non_null_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_non_null_values_to_be_between.py
@@ -200,7 +200,7 @@ class ExpectColumnProportionOfNonNullValuesToBeBetween(ColumnAggregateExpectatio
 
     _library_metadata = library_metadata
 
-    metric_dependencies = ("column.nonnull_count",)
+    metric_dependencies = ("column.nonnull_proportion",)
     success_keys = (
         "min_value",
         "max_value",
@@ -276,7 +276,7 @@ class ExpectColumnProportionOfNonNullValuesToBeBetween(ColumnAggregateExpectatio
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
-            metric_name="column.nonnull_count",
+            metric_name="column.nonnull_proportion",
             metrics=metrics,
             runtime_configuration=runtime_configuration,
             execution_engine=execution_engine,

--- a/great_expectations/expectations/core/expect_column_proportion_of_non_null_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_non_null_values_to_be_between.py
@@ -274,4 +274,10 @@ class ExpectColumnProportionOfNonNullValuesToBeBetween(ColumnAggregateExpectatio
         metrics: dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
-    ): ...
+    ):
+        return self._validate_metric_value_between(
+            metric_name="column.nonnull_count",
+            metrics=metrics,
+            runtime_configuration=runtime_configuration,
+            execution_engine=execution_engine,
+        )

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/__init__.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/__init__.py
@@ -15,6 +15,7 @@ from .column_parameterized_distribution_ks_test_p_value import (
     ColumnParameterizedDistributionKSTestPValue,
 )
 from .column_partition import ColumnPartition
+from .column_proportion_of_non_null_values import ColumnNonNullProportion
 from .column_proportion_of_unique_values import ColumnUniqueProportion
 from .column_quantile_values import ColumnQuantileValues
 from .column_sample_values import ColumnSampleValues

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_proportion_of_non_null_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_proportion_of_non_null_values.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from great_expectations.compatibility.typing_extensions import override
+from great_expectations.execution_engine import (
+    ExecutionEngine,
+    PandasExecutionEngine,
+    SparkDFExecutionEngine,
+    SqlAlchemyExecutionEngine,
+)
+from great_expectations.expectations.metrics.column_aggregate_metric_provider import (
+    ColumnAggregateMetricProvider,
+)
+from great_expectations.expectations.metrics.metric_provider import metric_value
+from great_expectations.validator.metric_configuration import MetricConfiguration
+
+if TYPE_CHECKING:
+    from great_expectations.expectations.expectation_configuration import (
+        ExpectationConfiguration,
+    )
+
+
+def nonnull_proportion(_metrics):
+    """Computes the proportion of non-null values out of all values"""
+    total_values = _metrics.get("table.row_count")
+    nonnull_count = _metrics.get("column.nonnull_count")
+
+    # Ensuring that we do not divide by 0, returning 0 if all values are nulls
+    if total_values > 0:
+        return nonnull_count / total_values
+    else:
+        return 0
+
+
+class ColumnNonNullProportion(ColumnAggregateMetricProvider):
+    metric_name = "column.nonnull_proportion"
+
+    @metric_value(engine=PandasExecutionEngine)
+    def _pandas(*args, metrics, **kwargs):
+        return nonnull_proportion(metrics)
+
+    @metric_value(engine=SqlAlchemyExecutionEngine)
+    def _sqlalchemy(*args, metrics, **kwargs):
+        return nonnull_proportion(metrics)
+
+    @metric_value(engine=SparkDFExecutionEngine)
+    def _spark(*args, metrics, **kwargs):
+        return nonnull_proportion(metrics)
+
+    @classmethod
+    @override
+    def _get_evaluation_dependencies(
+        cls,
+        metric: MetricConfiguration,
+        configuration: Optional[ExpectationConfiguration] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
+        runtime_configuration: Optional[dict] = None,
+    ):
+        dependencies: dict = super()._get_evaluation_dependencies(
+            metric=metric,
+            configuration=configuration,
+            execution_engine=execution_engine,
+            runtime_configuration=runtime_configuration,
+        )
+
+        dependencies["column.nonnull_count"] = MetricConfiguration(
+            metric_name="column.nonnull_count",
+            metric_domain_kwargs=metric.metric_domain_kwargs,
+        )
+
+        return dependencies

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_proportion_of_nonnull_values_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_proportion_of_nonnull_values_to_be_between.py
@@ -8,9 +8,6 @@ import great_expectations.expectations as gxe
 from great_expectations.core.result_format import ResultFormat
 from great_expectations.datasource.fluent.interfaces import Batch
 from tests.integration.conftest import parameterize_batch_for_data_sources
-from tests.integration.data_sources_and_expectations.test_canonical_expectations import (
-    JUST_PANDAS_DATA_SOURCES,
-)
 from tests.integration.test_utils.data_source_config import RedshiftDatasourceTestConfig
 from tests.integration.test_utils.data_source_config.base import DataSourceTestConfig
 from tests.integration.test_utils.data_source_config.big_query import BigQueryDatasourceTestConfig
@@ -37,6 +34,7 @@ HALF_NONNULL_COL = "half_nonnull"
 MOSTLY_NONNULL_COL = "mostly_nonnull"
 NO_NONNULL_COL = "no_nonnull"
 STRING_COL = "my_strings"
+TEST_COL = "test_col"
 
 
 # Create a sample dataframe with different proportions of nonnull values
@@ -50,6 +48,9 @@ DATA = pd.DataFrame(
     },
     dtype="object",
 )
+
+# Create an empty dataframe
+EMPTY_DATA = pd.DataFrame({TEST_COL: []})
 
 COLUMN_TYPES = {NO_NONNULL_COL: sqlatypes.INTEGER}
 try:
@@ -79,11 +80,16 @@ ALL_DATA_SOURCES: Sequence[DataSourceTestConfig] = [
     SqliteDatasourceTestConfig(column_types=COLUMN_TYPES),
 ]
 
+# Define a data source config that only includes SQLite
+JUST_SQLITE_DATA_SOURCES: Sequence[DataSourceTestConfig] = [
+    SqliteDatasourceTestConfig(column_types=COLUMN_TYPES),
+]
+
 
 @parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=DATA)
 def test_success_complete_results(batch_for_datasource: Batch) -> None:
     expectation = gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
-        column=HALF_NONNULL_COL, min_value=0.5, max_value=0.5
+        column=HALF_NONNULL_COL, min_value=0.4, max_value=0.7
     )
     result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
     assert result.success
@@ -92,9 +98,8 @@ def test_success_complete_results(batch_for_datasource: Batch) -> None:
 
 @parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=DATA)
 def test_strings(batch_for_datasource: Batch) -> None:
-    # String column has 6 non-null values out of 10 (60%)
     expectation = gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
-        column=STRING_COL, min_value=0.6, max_value=0.6
+        column=STRING_COL, min_value=0.4, max_value=0.7
     )
     result = batch_for_datasource.validate(expectation)
     assert result.success
@@ -109,13 +114,13 @@ def test_strings(batch_for_datasource: Batch) -> None:
         ),
         pytest.param(
             gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
-                column=HALF_NONNULL_COL, min_value=0.5, max_value=0.5
+                column=HALF_NONNULL_COL, min_value=0.4, max_value=0.7
             ),
             id="half_nonnull",
         ),
         pytest.param(
             gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
-                column=ALL_NONNULL_COL, min_value=1.0, max_value=1.0
+                column=ALL_NONNULL_COL, min_value=0.9, max_value=1.0
             ),
             id="all_nonnull",
         ),
@@ -149,7 +154,7 @@ def test_strings(batch_for_datasource: Batch) -> None:
         ),
     ],
 )
-@parameterize_batch_for_data_sources(data_source_configs=JUST_PANDAS_DATA_SOURCES, data=DATA)
+@parameterize_batch_for_data_sources(data_source_configs=JUST_SQLITE_DATA_SOURCES, data=DATA)
 def test_success(
     batch_for_datasource: Batch, expectation: gxe.ExpectColumnProportionOfNonNullValuesToBeBetween
 ) -> None:
@@ -180,9 +185,29 @@ def test_success(
         ),
     ],
 )
-@parameterize_batch_for_data_sources(data_source_configs=JUST_PANDAS_DATA_SOURCES, data=DATA)
+@parameterize_batch_for_data_sources(data_source_configs=JUST_SQLITE_DATA_SOURCES, data=DATA)
 def test_failure(
     batch_for_datasource: Batch, expectation: gxe.ExpectColumnProportionOfNonNullValuesToBeBetween
 ) -> None:
     result = batch_for_datasource.validate(expectation)
     assert not result.success
+
+
+@parameterize_batch_for_data_sources(data_source_configs=JUST_SQLITE_DATA_SOURCES, data=EMPTY_DATA)
+def test_empty_dataframe(batch_for_datasource: Batch) -> None:
+    """Test that expectations handle empty dataframes correctly."""
+    expectation = gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+        column=TEST_COL, min_value=0.0, max_value=1.0
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+    assert result.success
+
+    expectation_zero = gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+        column=TEST_COL, min_value=0.0, max_value=0.0
+    )
+    result_zero = batch_for_datasource.validate(
+        expectation_zero, result_format=ResultFormat.COMPLETE
+    )
+
+    assert result_zero.success
+    assert result_zero.to_json_dict()["result"] == {"observed_value": 0}

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_proportion_of_nonnull_values_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_proportion_of_nonnull_values_to_be_between.py
@@ -1,0 +1,188 @@
+from collections.abc import Sequence
+
+import pandas as pd
+import pytest
+from sqlalchemy import types as sqlatypes
+
+import great_expectations.expectations as gxe
+from great_expectations.core.result_format import ResultFormat
+from great_expectations.datasource.fluent.interfaces import Batch
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.data_sources_and_expectations.test_canonical_expectations import (
+    JUST_PANDAS_DATA_SOURCES,
+)
+from tests.integration.test_utils.data_source_config import RedshiftDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.base import DataSourceTestConfig
+from tests.integration.test_utils.data_source_config.big_query import BigQueryDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.databricks import (
+    DatabricksDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.mssql import MSSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.mysql import MySQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.pandas_data_frame import (
+    PandasDataFrameDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.pandas_filesystem_csv import (
+    PandasFilesystemCsvDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.postgres import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.snowflake import SnowflakeDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.spark_filesystem_csv import (
+    SparkFilesystemCsvDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.sqlite import SqliteDatasourceTestConfig
+
+ALL_NONNULL_COL = "all_nonnull"
+HALF_NONNULL_COL = "half_nonnull"
+MOSTLY_NONNULL_COL = "mostly_nonnull"
+NO_NONNULL_COL = "no_nonnull"
+STRING_COL = "my_strings"
+
+
+# Create a sample dataframe with different proportions of nonnull values
+DATA = pd.DataFrame(
+    {
+        ALL_NONNULL_COL: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        HALF_NONNULL_COL: [0, 1, 2, 3, 4, None, None, None, None, None],
+        MOSTLY_NONNULL_COL: [0, 1, 2, 3, 4, 5, 6, 7, None, None],
+        NO_NONNULL_COL: [None, None, None, None, None, None, None, None, None, None],
+        STRING_COL: ["foo", "bar", "baz", None, None, "qux", "quux", None, "corge", None],
+    },
+    dtype="object",
+)
+
+COLUMN_TYPES = {NO_NONNULL_COL: sqlatypes.INTEGER}
+try:
+    from great_expectations.compatibility.pyspark import types as PYSPARK_TYPES
+
+    SPARK_COLUMN_TYPES = {
+        ALL_NONNULL_COL: PYSPARK_TYPES.IntegerType,
+        HALF_NONNULL_COL: PYSPARK_TYPES.IntegerType,
+        MOSTLY_NONNULL_COL: PYSPARK_TYPES.IntegerType,
+        NO_NONNULL_COL: PYSPARK_TYPES.IntegerType,
+        STRING_COL: PYSPARK_TYPES.StringType,
+    }
+except ModuleNotFoundError:
+    SPARK_COLUMN_TYPES = {}
+
+ALL_DATA_SOURCES: Sequence[DataSourceTestConfig] = [
+    BigQueryDatasourceTestConfig(column_types=COLUMN_TYPES),
+    DatabricksDatasourceTestConfig(column_types=COLUMN_TYPES),
+    MSSQLDatasourceTestConfig(column_types=COLUMN_TYPES),
+    MySQLDatasourceTestConfig(column_types=COLUMN_TYPES),
+    PandasDataFrameDatasourceTestConfig(),
+    PandasFilesystemCsvDatasourceTestConfig(),
+    PostgreSQLDatasourceTestConfig(column_types=COLUMN_TYPES),
+    RedshiftDatasourceTestConfig(column_types=COLUMN_TYPES),
+    SnowflakeDatasourceTestConfig(column_types=COLUMN_TYPES),
+    SparkFilesystemCsvDatasourceTestConfig(column_types=SPARK_COLUMN_TYPES),
+    SqliteDatasourceTestConfig(column_types=COLUMN_TYPES),
+]
+
+
+@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=DATA)
+def test_success_complete_results(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+        column=HALF_NONNULL_COL, min_value=0.5, max_value=0.5
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+    assert result.success
+    assert result.to_json_dict()["result"] == {"observed_value": 0.5}
+
+
+@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=DATA)
+def test_strings(batch_for_datasource: Batch) -> None:
+    # String column has 6 non-null values out of 10 (60%)
+    expectation = gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+        column=STRING_COL, min_value=0.6, max_value=0.6
+    )
+    result = batch_for_datasource.validate(expectation)
+    assert result.success
+
+
+@pytest.mark.parametrize(
+    "expectation",
+    [
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(column=HALF_NONNULL_COL),
+            id="vacuously_true",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=HALF_NONNULL_COL, min_value=0.5, max_value=0.5
+            ),
+            id="half_nonnull",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=ALL_NONNULL_COL, min_value=1.0, max_value=1.0
+            ),
+            id="all_nonnull",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=NO_NONNULL_COL, min_value=0.0, max_value=0.0
+            ),
+            id="no_nonnull",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=MOSTLY_NONNULL_COL, min_value=0.8
+            ),
+            id="only_min",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=MOSTLY_NONNULL_COL, max_value=0.8
+            ),
+            id="only_max",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=MOSTLY_NONNULL_COL,
+                min_value=0.79,
+                max_value=0.81,
+                strict_min=True,
+                strict_max=True,
+            ),
+            id="strict_bounds",
+        ),
+    ],
+)
+@parameterize_batch_for_data_sources(data_source_configs=JUST_PANDAS_DATA_SOURCES, data=DATA)
+def test_success(
+    batch_for_datasource: Batch, expectation: gxe.ExpectColumnProportionOfNonNullValuesToBeBetween
+) -> None:
+    result = batch_for_datasource.validate(expectation)
+    assert result.success
+
+
+@pytest.mark.parametrize(
+    "expectation",
+    [
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=HALF_NONNULL_COL, min_value=0.5, strict_min=True
+            ),
+            id="strict_min",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=HALF_NONNULL_COL, max_value=0.5, strict_max=True
+            ),
+            id="strict_max",
+        ),
+        pytest.param(
+            gxe.ExpectColumnProportionOfNonNullValuesToBeBetween(
+                column=HALF_NONNULL_COL, min_value=0.6, max_value=0.7
+            ),
+            id="wrong_bounds",
+        ),
+    ],
+)
+@parameterize_batch_for_data_sources(data_source_configs=JUST_PANDAS_DATA_SOURCES, data=DATA)
+def test_failure(
+    batch_for_datasource: Batch, expectation: gxe.ExpectColumnProportionOfNonNullValuesToBeBetween
+) -> None:
+    result = batch_for_datasource.validate(expectation)
+    assert not result.success


### PR DESCRIPTION
This also introduces an intermediate metric `column.nonnull_proportion` so we can accurately report the normalized proportion of nonnull values in a column.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
