### PR TITLE
[MAINTENANCE] Update ports that mercury runs on

### DIFF
--- a/assets/docker/mercury/docker-compose.yml
+++ b/assets/docker/mercury/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     platform: linux/amd64
     restart: always
     ports:
-      - 5001:5000
+      - 6001:6001
     environment:
       LOGGING_LEVEL: ${LOGGING_LEVEL}
       ENVIRONMENT: ${ENVIRONMENT}
@@ -72,7 +72,7 @@ services:
         python -m tests.utils.dev_db_seed_script
         gunicorn mercury.api:get_app\(\) --config ./gunicorn.conf.py --workers=1
     healthcheck:
-      test: bash -c ':> /dev/tcp/0.0.0.0/5000' || exit 1
+      test: bash -c ':> /dev/tcp/0.0.0.0/6001' || exit 1
       interval: 5s
       timeout: 2s
       retries: 20
@@ -86,7 +86,7 @@ services:
     platform: linux/amd64
     restart: always
     ports:
-      - 7000:7000
+      - 6002:6002
     environment:
       LOGGING_LEVEL: ${LOGGING_LEVEL}
       ENVIRONMENT: ${ENVIRONMENT}

--- a/assets/docker/mercury/nginx.conf
+++ b/assets/docker/mercury/nginx.conf
@@ -2,11 +2,11 @@ events {}
 
 http {
     upstream mercury-service-api {
-        server mercury-service-api:5000;
+        server mercury-service-api:6001;
     }
 
     upstream mercury-service-api-v1 {
-        server mercury-service-api-v1:7000;
+        server mercury-service-api-v1:6002;
     }
 
 


### PR DESCRIPTION
Update the ports for the cloud tests to the new ports

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
