### PR TITLE
[BUGFIX] Make workspaces optional for cloud_user_info

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -76,19 +76,7 @@ logger = logging.getLogger(__name__)
 
 class NoUserIdError(Exception):
     def __init__(self):
-        super().__init__("No user id in /account/me response")
-
-
-class NoWorkspacesError(Exception):
-    def __init__(self):
-        super().__init__("No workspaces in /account/me response")
-
-
-class WorkspacesKeyError(Exception):
-    def __init__(self):
-        super().__init__(
-            "Workspaces returned in /account/me response don't have required keys: (id, role)"
-        )
+        super().__init__("No user id in /accounts/me response")
 
 
 class WorkspaceNotSetError(Exception):

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -223,16 +223,11 @@ class CloudDataContext(SerializableDataContext):
         user_id = data.get("user_id") or data.get("id")
         if not user_id:
             raise NoUserIdError()
-        response_workspaces = data.get("workspaces")
-        if not response_workspaces:
-            raise NoWorkspacesError()
-        workspaces = []
-        for response_workspace in response_workspaces:
-            if "id" not in response_workspace or "role" not in response_workspace:
-                raise WorkspacesKeyError()
-            workspaces.append(
-                Workspace(id=response_workspace["id"], role=response_workspace["role"])
-            )
+        response_workspaces = data.get("workspaces", [])
+        workspaces = [
+            Workspace(id=response_workspace["id"], role=response_workspace["role"])
+            for response_workspace in response_workspaces
+        ]
         return CloudUserInfo(user_id=uuid.UUID(user_id), workspaces=workspaces)
 
     def cloud_user_info(self, force_refresh: bool = False) -> CloudUserInfo:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pandas<2.2; python_version >= "3.12"
 posthog>3
 # patch version updates `typing_extensions` to the needed version
 pydantic>=1.10.7
-pyparsing>=2.4
+pyparsing>=2.4,!=3.2.4
 python-dateutil>=2.8.1
 requests>=2.20
 ruamel.yaml>=0.16

--- a/tests/analytics/test_analytics.py
+++ b/tests/analytics/test_analytics.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from unittest import mock
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -315,6 +315,86 @@ def test_analytics_enabled_after_setting_explicitly(
             user_agent_str=mock.ANY,
             mode="ephemeral",
         )
+
+
+@pytest.mark.unit
+def test_cloud_context_init_with_system_user_no_workspaces(
+    unset_gx_env_variables: None,
+    monkeypatch,
+):
+    monkeypatch.setattr(ENV_CONFIG, "gx_analytics_enabled", True)  # Enable usage stats
+
+    user_id = uuid4()
+    organization_id = uuid4()
+    workspace_id = uuid4()
+
+    # Mock cloud API response for system user with no workspaces
+    def mock_request_cloud_backend(*args, **kwargs):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            "user_id": str(user_id),
+            "workspaces": [],
+        }
+        return mock_response
+
+    mock_config = {
+        "cloud_base_url": "https://api.test.greatexpectations.io",
+        "cloud_access_token": "test_token_123",
+        "cloud_organization_id": str(organization_id),
+        "cloud_workspace_id": str(workspace_id),
+    }
+
+    mock_data_context_config = {
+        "config_version": 4.0,
+        "datasources": {},
+        "stores": {},
+        "expectations_store_name": "expectations_store",
+        "validation_results_store_name": "validation_results_store",
+        "checkpoint_store_name": "checkpoint_store",
+        "data_docs_sites": {},
+        "analytics_enabled": True,
+    }
+
+    with (
+        mock.patch(
+            "great_expectations.data_context.data_context.cloud_data_context.CloudDataContext.retrieve_data_context_config_from_cloud",
+            return_value=mock_data_context_config,
+        ),
+        mock.patch(
+            "great_expectations.data_context.data_context.cloud_data_context.CloudDataContext._save_project_config"
+        ),
+        mock.patch(
+            "great_expectations.data_context.data_context.cloud_data_context.CloudDataContext._check_if_latest_version"
+        ),
+        mock.patch(
+            "great_expectations.data_context.data_context.cloud_data_context.CloudDataContext._request_cloud_backend",
+            side_effect=mock_request_cloud_backend,
+        ),
+        mock.patch(
+            "great_expectations.data_context.data_context.cloud_data_context.init_analytics"
+        ) as mock_init,
+        mock.patch("posthog.capture") as mock_submit,
+    ):
+        # This should not raise an error for system users with no workspaces
+        context = gx.get_context(
+            mode="cloud",
+            cloud_base_url=mock_config["cloud_base_url"],
+            cloud_access_token=mock_config["cloud_access_token"],
+            cloud_organization_id=mock_config["cloud_organization_id"],
+            cloud_workspace_id=mock_config["cloud_workspace_id"],
+        )
+
+    # Verify analytics initialization was called with the system user's ID
+    mock_init.assert_called_once_with(
+        enable=True,
+        user_id=user_id,
+        data_context_id=mock.ANY,
+        organization_id=organization_id,
+        oss_id=mock.ANY,
+        cloud_mode=True,
+        mode="cloud",
+        user_agent_str=None,
+    )
 
 
 @pytest.mark.parametrize("initial_user_agent_str", [None, "old user agent string"])

--- a/tests/analytics/test_analytics.py
+++ b/tests/analytics/test_analytics.py
@@ -321,6 +321,7 @@ def test_analytics_enabled_after_setting_explicitly(
 def test_cloud_context_init_with_system_user_no_workspaces(
     unset_gx_env_variables: None,
     monkeypatch,
+    mocker,
 ):
     monkeypatch.setattr(ENV_CONFIG, "gx_analytics_enabled", True)  # Enable usage stats
 
@@ -330,7 +331,7 @@ def test_cloud_context_init_with_system_user_no_workspaces(
 
     # Mock cloud API response for system user with no workspaces
     def mock_request_cloud_backend(*args, **kwargs):
-        mock_response = mock.Mock()
+        mock_response = mocker.MagicMock()
         mock_response.json.return_value = {
             "user_id": str(user_id),
             "workspaces": [],
@@ -373,10 +374,10 @@ def test_cloud_context_init_with_system_user_no_workspaces(
         mock.patch(
             "great_expectations.data_context.data_context.cloud_data_context.init_analytics"
         ) as mock_init,
-        mock.patch("posthog.capture") as mock_submit,
+        mock.patch("posthog.capture"),
     ):
         # This should not raise an error for system users with no workspaces
-        context = gx.get_context(
+        gx.get_context(
             mode="cloud",
             cloud_base_url=mock_config["cloud_base_url"],
             cloud_access_token=mock_config["cloud_access_token"],


### PR DESCRIPTION
The system user (used by the runner) currently gets an error raised because it doesn’t have any associated workspaces. This PR removes the workspaces validation from the `_get_cloud_user_info` function.

`cloud_user_info` is currently used in two places:

- For analytics: We don’t want to raise an error because system users are fine with empty workspaces.
- For regular workspaces paths: There is already a validation for workspaces (https://github.com/great-expectations/great_expectations/blob/264b4e0b8c3c34851d5d0b5722b485458590d298/great_expectations/data_context/data_context/cloud_data_context.py#L175). The system user path doesn’t get to the workspace validation.

Removing the validation from `_get_cloud_user_info` ensures that we don’t block the runner system user from logging analytics when no workspaces exist for a user.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
