### PR TITLE
[BUGFIX] Make ExpectTableColumnsToMatchSet case insensitive

### DIFF
--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -497,3 +497,8 @@ class RedshiftExecutionEngineError(GreatExpectationsError):
     def __init__(self, message: str) -> None:
         msg = f"Redshift execution engine error: {message}"
         super().__init__(msg)
+
+
+class InvalidSetTypeError(GreatExpectationsError):
+    def __init__(self, expected_type: str, actual_type: str) -> None:
+        super().__init__(f"Expected a set[{expected_type}], got an element of type {actual_type}")

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -492,7 +492,9 @@ def _make_column_set_with_execution_engine_type(
     if column_set is None:
         return set()
 
-    dialect = execution_engine.dialect.name if execution_engine else None
+    dialect = (
+        execution_engine.dialect.name if execution_engine and execution_engine.dialect else None
+    )
     if dialect in [GXSqlDialect.DATABRICKS, GXSqlDialect.POSTGRESQL, GXSqlDialect.SNOWFLAKE]:
         # For these dialects, column_set we want to use
         # The metric column_set will return a set of strs but table.columns will return a list of

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -423,9 +423,11 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        breakpoint()
         expected_column_set = _make_column_set_with_execution_engine_type(
             self._get_success_kwargs().get("column_set"), execution_engine
         )
+        breakpoint()
         actual_column_list = metrics.get("table.columns")
         actual_column_set = set(actual_column_list)
         exact_match = self._get_success_kwargs().get("exact_match")
@@ -495,7 +497,11 @@ def _make_column_set_with_execution_engine_type(
     dialect = (
         execution_engine.dialect.name if execution_engine and execution_engine.dialect else None
     )
-    if dialect in [GXSqlDialect.DATABRICKS, GXSqlDialect.POSTGRESQL, GXSqlDialect.SNOWFLAKE]:
+    if dialect and dialect in [
+        GXSqlDialect.DATABRICKS,
+        GXSqlDialect.POSTGRESQL,
+        GXSqlDialect.SNOWFLAKE,
+    ]:
         # For these dialects, column_set we want to use
         # The metric column_set will return a set of strs but table.columns will return a list of
         # CaseInsensitiveStrings. CaseInsensitiveStrings and strs can be equal but have different

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -8,6 +8,7 @@ from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
 from great_expectations.exceptions.exceptions import InvalidSetTypeError
+from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -422,14 +423,9 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
-        # The metric column_set will return a set of strs but table.columns will return a list of
-        # CaseInsensitiveStrings. CaseInsensitiveStrings and strs can be equal but have different
-        # hashes which breaks set operations. Since we want to do set operations in a case
-        # insensitive manner, we make the expect_column_set case insensitive.
-        expected_column_set = _make_case_insensitive_set(
-            self._get_success_kwargs().get("column_set")
+        expected_column_set = _make_column_set_with_execution_engine_type(
+            self._get_success_kwargs().get("column_set"), execution_engine
         )
-
         actual_column_list = metrics.get("table.columns")
         actual_column_set = set(actual_column_list)
         exact_match = self._get_success_kwargs().get("exact_match")
@@ -476,6 +472,36 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
                 # Passed if there are no items in the missing list
                 else:
                     return return_success
+
+
+def _make_column_set_with_execution_engine_type(
+    column_set: Optional[set[str]],
+    execution_engine: Optional[ExecutionEngine],
+) -> set[str]:
+    """
+    Transforms column names in column_set to the appropriate type for the execution_engine.
+
+    Args:
+        column_set: A set of column names.
+        execution_engine: An execution engine.
+
+    Returns:
+        A set of column names whose type matches the metric table.columns. This type varies
+        based on the execution engine.
+    """
+    if column_set is None:
+        return set()
+
+    dialect = execution_engine.dialect.name if execution_engine else None
+    if dialect in [GXSqlDialect.DATABRICKS, GXSqlDialect.POSTGRESQL, GXSqlDialect.SNOWFLAKE]:
+        # For these dialects, column_set we want to use
+        # The metric column_set will return a set of strs but table.columns will return a list of
+        # CaseInsensitiveStrings. CaseInsensitiveStrings and strs can be equal but have different
+        # hashes which breaks set operations. Since we want to do set operations in a case
+        # insensitive manner, we make the expect_column_set case insensitive.
+        return _make_case_insensitive_set(column_set)
+    else:
+        return set(column_set)
 
 
 def _make_case_insensitive_set(strs: set[str]) -> set[CaseInsensitiveString]:

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -7,6 +7,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
+from great_expectations.exceptions.exceptions import InvalidSetTypeError
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
     from great_expectations.expectations.expectation_configuration import (
         ExpectationConfiguration,
     )
+    from great_expectations.expectations.metrics.util import CaseInsensitiveString
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 
@@ -420,9 +422,14 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
-        # Obtaining columns and ordered list for sake of comparison
-        expected_column_set = self._get_success_kwargs().get("column_set")
-        expected_column_set = set(expected_column_set) if expected_column_set is not None else set()
+        # The metric column_set will return a set of strs but table.columns will return a list of
+        # CaseInsensitiveStrings. CaseInsensitiveStrings and strs can be equal but have different
+        # hashes which breaks set operations. Since we want to do set operations in a case
+        # insensitive manner, we make the expect_column_set case insensitive.
+        expected_column_set = _make_case_insensitive_set(
+            self._get_success_kwargs().get("column_set")
+        )
+
         actual_column_list = metrics.get("table.columns")
         actual_column_set = set(actual_column_list)
         exact_match = self._get_success_kwargs().get("exact_match")
@@ -469,3 +476,26 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
                 # Passed if there are no items in the missing list
                 else:
                     return return_success
+
+
+def _make_case_insensitive_set(strs: set[str]) -> set[CaseInsensitiveString]:
+    """Creates a set of CaseInsensitiveStrings from a set of strs.
+
+    Args:
+        strs: A set of strs (not CaseInsensitiveStrings).
+
+    Returns:
+        A set of CaseInsensitiveStrings.
+    """
+    # Making a CaseInsentitiveSet data structure would be a more general solution and
+    # if we need to do this type transformation more than once we should make one in
+    # great_expectations/expectations/metrics/util.py.
+    from great_expectations.expectations.metrics.util import CaseInsensitiveString
+
+    case_insensitive_strs = set()
+    for s in strs:
+        if isinstance(s, str) and not isinstance(s, CaseInsensitiveString):
+            case_insensitive_strs.add(CaseInsensitiveString(s))
+        else:
+            raise InvalidSetTypeError("str", type(s))
+    return case_insensitive_strs

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -423,11 +423,9 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
-        breakpoint()
         expected_column_set = _make_column_set_with_execution_engine_type(
             self._get_success_kwargs().get("column_set"), execution_engine
         )
-        breakpoint()
         actual_column_list = metrics.get("table.columns")
         actual_column_set = set(actual_column_list)
         exact_match = self._get_success_kwargs().get("exact_match")

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -497,5 +497,5 @@ def _make_case_insensitive_set(strs: set[str]) -> set[CaseInsensitiveString]:
         if isinstance(s, str) and not isinstance(s, CaseInsensitiveString):
             case_insensitive_strs.add(CaseInsensitiveString(s))
         else:
-            raise InvalidSetTypeError("str", type(s))
+            raise InvalidSetTypeError("str", str(type(s)))
     return case_insensitive_strs

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
@@ -8,6 +8,7 @@ from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.integration.data_sources_and_expectations.test_canonical_expectations import (
     ALL_DATA_SOURCES,
     JUST_PANDAS_DATA_SOURCES,
+    SQL_DATA_SOURCES,
 )
 
 COL_A = "col_a"
@@ -122,7 +123,7 @@ CASE_INSENSITIVE_DATA = pd.DataFrame(
 
 
 @parameterize_batch_for_data_sources(
-    data_source_configs=ALL_DATA_SOURCES, data=CASE_INSENSITIVE_DATA
+    data_source_configs=SQL_DATA_SOURCES, data=CASE_INSENSITIVE_DATA
 )
 def test_case_insensitive_success(batch_for_datasource: Batch) -> None:
     expectation = gxe.ExpectTableColumnsToMatchSet(column_set=["COLUMN_A", "column_b", "COLumN_c"])

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
@@ -109,3 +109,22 @@ def test_success_with_suite_param_exact_match_(
         expectation, expectation_parameters={suite_param_key: suite_param_value}
     )
     assert result.success == expected_result
+
+
+# Case insenstivity tests
+CASE_INSENSITIVE_DATA = pd.DataFrame(
+    {
+        "column_a": [1],
+        "COLUMN_B": [2],
+        "CoLuMn_C": [3],
+    }
+)
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=ALL_DATA_SOURCES, data=CASE_INSENSITIVE_DATA
+)
+def test_case_insensitive_success(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectTableColumnsToMatchSet(column_set=["COLUMN_A", "column_b", "COLumN_c"])
+    result = batch_for_datasource.validate(expectation)
+    assert result.success

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_table_columns_to_match_set.py
@@ -8,8 +8,12 @@ from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.integration.data_sources_and_expectations.test_canonical_expectations import (
     ALL_DATA_SOURCES,
     JUST_PANDAS_DATA_SOURCES,
-    SQL_DATA_SOURCES,
 )
+from tests.integration.test_utils.data_source_config.databricks import (
+    DatabricksDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.postgres import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.snowflake import SnowflakeDatasourceTestConfig
 
 COL_A = "col_a"
 COL_B = "col_b"
@@ -123,7 +127,12 @@ CASE_INSENSITIVE_DATA = pd.DataFrame(
 
 
 @parameterize_batch_for_data_sources(
-    data_source_configs=SQL_DATA_SOURCES, data=CASE_INSENSITIVE_DATA
+    data_source_configs=[
+        PostgreSQLDatasourceTestConfig(),
+        DatabricksDatasourceTestConfig(),
+        SnowflakeDatasourceTestConfig(),
+    ],
+    data=CASE_INSENSITIVE_DATA,
 )
 def test_case_insensitive_success(batch_for_datasource: Batch) -> None:
     expectation = gxe.ExpectTableColumnsToMatchSet(column_set=["COLUMN_A", "column_b", "COLumN_c"])


### PR DESCRIPTION
We currently only explicitly use our`CaseInsensitiveString` for 3 dialects: postgresql, databricks sql, and snowflake. I've validated with databricks that the following expectations, which I believe are all but 1 of consumers of the metrics `table.column_types` and `table.columns`, are case insensitive:
```
expect_table_columns_to_match_ordered_list
expect_column_values_to_be_in_type_list
expect_column_to_exist
expect_table_column_count_to_be_between
expect_column_values_to_be_of_type
```

The last expectation,  `ExpectTableColumnsToMatchSet`, is case sensitive because a string and an equivalent `CaseInsensitiveString` don't necessarily hash to the same value which breaks set operations. This fixes the validation logic in that expectation to account for this.

I will likely follow this up with a more general solution to fix sql datasources more broadly.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
