### PR TITLE
[FEATURE] Update JSON schemas for Expectations to incorporate failure severity

### DIFF
--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -242,6 +251,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -242,6 +251,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -242,6 +251,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -270,6 +279,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -236,6 +245,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -236,6 +245,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -236,6 +245,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -236,6 +245,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -254,6 +263,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -222,6 +231,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -211,6 +220,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -230,6 +239,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -223,6 +232,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -237,6 +246,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -198,6 +207,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -220,6 +229,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -236,6 +245,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnToExist.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -168,6 +177,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -237,6 +246,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -236,6 +245,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -199,6 +208,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -212,6 +221,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -252,6 +261,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -258,6 +267,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -197,6 +206,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -186,6 +195,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -199,6 +208,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -186,6 +195,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -197,6 +206,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -217,6 +226,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -197,6 +206,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -217,6 +226,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -258,6 +267,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -186,6 +195,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -196,6 +205,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -199,6 +208,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -196,6 +205,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -199,6 +208,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -198,6 +207,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -219,6 +228,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectQueryResultsToMatchComparison.json
+++ b/great_expectations/expectations/core/schemas/ExpectQueryResultsToMatchComparison.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -182,6 +191,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -201,6 +210,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -187,6 +196,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnCountToEqual.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -162,6 +171,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchOrderedList.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -165,6 +174,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableColumnsToMatchSet.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -178,6 +187,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -219,6 +228,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -176,6 +185,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -174,6 +183,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
+++ b/great_expectations/expectations/core/schemas/UnexpectedRowsExpectation.json
@@ -54,6 +54,15 @@
                 "type": "object"
             }
         },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
         "windows": {
             "title": "Windows",
             "description": "Definition(s) for evaluation of temporal windows",
@@ -142,6 +151,16 @@
                 "BASIC",
                 "COMPLETE",
                 "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
             ],
             "type": "string"
         },

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -44,7 +44,6 @@ from great_expectations.core.metric_function_types import (
     SummarizationMetricNameSuffixes,
 )
 from great_expectations.core.result_format import ResultFormat
-from great_expectations.expectations.metadata_types import FailureSeverity
 from great_expectations.core.suite_parameters import (
     get_suite_parameter_key,
     is_suite_parameter,
@@ -58,6 +57,7 @@ from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
     parse_result_format,
 )
+from great_expectations.expectations.metadata_types import FailureSeverity
 from great_expectations.expectations.model_field_descriptions import (
     COLUMN_A_DESCRIPTION,
     COLUMN_B_DESCRIPTION,
@@ -322,8 +322,6 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                 },
             }
 
-
-
             # Add extra fields to schema from custom schema_overrides
             # schema_overrides is not a pydantic concept, but pydantic.Field allows
             # us to pass through arbitrary fields.
@@ -344,7 +342,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     rendered_content: Optional[List[RenderedAtomicContent]] = None
     severity: FailureSeverity = pydantic.Field(
         default=FailureSeverity.CRITICAL,
-        description="Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions."
+        description="Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
     )
 
     version: ClassVar[str] = ge_version

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -342,7 +342,10 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     rendered_content: Optional[List[RenderedAtomicContent]] = None
     severity: FailureSeverity = pydantic.Field(
         default=FailureSeverity.CRITICAL,
-        description="Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+        description=(
+            "Indicate the impact of this Expectation failing. Severity levels can be "
+            "used to trigger different alerting patterns and actions."
+        ),
     )
 
     version: ClassVar[str] = ge_version

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -44,6 +44,7 @@ from great_expectations.core.metric_function_types import (
     SummarizationMetricNameSuffixes,
 )
 from great_expectations.core.result_format import ResultFormat
+from great_expectations.expectations.metadata_types import FailureSeverity
 from great_expectations.core.suite_parameters import (
     get_suite_parameter_key,
     is_suite_parameter,
@@ -321,6 +322,8 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                 },
             }
 
+
+
             # Add extra fields to schema from custom schema_overrides
             # schema_overrides is not a pydantic concept, but pydantic.Field allows
             # us to pass through arbitrary fields.
@@ -339,6 +342,10 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
 
     catch_exceptions: bool = False
     rendered_content: Optional[List[RenderedAtomicContent]] = None
+    severity: FailureSeverity = pydantic.Field(
+        default=FailureSeverity.CRITICAL,
+        description="Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions."
+    )
 
     version: ClassVar[str] = ge_version
     domain_keys: ClassVar[Tuple[str, ...]] = ()

--- a/great_expectations/expectations/metadata_types.py
+++ b/great_expectations/expectations/metadata_types.py
@@ -31,3 +31,11 @@ class SupportedDataSources(str, Enum):
     CITUS = "Citus"
     ALLOY = "AlloyDB"
     NEON = "Neon"
+
+
+class FailureSeverity(str, Enum):
+    """Severity levels for expectation failures."""
+
+    CRITICAL = "critical"
+    WARNING = "warning"
+    INFO = "info"

--- a/tests/expectations/core/test_expectation_serialization.py
+++ b/tests/expectations/core/test_expectation_serialization.py
@@ -60,10 +60,7 @@ from great_expectations.expectations.window import Offset, Window
                         constraint_fn="a",
                         parameter_name="b",
                         range=5,
-                        offset=Offset(
-                            positive=0.2, 
-                            negative=0.2
-                        ),
+                        offset=Offset(positive=0.2, negative=0.2),
                     )
                 ],
             ),

--- a/tests/expectations/core/test_expectation_serialization.py
+++ b/tests/expectations/core/test_expectation_serialization.py
@@ -68,9 +68,10 @@ from great_expectations.expectations.window import Offset, Window
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
                 '"severity": "critical", "windows": [{"constraint_fn": "a", '
-                '"parameter_name": "b", "offset": {"positive": 0.2, "negative": 0.2}, '
-                '"strict": false}], "range": 5, "batch_id": null, "column": "test_column", '
-                '"mostly": 0.82, "row_condition": null, "condition_parser": null}'
+                '"parameter_name": "b", "range": 5, "offset": {"positive": 0.2, '
+                '"negative": 0.2}, "strict": false}], "batch_id": null, '
+                '"column": "test_column", "mostly": 0.82, "row_condition": null, '
+                '"condition_parser": null}'
             ),
         ),
     ],

--- a/tests/expectations/core/test_expectation_serialization.py
+++ b/tests/expectations/core/test_expectation_serialization.py
@@ -20,9 +20,9 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": false, "rendered_content": null, '
-                '"severity": "critical", "windows": null, "batch_id": null, "column": "test_column", '
-                '"row_condition": null, "condition_parser": null, "min_value": 1.0, '
-                '"max_value": null, "strict_min": false, "strict_max": false}'
+                '"severity": "critical", "windows": null, "batch_id": null, '
+                '"column": "test_column", "row_condition": null, "condition_parser": null, '
+                '"min_value": 1.0, "max_value": null, "strict_min": false, "strict_max": false}'
             ),
         ),
         (
@@ -33,8 +33,9 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
-                '"severity": "critical", "windows": null, "batch_id": null, "column": "test_column", '
-                '"mostly": 0.82, "row_condition": null, "condition_parser": null}'
+                '"severity": "critical", "windows": null, "batch_id": null, '
+                '"column": "test_column", "mostly": 0.82, "row_condition": null, '
+                '"condition_parser": null}'
             ),
         ),
         (
@@ -59,17 +60,20 @@ from great_expectations.expectations.window import Offset, Window
                         constraint_fn="a",
                         parameter_name="b",
                         range=5,
-                        offset=Offset(positive=0.2, negative=0.2),
+                        offset=Offset(
+                            positive=0.2, 
+                            negative=0.2
+                        ),
                     )
                 ],
             ),
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
-                '"severity": "critical", "windows": [{"constraint_fn": "a", "parameter_name": "b", '
-                '"offset": {"positive": 0.2, "negative": 0.2}, "strict": false}], '
-                '"range": 5, "batch_id": null, "column": "test_column", "mostly": 0.82, '
-                '"row_condition": null, "condition_parser": null}'
+                '"severity": "critical", "windows": [{"constraint_fn": "a", '
+                '"parameter_name": "b", "offset": {"positive": 0.2, "negative": 0.2}, '
+                '"strict": false}], "range": 5, "batch_id": null, "column": "test_column", '
+                '"mostly": 0.82, "row_condition": null, "condition_parser": null}'
             ),
         ),
     ],

--- a/tests/expectations/core/test_expectation_serialization.py
+++ b/tests/expectations/core/test_expectation_serialization.py
@@ -20,7 +20,7 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": false, "rendered_content": null, '
-                '"windows": null, "batch_id": null, "column": "test_column", '
+                '"severity": "critical", "windows": null, "batch_id": null, "column": "test_column", '
                 '"row_condition": null, "condition_parser": null, "min_value": 1.0, '
                 '"max_value": null, "strict_min": false, "strict_max": false}'
             ),
@@ -33,8 +33,8 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
-                '"windows": null, "batch_id": null, "column": "test_column", "mostly": 0.82, '
-                '"row_condition": null, "condition_parser": null}'
+                '"severity": "critical", "windows": null, "batch_id": null, "column": "test_column", '
+                '"mostly": 0.82, "row_condition": null, "condition_parser": null}'
             ),
         ),
         (
@@ -45,8 +45,8 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": "Data shouldn\'t be bad.", "catch_exceptions": false, '
-                '"rendered_content": null, "windows": null, "batch_id": null, '
-                '"unexpected_rows_query": "SELECT * FROM '
+                '"rendered_content": null, "severity": "critical", "windows": null, '
+                '"batch_id": null, "unexpected_rows_query": "SELECT * FROM '
                 "my_table WHERE data='bad'\"}"
             ),
         ),
@@ -66,9 +66,9 @@ from great_expectations.expectations.window import Offset, Window
             (
                 '{"id": null, "meta": null, "notes": null, "result_format": "BASIC", '
                 '"description": null, "catch_exceptions": true, "rendered_content": null, '
-                '"windows": [{"constraint_fn": "a", "parameter_name": "b", "range": 5, '
+                '"severity": "critical", "windows": [{"constraint_fn": "a", "parameter_name": "b", '
                 '"offset": {"positive": 0.2, "negative": 0.2}, "strict": false}], '
-                '"batch_id": null, "column": "test_column", "mostly": 0.82, '
+                '"range": 5, "batch_id": null, "column": "test_column", "mostly": 0.82, '
                 '"row_condition": null, "condition_parser": null}'
             ),
         ),


### PR DESCRIPTION
Add a new `FailureSeverity` enum to capture the idea of Expectation failure severity. Update JSON schemas to reflect the new `severity` field. 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
