### PR TITLE
[BUGFIX] Add ordered_list alias to column_list Pydantic field for ExpectTableColumnsToMatchOrderedList

### DIFF
--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -182,7 +182,8 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
     """  # noqa: E501 # FIXME CoP
 
     column_list: Union[list, set, SuiteParameterDict, None] = pydantic.Field(
-        description=COLUMN_LIST_DESCRIPTION
+        description=COLUMN_LIST_DESCRIPTION,
+        alias="ordered_list"
     )
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -182,8 +182,7 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
     """  # noqa: E501 # FIXME CoP
 
     column_list: Union[list, set, SuiteParameterDict, None] = pydantic.Field(
-        description=COLUMN_LIST_DESCRIPTION,
-        alias="ordered_list"
+        description=COLUMN_LIST_DESCRIPTION, alias="ordered_list"
     )
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {


### PR DESCRIPTION
Add `ordered_list` alias to `column_list` Pydantic field for `ExpectTableColumnsToMatchOrderedList`. This is needed for a front-end change in the Expectation Drawer 


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
