### PR TITLE
[Docs] Typo fix, tense update

### DIFF
--- a/docs/docusaurus/docs/help/compatibility_reference.md
+++ b/docs/docusaurus/docs/help/compatibility_reference.md
@@ -14,7 +14,7 @@ The following table defines integrations and tools supported by GX Cloud and GX 
 | Orchestrators | Airflow version 2.9.0+ | Airflow version 2.9.0+ | Although only Airflow is supported, GX Cloud and GX Core should work with any orchestrator that executes Python code. |
 | Operating systems | Mac/Linux | Mac/Linux | Though GX does not currently support Windows, we've seen users successfully deploy on Windows. |
 | Python versions | 3.9 to 3.12 | 3.9 to 3.12 | GX typically follows the [Python release cycle](https://devguide.python.org/versions/). |
-| GX library versions | ≥1.0 | ≥1.0 | Support for 0.18 was deprecated October 25, 2024 and will reach end of life on October 1, 2025. |
+| GX library versions | ≥1.0 | ≥1.0 | Support for 0.18 was deprecated October 25, 2024 and reached end of life on October 1, 2025. |
 | Web browsers | [Google Chrome](https://www.google.com/chrome/)<br/>[Mozilla Firefox](https://www.mozilla.org/en-US/firefox/)<br/>[Apple Safari](https://www.apple.com/safari/)<br/>[Microsoft Edge](https://www.microsoft.com/en-us/edge?ep=82&form=MA13KI&es=24) | [Google Chrome](https://www.google.com/chrome/)<br/>[Mozilla Firefox](https://www.mozilla.org/en-US/firefox/)<br/>[Apple Safari](https://www.apple.com/safari/)<br/>[Microsoft Edge](https://www.microsoft.com/en-us/edge?ep=82&form=MA13KI&es=24) | Only the latest version of each browser is supported. |
 
 

--- a/docs/docusaurus/docs/reference/learn/data_quality_use_cases/unstructured_data.md
+++ b/docs/docusaurus/docs/reference/learn/data_quality_use_cases/unstructured_data.md
@@ -95,7 +95,7 @@ In this tutorial, you will connect to your GX Cloud organization using the GX Cl
 ## Validate your Expectations
 GX uses a Validation Definition to link a Batch Definition and Expectation Suite. A Checkpoint will be used to execute Validations. The results of the Validations can be later viewed through the GX Cloud UI.
 
-1. Create the Validation Defintion.
+1. Create the Validation Definition.
 
    ```python title="Python" name="docs/docusaurus/docs/reference/learn/data_quality_use_cases/unstructured_data/unstructured_data.py - create the vd"
    ```


### PR DESCRIPTION
This issueless PR fixes a typo noted in https://github.com/great-expectations/great_expectations/pull/11380#discussion_r2373445114 and updates verb tense in one spot to account for the passage of time. 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
