### PR TITLE
[DOCS] Correct forecasted range caveat

### DIFF
--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -134,7 +134,7 @@ When you select your `n` run count, and:
 
 Forecasted ranges are determined by GX Cloud through a continuous learning algorithm that analyzes historical patterns in your data. For example, a forecasted range for volume Anomaly Detection could detect a sudden increase when volume has been stable or stagnation in a season when volume typically grows. GX Cloud sets and updates forecasted range parameters on your behalf. 
 
-Expectations with forecasted ranges will neither pass nor fail until there have been at least 2 validation runs. This is because GX Cloud needs at least 2 data points to produce a forecast.
+Expectations with forecasted ranges will always succeed for the first 2 validation runs. This is because GX Cloud needs at least 2 data points to produce a forecast.
 
 ## Expectation condition
 


### PR DESCRIPTION
This issueless PR corrects a statement about forecasted ranges as raised by @sujensen in a DM.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
