### PR TITLE
[MAINTENANCE] Remove TableFactory from cloud e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ assets/docker/mercury/volume/
 
 # cursor
 .cursor/
+
+# mise
+mise.toml

--- a/tests/integration/cloud/end_to_end/conftest.py
+++ b/tests/integration/cloud/end_to_end/conftest.py
@@ -4,7 +4,7 @@ import logging
 import os
 import pathlib
 import uuid
-from typing import TYPE_CHECKING, Final, Generator, Iterator, Literal, Protocol
+from typing import TYPE_CHECKING, Final, Generator, Iterator
 
 import numpy as np
 import pandas as pd
@@ -13,17 +13,15 @@ import pytest
 import great_expectations as gx
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.checkpoint import Checkpoint
-from great_expectations.compatibility.sqlalchemy import TextClause
 from great_expectations.core import ExpectationSuite
 from great_expectations.data_context import CloudDataContext
 from great_expectations.execution_engine import (
     SparkDFExecutionEngine,
-    SqlAlchemyExecutionEngine,
 )
 from great_expectations.expectations import ExpectColumnValuesToNotBeNull
 
 if TYPE_CHECKING:
-    from great_expectations.compatibility import pyspark, sqlalchemy
+    from great_expectations.compatibility import pyspark
 
 LOGGER: Final = logging.getLogger("tests")
 
@@ -107,70 +105,6 @@ def checkpoint(
 @pytest.fixture(scope="module")
 def tmp_path(tmp_path_factory) -> pathlib.Path:
     return tmp_path_factory.mktemp("project")
-
-
-class TableFactory(Protocol):
-    def __call__(
-        self,
-        gx_engine: SqlAlchemyExecutionEngine,
-        table_names: set[str],
-        schema_name: str | None = None,
-    ) -> None: ...
-
-
-@pytest.fixture(scope="module")
-def table_factory() -> Iterator[TableFactory]:
-    """
-    Given a SQLAlchemy engine, table_name and schema,
-    create the table if it does not exist and drop it after the test class.
-    """
-    all_created_tables: dict[str, list[dict[Literal["table_name", "schema_name"], str | None]]] = {}
-    engines: dict[str, sqlalchemy.engine.Engine] = {}
-
-    def _table_factory(
-        gx_engine: SqlAlchemyExecutionEngine,
-        table_names: set[str],
-        schema_name: str | None = None,
-    ) -> None:
-        sa_engine = gx_engine.engine
-        LOGGER.info(
-            f"Creating `{sa_engine.dialect.name}` table for {table_names} if it does not exist"
-        )
-        created_tables: list[dict[Literal["table_name", "schema_name"], str | None]] = []
-
-        with gx_engine.get_connection() as conn:
-            transaction = conn.begin()
-            if schema_name:
-                conn.execute(TextClause(f"CREATE SCHEMA IF NOT EXISTS {schema_name}"))
-            for name in table_names:
-                qualified_table_name = f"{schema_name}.{name}" if schema_name else name
-                create_tables: str = (
-                    f"CREATE TABLE IF NOT EXISTS {qualified_table_name}"
-                    f" (id INTEGER, name VARCHAR(255), value INTEGER)"
-                )
-                conn.execute(TextClause(create_tables))
-
-                created_tables.append(dict(table_name=name, schema_name=schema_name))
-            transaction.commit()
-        all_created_tables[sa_engine.dialect.name] = created_tables
-        engines[sa_engine.dialect.name] = sa_engine
-
-    yield _table_factory
-
-    # teardown
-    for dialect, tables in all_created_tables.items():
-        engine = engines[dialect]
-        with engine.connect() as conn:
-            transaction = conn.begin()
-            schema: str | None = None
-            for table in tables:
-                name = table["table_name"]
-                schema = table["schema_name"]
-                qualified_table_name = f"{schema}.{name}" if schema else name
-                conn.execute(TextClause(f"DROP TABLE IF EXISTS {qualified_table_name}"))
-            if schema:
-                conn.execute(TextClause(f"DROP SCHEMA IF EXISTS {schema}"))
-            transaction.commit()
 
 
 def construct_spark_df_from_pandas(

--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -1,123 +1,46 @@
 from __future__ import annotations
 
-import os
 import uuid
-from typing import TYPE_CHECKING, Final, Generator
+from typing import TYPE_CHECKING
 
-import pytest
+import pandas as pd
 
 from great_expectations import ValidationDefinition
-from great_expectations.core.batch_definition import BatchDefinition
+from great_expectations.checkpoint import Checkpoint
+from great_expectations.core import ExpectationSuite
+from great_expectations.expectations import ExpectColumnValuesToNotBeNull
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config.snowflake import SnowflakeDatasourceTestConfig
 
 if TYPE_CHECKING:
-    from great_expectations.checkpoint.checkpoint import Checkpoint, CheckpointResult
-    from great_expectations.core import ExpectationSuite
-    from great_expectations.data_context import CloudDataContext
-    from great_expectations.datasource.fluent import (
-        DataAsset,
-        SnowflakeDatasource,
-    )
-    from great_expectations.datasource.fluent.sql_datasource import TableAsset
-    from tests.integration.cloud.end_to_end.conftest import TableFactory
-
-RANDOM_SCHEMA: Final[str] = f"i{uuid.uuid4().hex}"
+    from great_expectations.checkpoint.checkpoint import CheckpointResult
 
 
-@pytest.fixture(scope="module")
-def connection_string() -> str:
-    if os.getenv("SNOWFLAKE_CI_USER_PASSWORD") and os.getenv("SNOWFLAKE_CI_ACCOUNT"):
-        return (
-            "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@oca29081.us-east-1/ci"
-            f"/{RANDOM_SCHEMA}?warehouse=ci&role=ci"
+@parameterize_batch_for_data_sources(
+    data_source_configs=[SnowflakeDatasourceTestConfig()],
+    data=pd.DataFrame({"test_e2e_sf": [1, 2]}),
+)
+def test_checkpoint_run(batch_for_datasource):
+    """Test running a Checkpoint end-to-end"""
+    context = batch_for_datasource.datasource.data_context
+    expectation_suite = context.suites.add(
+        ExpectationSuite(
+            name=f"es_{uuid.uuid4().hex}",
+            expectations=[ExpectColumnValuesToNotBeNull(column="test_e2e_sf", mostly=1)],
         )
-    elif os.getenv("SNOWFLAKE_USER") and os.getenv("SNOWFLAKE_CI_ACCOUNT"):
-        return (
-            "snowflake://${SNOWFLAKE_USER}@oca29081.us-east-1/DEMO_DB"
-            f"/{RANDOM_SCHEMA}?warehouse=COMPUTE_WH&role=PUBLIC&authenticator=externalbrowser"
-        )
-    else:
-        pytest.skip("no snowflake credentials")
-
-
-@pytest.fixture(scope="module")
-def datasource(
-    context: CloudDataContext,
-    datasource_name: str,
-    connection_string: str,
-) -> SnowflakeDatasource:
-    """Test Adding and Updating the Datasource associated with this module.
-    Note: There is no need to test Get or Delete Datasource.
-    Those assertions can be found in the datasource_name fixture."""
-    datasource = context.data_sources.add_snowflake(
-        name=datasource_name,
-        connection_string=connection_string,
-        create_temp_table=False,
     )
-    return datasource
-
-
-@pytest.fixture(scope="module")
-def data_asset(
-    datasource: SnowflakeDatasource,
-    table_factory: TableFactory,
-) -> Generator[DataAsset, None, None]:
-    """Test the entire Data Asset CRUD lifecycle here and in Data Asset-specific fixtures."""
-    asset_name = f"da_{uuid.uuid4().hex}"
-    table_name = f"i{uuid.uuid4().hex}"
-    table_factory(
-        gx_engine=datasource.get_execution_engine(),
-        table_names={table_name},
-        schema_name=RANDOM_SCHEMA,
-    )
-    yield datasource.add_table_asset(
-        name=asset_name,
-        table_name=table_name,
-    )
-    datasource.delete_asset(name=asset_name)
-    with pytest.raises(LookupError):
-        datasource.get_asset(name=asset_name)
-
-
-@pytest.fixture(scope="module")
-def batch_definition(
-    context: CloudDataContext,
-    data_asset: TableAsset,
-) -> BatchDefinition:
-    batch_def_name = f"batch_def_{uuid.uuid4().hex}"
-    return data_asset.add_batch_definition_whole_table(
-        name=batch_def_name,
-    )
-
-
-@pytest.fixture(scope="module")
-def validation_definition(
-    context: CloudDataContext,
-    expectation_suite: ExpectationSuite,
-    batch_definition: BatchDefinition,
-) -> Generator[ValidationDefinition, None, None]:
-    validation_def_name = f"val_def_{uuid.uuid4().hex}"
-    yield context.validation_definitions.add(
+    validation_definition = context.validation_definitions.add(
         ValidationDefinition(
-            name=validation_def_name,
-            data=batch_definition,
+            name=f"val_def_{uuid.uuid4().hex}",
+            data=batch_for_datasource.data_asset.batch_definitions[0],
             suite=expectation_suite,
         )
     )
-    context.validation_definitions.delete(name=validation_def_name)
-
-
-@pytest.fixture(scope="module")
-def checkpoint(
-    checkpoint: Checkpoint,
-    validation_definition: ValidationDefinition,
-) -> Checkpoint:
-    checkpoint.validation_definitions = [validation_definition]
-    checkpoint.save()
-    return checkpoint
-
-
-@pytest.mark.cloud
-def test_checkpoint_run(checkpoint: Checkpoint):
-    """Test running a Checkpoint that was created using the entities defined in this module."""
+    checkpoint = context.checkpoints.add(
+        Checkpoint(
+            name=f"E2E Test Checkpoint {uuid.uuid4().hex}",
+            validation_definitions=[validation_definition],
+        )
+    )
     checkpoint_result: CheckpointResult = checkpoint.run()
     assert checkpoint_result.success


### PR DESCRIPTION
Refactors Snowflake E2E Cloud tests to use the `@parameterize_batch_for_data_sources` decorator instead of `table_factory: TableFactory` to better leverage the connection pooling and table management (setup, teardown) of the decorator.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
