### PR TITLE
[DOCS] env var typo 

### DIFF
--- a/docs/docusaurus/docs/cloud/connect/connect_python.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_python.md
@@ -61,7 +61,7 @@ Environment variables securely store your GX Cloud access credentials.
     ```
 
     :::note Note
-   After you save your **GX_CLOUD_ACCESS_TOKEN** and **GX_CLOUD_ORGANIZTION_ID**, you can use Python scripts to access GX Cloud and complete other tasks. See the [API reference](/reference/index.md).
+   After you save your **GX_CLOUD_ACCESS_TOKEN** and **GX_CLOUD_ORGANIZATION_ID**, you can use Python scripts to access GX Cloud and complete other tasks. See the [API reference](/reference/index.md).
     :::
 
 2. Optional. If you created a temporary file to record your user access token and Organization ID, delete it.


### PR DESCRIPTION
This issueless PR fixes a typo raised in slack https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1754670749074509 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [X] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
