### PR TITLE
[MAINTENANCE] Update build commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -994,16 +994,14 @@ jobs:
       - name: Update pip
         run: python -m pip install --upgrade pip
 
-      - name: Install Twine and Wheel, and prepare packaging
+      - name: Install build tools and prepare packaging
         run: |
-          pip install twine wheel
+          pip install twine build
           git config --global user.email "team@greatexpectations.io"
           git config --global user.name "Great Expectations"
 
       - name: Build distribution
-        run: |
-          python setup.py sdist
-          python setup.py bdist_wheel
+        run: python -m build
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What
- Update packaging commands due to a failing distribution step in the release build
- The packaging is failing because it doesn't have `typing_extensions` installed in that CI stage
- For replacement commands, see the table at the bottom of [this in-depth article](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html) about not invoking `setup.py` directly

## Why
- [The modern way to build a python wheel and tarball](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#packaging-your-project) is via the `build` library, not the `wheel` library.
- The `build` command will create both .tgz and .whl files by default.
- The `build` command will use the [pyproject.toml build-system dependencies](https://github.com/great-expectations/great_expectations/blob/e9e1300738351b3c34f19f8c86a6a36f3820be38/pyproject.toml#L2), as opposed to specifying the `typing_extensions` dependency in [ci.yml](https://github.com/great-expectations/great_expectations/blob/e9e1300738351b3c34f19f8c86a6a36f3820be38/.github/workflows/ci.yml#L999).
----------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
