### PR TITLE
[BUGFIX] Fix ExpectColumnValuesToBeInTypeList for Trino

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -463,14 +463,24 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             GXSqlDialect.DATABRICKS,
             GXSqlDialect.POSTGRESQL,
             GXSqlDialect.SNOWFLAKE,
+            GXSqlDialect.TRINO,
         ]:
-            success = isinstance(actual_column_type, str) and any(
-                actual_column_type.lower() == expected_type.lower()
-                for expected_type in expected_types_list
-            )
+            if isinstance(actual_column_type, str):
+                success = any(
+                    actual_column_type.lower() == expected_type.lower()
+                    for expected_type in expected_types_list
+                )
+                ret_type = actual_column_type
+            else:
+                ret_type = type(actual_column_type).__name__
+                success = any(
+                    ret_type.lower() == expected_type.lower()
+                    for expected_type in expected_types_list
+                )
+
             return {
                 "success": success,
-                "result": {"observed_value": actual_column_type},
+                "result": {"observed_value": ret_type},
             }
         else:
             types = []


### PR DESCRIPTION
Handle type comparisons with Trino dialect.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
