### PR TITLE
[DOCS] Cloud API data source tip

### DIFF
--- a/docs/docusaurus/docs/cloud/connect/connect_python.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_python.md
@@ -80,6 +80,13 @@ Environment variables securely store your GX Cloud access credentials.
 
 ## Connect to a Data Asset
 
+:::tip Working with Data Sources
+
+The Data Context you created includes a built-in `pandas_default` Data Source. This Data Source gives access to all of the `read_*(...)` methods available in pandas. This allows you connect to a pandas Data Asset without adding your own Data Source first.
+
+Cloud API instructions for connecting to other Data Sources such as Amazon S3, Azure Blob Storage, Google Cloud Storage, BigQuery, and Spark are under construction. In the meantime you can refer to the [GX Core docs](https://docs.greatexpectations.io/docs/core/connect_to_data/) for guidance as the Cloud API uses the same methods for connecting Data Sources.
+:::
+
 - Run the following Python code to connect to existing `.csv` data stored in the `great_expectations` GitHub repository and create a Validator object:
 
     ```python title="Python" name="tutorials/quickstart/quickstart.py connect_to_data"

--- a/docs/docusaurus/docs/cloud/connect/connect_python.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_python.md
@@ -82,7 +82,7 @@ Environment variables securely store your GX Cloud access credentials.
 
 :::tip Working with Data Sources
 
-The Data Context you created includes a built-in `pandas_default` Data Source. This Data Source gives access to all of the `read_*(...)` methods available in pandas. This allows you connect to a pandas Data Asset without adding your own Data Source first.
+The Data Context you created includes a built-in `pandas_default` Data Source. This Data Source gives access to all of the `read_*(...)` methods available in pandas. This allows you connect to a pandas Data Asset without adding your own Data Source first as demonstrated in this section.
 
 Cloud API instructions for connecting to other Data Sources such as Amazon S3, Azure Blob Storage, Google Cloud Storage, BigQuery, and Spark are under construction. In the meantime you can refer to the [GX Core docs](https://docs.greatexpectations.io/docs/core/connect_to_data/) for guidance as the Cloud API uses the same methods for connecting Data Sources.
 :::

--- a/docs/docusaurus/docs/cloud/connect/connect_python.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_python.md
@@ -84,7 +84,7 @@ Environment variables securely store your GX Cloud access credentials.
 
 The Data Context you created includes a built-in `pandas_default` Data Source. This Data Source gives access to all of the `read_*(...)` methods available in pandas. This allows you connect to a pandas Data Asset without adding your own Data Source first as demonstrated in this section.
 
-Cloud API instructions for connecting to other Data Sources such as Amazon S3, Azure Blob Storage, Google Cloud Storage, BigQuery, and Spark are under construction. In the meantime you can refer to the [GX Core docs](https://docs.greatexpectations.io/docs/core/connect_to_data/) for guidance as the Cloud API uses the same methods for connecting Data Sources.
+Cloud API instructions for connecting to other Data Sources such as Amazon S3, Azure Blob Storage, Google Cloud Storage, BigQuery, and Spark are under construction. In the meantime you can refer to the [GX Core docs](/docs/core/connect_to_data/connect_to_data.md) for guidance as the Cloud API uses the same methods for connecting Data Sources.
 :::
 
 - Run the following Python code to connect to existing `.csv` data stored in the `great_expectations` GitHub repository and create a Validator object:

--- a/docs/docusaurus/docs/cloud/connect/connect_python.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_python.md
@@ -82,9 +82,9 @@ Environment variables securely store your GX Cloud access credentials.
 
 :::tip Working with Data Sources
 
-The Data Context you created includes a built-in `pandas_default` Data Source. This Data Source gives access to all of the `read_*(...)` methods available in pandas. This allows you connect to a pandas Data Asset without adding your own Data Source first as demonstrated in this section.
+The Data Context you created includes a built-in `pandas_default` Data Source. This Data Source gives access to all of the `read_*(...)` methods available in pandas. This allows you to connect to a pandas Data Asset without adding your own Data Source first as demonstrated in this section.
 
-Cloud API instructions for connecting to other Data Sources such as Amazon S3, Azure Blob Storage, Google Cloud Storage, BigQuery, and Spark are under construction. In the meantime you can refer to the [GX Core docs](/docs/core/connect_to_data/connect_to_data.md) for guidance as the Cloud API uses the same methods for connecting Data Sources.
+Cloud API instructions for connecting to other Data Sources such as Amazon S3, Azure Blob Storage, Google Cloud Storage, BigQuery, and Spark are under construction. In the meantime, you can refer to the [GX Core docs](/docs/core/connect_to_data/connect_to_data.md) for guidance as the Cloud API uses the same methods for connecting Data Sources.
 :::
 
 - Run the following Python code to connect to existing `.csv` data stored in the `great_expectations` GitHub repository and create a Validator object:


### PR DESCRIPTION
This issueless PR adds a temporary tip about Cloud API data sources as discussed in https://greatexpectationslabs.slack.com/archives/C08UEGJ0J6S/p1749762147806309?thread_ts=1749758823.491529&cid=C08UEGJ0J6S

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
