### PR TITLE
[MAINTENANCE] Add typing extensions dependency to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "versioneer"]
+requires = ["setuptools", "wheel", "versioneer", "typing_extensions>=4.1.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]


### PR DESCRIPTION
- The build is failing because `versioneer.py` doesn't have access to `typing_extensions`: https://github.com/great-expectations/great_expectations/actions/runs/16626349819/job/47051128529
- Not sure why this didn't fail before, but this is the solution for the issue we see now. `typing_extensions` was likely cached/installed in the build environment for some other reason since the import was added (2 months ago).
-------------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
