### PR TITLE
[BUGFIX] Remove datetime types from proportion `min_value` and `max_value` parameters

### DIFF
--- a/great_expectations/expectations/core/expect_column_proportion_of_non_null_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_non_null_values_to_be_between.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core.types import (
-    Comparable,  # noqa: TC001 # pydantic instantiates this type at runtime
+from great_expectations.core.suite_parameters import (
+    SuiteParameterDict,  # noqa: TC001 # pydantic isinstance
 )
 from great_expectations.expectations.expectation import (
     COLUMN_DESCRIPTION,
@@ -192,10 +192,10 @@ class ExpectColumnProportionOfNonNullValuesToBeBetween(ColumnAggregateExpectatio
                 }}
     """
 
-    min_value: Optional[Comparable] = pydantic.Field(
+    min_value: Optional[Union[float, SuiteParameterDict]] = pydantic.Field(
         default=None, description=MIN_VALUE_DESCRIPTION
     )
-    max_value: Optional[Comparable] = pydantic.Field(
+    max_value: Optional[Union[float, SuiteParameterDict]] = pydantic.Field(
         default=None, description=MAX_VALUE_DESCRIPTION
     )
     strict_min: bool = pydantic.Field(default=False, description=STRICT_MIN_DESCRIPTION)

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -4,9 +4,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
 from great_expectations.compatibility import pydantic
 from great_expectations.core.suite_parameters import (
-    SuiteParameterDict,  # noqa: TC001 # FIXME CoP
+    SuiteParameterDict,  # noqa: TC001 # pydantic isinstance
 )
-from great_expectations.core.types import Comparable  # noqa: TC001 # FIXME CoP
 from great_expectations.expectations.expectation import (
     COLUMN_DESCRIPTION,
     ColumnAggregateExpectation,
@@ -189,10 +188,10 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnAggregateExpectation
                 }}
     """  # noqa: E501 # FIXME CoP
 
-    min_value: Optional[Comparable] = pydantic.Field(
+    min_value: Optional[Union[float, SuiteParameterDict]] = pydantic.Field(
         default=None, description=MIN_VALUE_DESCRIPTION
     )
-    max_value: Optional[Comparable] = pydantic.Field(
+    max_value: Optional[Union[float, SuiteParameterDict]] = pydantic.Field(
         default=None, description=MAX_VALUE_DESCRIPTION
     )
     strict_min: Union[bool, SuiteParameterDict] = pydantic.Field(

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
@@ -95,14 +95,6 @@
                 },
                 {
                     "type": "object"
-                },
-                {
-                    "type": "string",
-                    "format": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time"
                 }
             ]
         },
@@ -115,14 +107,6 @@
                 },
                 {
                     "type": "object"
-                },
-                {
-                    "type": "string",
-                    "format": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time"
                 }
             ]
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -95,14 +95,6 @@
                 },
                 {
                     "type": "object"
-                },
-                {
-                    "type": "string",
-                    "format": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time"
                 }
             ]
         },
@@ -115,14 +107,6 @@
                 },
                 {
                     "type": "object"
-                },
-                {
-                    "type": "string",
-                    "format": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time"
                 }
             ]
         },


### PR DESCRIPTION


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated