### PR TITLE
[MAINTENANCE] Allow posthog v4 and v5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pandas>=1.1.3,<2.2; python_version == "3.9"
 pandas>=1.3.0,<2.2; python_version >= "3.10"
 pandas<2.2; python_version >= "3.12"
 # analytics
-posthog>3,<4
+posthog>3,<6
 # patch version updates `typing_extensions` to the needed version
 pydantic>=1.10.7
 pyparsing>=2.4

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -245,7 +245,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev.txt", "pandas", (("<", "2.2.0"),)),
-        ("requirements-dev.txt", "posthog", (("<", "4"), (">", "3"))),
+        ("requirements-dev.txt", "posthog", (("<", "6"), (">", "3"))),
         ("requirements-dev.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),
         (
             "requirements-dev.txt",
@@ -260,5 +260,5 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements.txt", "pandas", (("<", "2.2"),)),
-        ("requirements.txt", "posthog", (("<", "4"), (">", "3"))),
+        ("requirements.txt", "posthog", (("<", "6"), (">", "3"))),
     }


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
