### PR TITLE
[MAINTENANCE] pandas pin -- compile sqla objects without unpinning pandas

### DIFF
--- a/great_expectations/compatibility/sqlalchemy_and_pandas.py
+++ b/great_expectations/compatibility/sqlalchemy_and_pandas.py
@@ -76,7 +76,20 @@ def pandas_read_sql(sql, con, **kwargs) -> pd.DataFrame | Iterator[pd.DataFrame]
             warnings.filterwarnings(action="ignore", category=DeprecationWarning)
             return_value = pd.read_sql(sql=sql, con=con, **kwargs)
     else:
-        if not sql.supports_execution:
-            sql = sa.select(sa.text("*")).select_from(sql)
+        # For pandas 2.0+, we need to handle SQLAlchemy objects more carefully
+        if sa and hasattr(sql, '__class__') and hasattr(sql.__class__, '__module__'):
+            # Check if this is a SQLAlchemy object
+            if 'sqlalchemy' in sql.__class__.__module__:
+                # For SQLAlchemy objects, we need to compile them to string
+                if hasattr(sql, 'compile'):
+                    # Compile the SQL statement to a string
+                    compiled = sql.compile(compile_kwargs={"literal_binds": True})
+                    sql = str(compiled)
+                elif hasattr(sql, '__str__'):
+                    # Fallback to string conversion
+                    sql = str(sql)
+        
+        # For pandas 2.0+, pass objects as-is and let pandas handle them
+        # The main fix is ensuring SQL objects are compiled to strings
         return_value = pd.read_sql(sql=sql, con=con, **kwargs)
     return return_value

--- a/great_expectations/compatibility/sqlalchemy_and_pandas.py
+++ b/great_expectations/compatibility/sqlalchemy_and_pandas.py
@@ -77,18 +77,18 @@ def pandas_read_sql(sql, con, **kwargs) -> pd.DataFrame | Iterator[pd.DataFrame]
             return_value = pd.read_sql(sql=sql, con=con, **kwargs)
     else:
         # For pandas 2.0+, we need to handle SQLAlchemy objects more carefully
-        if sa and hasattr(sql, '__class__') and hasattr(sql.__class__, '__module__'):
+        if sa and hasattr(sql, "__class__") and hasattr(sql.__class__, "__module__"):
             # Check if this is a SQLAlchemy object
-            if 'sqlalchemy' in sql.__class__.__module__:
+            if "sqlalchemy" in sql.__class__.__module__:
                 # For SQLAlchemy objects, we need to compile them to string
-                if hasattr(sql, 'compile'):
+                if hasattr(sql, "compile"):
                     # Compile the SQL statement to a string
                     compiled = sql.compile(compile_kwargs={"literal_binds": True})
                     sql = str(compiled)
-                elif hasattr(sql, '__str__'):
+                elif hasattr(sql, "__str__"):
                     # Fallback to string conversion
                     sql = str(sql)
-        
+
         # For pandas 2.0+, pass objects as-is and let pandas handle them
         # The main fix is ensuring SQL objects are compiled to strings
         return_value = pd.read_sql(sql=sql, con=con, **kwargs)

--- a/great_expectations/expectations/metrics/table_metrics/table_head.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_head.py
@@ -75,12 +75,13 @@ class TableHead(TableMetricProvider):
         if metric_value_kwargs["fetch_all"]:
             limit = None
 
-        selectable = sa.select("*").select_from(selectable).limit(limit).selectable  # type: ignore[assignment,arg-type] # FIXME CoP
+        # Create a select statement with limit applied
+        limited_selectable = sa.select("*").select_from(selectable).limit(limit)
 
         try:
             with execution_engine.get_connection() as con:
                 df = pandas_read_sql(
-                    sql=selectable,
+                    sql=limited_selectable,
                     con=con,
                 )
         except StopIteration:


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
