### PR TITLE
[BUGFIX] Make handling of quoted schema and table names more robust

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1061,7 +1061,9 @@ class TableAsset(_SQLAsset):
         # we need to ensure we retain the quotes when serializing quoted names
         qc = self._quote_character
         if qc is not None:
-            original_dict["table_name"] = f"{qc}{self.table_name}{DEFAULT_FINAL_QUOTE_CHARACTERS[qc]}"
+            original_dict["table_name"] = (
+                f"{qc}{self.table_name}{DEFAULT_FINAL_QUOTE_CHARACTERS[qc]}"
+            )
 
         return original_dict
 

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -14,6 +14,7 @@ from typing import (
     Generic,
     List,
     Literal,
+    Mapping,
     Optional,
     Protocol,
     Sequence,
@@ -94,7 +95,13 @@ if TYPE_CHECKING:
 
 LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
-DEFAULT_QUOTE_CHARACTERS: Final[Tuple[str, str]] = ('"', "'")
+DEFAULT_INITIAL_QUOTE_CHARACTERS: Final[Tuple[str, str, str, str]] = ('"', "'", "`", "[")
+DEFAULT_FINAL_QUOTE_CHARACTERS: Final[Mapping[str, str]] = {
+    '"': '"',
+    "'": "'",
+    "`": "`",
+    "[": "]",
+}
 
 
 @overload
@@ -107,7 +114,7 @@ def to_lower_if_not_quoted(value: None, quote_characters: Sequence[str] = ...) -
 
 def to_lower_if_not_quoted(
     value: str | None,
-    quote_characters: Sequence[str] = DEFAULT_QUOTE_CHARACTERS,
+    quote_characters: Sequence[str] = DEFAULT_INITIAL_QUOTE_CHARACTERS,
 ) -> str | None:
     """
     Convert a string to lowercase if it is not enclosed in quotes.
@@ -115,7 +122,7 @@ def to_lower_if_not_quoted(
     if not value:
         return value
     for char in quote_characters:
-        if value.startswith(char) and value.endswith(char):
+        if value.startswith(char) and value.endswith(DEFAULT_FINAL_QUOTE_CHARACTERS[char]):
             LOGGER.warning(
                 f"The {value} string is bracketed by quotes,"
                 " so it will not be converted to lowercase."
@@ -1036,7 +1043,9 @@ class TableAsset(_SQLAsset):
                 # TODO: We need to handle nested quotes
                 values["_quote_character"] = table_name[0]
                 quote = True
-                table_name = table_name.strip("".join(DEFAULT_QUOTE_CHARACTERS))
+                table_name = table_name.lstrip("".join(DEFAULT_INITIAL_QUOTE_CHARACTERS)).rstrip(
+                    "".join(DEFAULT_FINAL_QUOTE_CHARACTERS.values())
+                )
 
             return sqlalchemy.quoted_name(
                 value=table_name,
@@ -1052,7 +1061,7 @@ class TableAsset(_SQLAsset):
         # we need to ensure we retain the quotes when serializing quoted names
         qc = self._quote_character
         if qc is not None:
-            original_dict["table_name"] = f"{qc}{self.table_name}{qc}"
+            original_dict["table_name"] = f"{qc}{self.table_name}{DEFAULT_FINAL_QUOTE_CHARACTERS[qc]}"
 
         return original_dict
 
@@ -1122,8 +1131,8 @@ class TableAsset(_SQLAsset):
             True if the target string is bracketed by quotes.
         """
         return any(
-            target.startswith(quote) and target.endswith(quote)
-            for quote in DEFAULT_QUOTE_CHARACTERS
+            target.startswith(quote) and target.endswith(DEFAULT_FINAL_QUOTE_CHARACTERS[quote])
+            for quote in DEFAULT_INITIAL_QUOTE_CHARACTERS
         )
 
     @classmethod
@@ -1137,7 +1146,7 @@ class TableAsset(_SQLAsset):
         Returns:
             The target string in lowercase if it is not bracketed by quotes.
         """
-        return to_lower_if_not_quoted(target, quote_characters=DEFAULT_QUOTE_CHARACTERS)
+        return to_lower_if_not_quoted(target, quote_characters=DEFAULT_INITIAL_QUOTE_CHARACTERS)
 
 
 def _warn_for_more_specific_datasource_type(connection_string: str) -> None:

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -13,7 +13,7 @@ from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.datasource.fluent import GxDatasourceWarning, SQLDatasource
 from great_expectations.datasource.fluent.sql_datasource import (
-    DEFAULT_QUOTE_CHARACTERS,
+    DEFAULT_INITIAL_QUOTE_CHARACTERS,
     TableAsset,
     to_lower_if_not_quoted,
 )
@@ -340,19 +340,20 @@ def test_specific_datasource_warnings(
 @pytest.mark.parametrize(
     ["input_", "expected_output", "quote_characters"],
     [
-        ("my_schema", "my_schema", DEFAULT_QUOTE_CHARACTERS),
-        ("MY_SCHEMA", "my_schema", DEFAULT_QUOTE_CHARACTERS),
-        ("My_Schema", "my_schema", DEFAULT_QUOTE_CHARACTERS),
-        ('"my_schema"', '"my_schema"', DEFAULT_QUOTE_CHARACTERS),
-        ('"MY_SCHEMA"', '"MY_SCHEMA"', DEFAULT_QUOTE_CHARACTERS),
-        ('"My_Schema"', '"My_Schema"', DEFAULT_QUOTE_CHARACTERS),
-        ("'my_schema'", "'my_schema'", DEFAULT_QUOTE_CHARACTERS),
-        ("'MY_SCHEMA'", "'MY_SCHEMA'", DEFAULT_QUOTE_CHARACTERS),
-        ("'My_Schema'", "'My_Schema'", DEFAULT_QUOTE_CHARACTERS),
-        (None, None, DEFAULT_QUOTE_CHARACTERS),
-        ("", "", DEFAULT_QUOTE_CHARACTERS),
-        ("`My_Schema`", "`My_Schema`", ("`",)),
-        ("'My_Schema'", "'my_schema'", ("`",)),
+        ("my_schema", "my_schema", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("MY_SCHEMA", "my_schema", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("My_Schema", "my_schema", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ('"my_schema"', '"my_schema"', DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ('"MY_SCHEMA"', '"MY_SCHEMA"', DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ('"My_Schema"', '"My_Schema"', DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'my_schema'", "'my_schema'", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'MY_SCHEMA'", "'MY_SCHEMA'", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'My_Schema'", "'My_Schema'", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        (None, None, DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("", "", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("`My_Schema`", "`My_Schema`", DEFAULT_INITIAL_QUOTE_CHARACTERS),
+        ("'My_Schema'", "'my_schema'", ("`")),
+        ("[My_Schema]", "[My_Schema]", DEFAULT_INITIAL_QUOTE_CHARACTERS),
     ],
     ids=lambda x: str(x),
 )
@@ -405,6 +406,8 @@ class TestTableAsset:
             "'my_schema'",
             "'MY_SCHEMA'",
             "'My_Schema'",
+            "`My_Schema`",
+            "[My_Schema]",
         ],
     )
     def test_quoted_schema_names_are_not_modified(
@@ -430,6 +433,8 @@ class TestTableAsset:
             "'my_table'",
             "'MY_TABLE'",
             "'My_Table'",
+            "`my_table`",
+            "[my_table]",
         ],
     )
     def test_quoted_table_names_are_quoted(
@@ -445,30 +450,42 @@ class TestTableAsset:
             schema_name="my_schema",
         )
         assert isinstance(table_asset.table_name, sqlalchemy.quoted_name)
-        assert table_asset.table_name == table_name.lstrip("\"'").rstrip("\"'")
+        assert table_asset.table_name == table_name[1:-1]
         assert table_asset.table_name.quote
 
     @pytest.mark.parametrize(
-        "table_name",
+        "table_name,serialized_name",
         [
-            '"my_table"',
-            '"MY_TABLE"',
-            '"My_Table"',
-            "'my_table'",
-            "'MY_TABLE'",
-            "'My_Table'",
-            "my_table",
-            "MY_TABLE",
-            "My_Table",
+            pytest.param('"my_table"', '"my_table"'),
+            pytest.param('"MY_TABLE"', '"MY_TABLE"'),
+            pytest.param('"My_Table"', '"My_Table"'),
+            pytest.param("'my_table'", "'my_table'"),
+            pytest.param("'MY_TABLE'", "'MY_TABLE'"),
+            pytest.param("'My_Table'", "'My_Table'"),
+            pytest.param("[My_Table]", "[My_Table]"),
+            pytest.param("`My_Table`", "`My_Table`"),
+            pytest.param("my_table", "my_table"),
+            pytest.param("MY_TABLE", "MY_TABLE"),
+            pytest.param("My_Table", "My_Table"),
         ],
     )
     def test_table_name_serialization_preserves_quotes(
         self,
         table_name: str,
+        serialized_name: str,
     ):
         table_asset = TableAsset(name="my_table_asset", table_name=table_name)
-        serialized = table_asset.dict()
-        assert serialized["table_name"] == table_name
+
+        with mock.patch(
+            "great_expectations.datasource.fluent.sql_datasource.TableAsset.datasource",
+            new_callable=mock.PropertyMock,
+            return_value=SQLDatasource(
+                name="my_snowflake_datasource",
+                connection_string="snowflake://<user_login_name>:<password>@<account_identifier>/<database_name>/<schema_name>?warehouse=<warehouse_name>&role=<role_name>",
+            ),
+        ):
+            serialized = table_asset.dict()
+            assert serialized["table_name"] == serialized_name
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This expands the characters that can be used to quote table and schema names to correspond to all known data sources. It also utilized SQLA's `IdentifierPreparer` to quote when serializing.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
