### PR TITLE
[BUGFIX] ensure snowflake conn str is always transformed to rich type

### DIFF
--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -677,8 +677,6 @@ class SnowflakeDatasource(SQLDatasource):
         return kwargs
 
     class Config:
-        validate_assignment = True
-
         @staticmethod
         def schema_extra(schema: dict, model: type[SnowflakeDatasource]) -> None:
             """

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -677,6 +677,8 @@ class SnowflakeDatasource(SQLDatasource):
         return kwargs
 
     class Config:
+        validate_assignment = True
+
         @staticmethod
         def schema_extra(schema: dict, model: type[SnowflakeDatasource]) -> None:
             """

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1228,6 +1228,9 @@ class SQLDatasource(Datasource):
     _TableAsset: Type[TableAsset] = pydantic.PrivateAttr(TableAsset)
     _QueryAsset: Type[QueryAsset] = pydantic.PrivateAttr(QueryAsset)
 
+    class Config:
+        validate_assignment = True
+
     @property
     @override
     def execution_engine_type(self) -> Type[SqlAlchemyExecutionEngine]:

--- a/tests/datasource/fluent/test_bigquery_datasource.py
+++ b/tests/datasource/fluent/test_bigquery_datasource.py
@@ -4,6 +4,7 @@ import pytest
 
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent import BigQueryDatasource
+from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 
 LOGGER = logging.getLogger(__name__)
@@ -36,3 +37,48 @@ def test_add_bigquery_datasource(
     assert source.name == test_datasource_name
     assert source.execution_engine_type is SqlAlchemyExecutionEngine
     assert source.assets == []
+
+
+@pytest.mark.unit
+def test_connection_updating_templated_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "bigquery://project-id/${MY_DATASET}"
+    datasource = BigQueryDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    # Assign a new templated connection string directly
+    new_conn_str = "bigquery://project-id/${MY_DATASET}".replace("MY_", "NEW_")
+    datasource.connection_string = new_conn_str
+
+    # Verify it's still a ConfigStr after assignment (not a plain str)
+    assert isinstance(datasource.connection_string, ConfigStr), (
+        f"Expected ConfigStr, got {type(datasource.connection_string)}. "
+        "This indicates validate_assignment is not enabled."
+    )
+    assert datasource.connection_string.template_str == new_conn_str
+
+
+@pytest.mark.unit
+def test_connection_updating_plain_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "bigquery://project-id/${MY_DATASET}"
+    datasource = BigQueryDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    plain_conn_str = "bigquery://my-project/my-dataset"
+    datasource.connection_string = plain_conn_str
+    assert isinstance(datasource.connection_string, str), (
+        f"Expected str for plain connection string, got {type(datasource.connection_string)}"
+    )

--- a/tests/datasource/fluent/test_databricks_sql_datasource.py
+++ b/tests/datasource/fluent/test_databricks_sql_datasource.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import pytest
 
 from great_expectations.compatibility import pydantic
+from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.databricks_sql_datasource import (
+    DatabricksDsn,
     DatabricksSQLDatasource,
 )
 
@@ -102,3 +104,49 @@ def test_invalid_connection_string_raises_dsn_error(
 
     assert expected_errors == exc_info.value.errors()
     assert "my_token" not in str(exc_info.value.errors())
+
+
+@pytest.mark.unit
+def test_connection_updating_templated_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "databricks://token:${MY_TOKEN}@hostname:443?http_path=/path/to/warehouse"
+    datasource = DatabricksSQLDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    # Assign a new templated connection string directly
+    new_conn_str = "databricks://token:${NEW_TOKEN}@hostname:443?http_path=/path/to/warehouse"
+    datasource.connection_string = new_conn_str
+
+    # Verify it's still a ConfigStr after assignment (not a plain str)
+    assert isinstance(datasource.connection_string, ConfigStr), (
+        f"Expected ConfigStr, got {type(datasource.connection_string)}. "
+        "This indicates validate_assignment is not enabled."
+    )
+    assert datasource.connection_string.template_str == new_conn_str
+
+
+@pytest.mark.unit
+def test_connection_updating_plain_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "databricks://token:${MY_TOKEN}@hostname:443?http_path=/path/to/warehouse"
+    datasource = DatabricksSQLDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    plain_conn_str = "databricks://token:plaintoken@plainhost:443?http_path=/plain/path&catalog=main&schema=default"
+    datasource.connection_string = plain_conn_str
+    assert isinstance(datasource.connection_string, DatabricksDsn), (
+        f"Expected DatabricksDsn for plain connection string, "
+        f"got {type(datasource.connection_string)}"
+    )

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -16,7 +16,7 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
 import great_expectations.exceptions as ge_exceptions
-from great_expectations.compatibility.pydantic import ValidationError
+from great_expectations.compatibility.pydantic import ValidationError, networks
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.partitioners import (
@@ -38,6 +38,7 @@ from great_expectations.datasource.fluent.batch_request import (
     BatchParameters,
     BatchRequest,
 )
+from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.interfaces import TestConnectionError
 from great_expectations.datasource.fluent.postgres_datasource import (
     PostgresDatasource,
@@ -1351,3 +1352,49 @@ def test_add_postgres_table_asset_with_batch_metadata(
         for i, year in enumerate(years):
             substituted_batch_metadata["year"] = year
             assert batches[i] == substituted_batch_metadata
+
+
+@pytest.mark.unit
+def test_connection_updating_templated_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "postgresql://user:${MY_PASSWORD}@localhost/db"
+    datasource = PostgresDatasource(
+        name="my_postgres",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    # Assign a new templated connection string directly
+    new_conn_str = "postgresql://newuser:${NEW_PASSWORD}@newhost/newdb"
+    datasource.connection_string = new_conn_str
+
+    # Verify it's still a ConfigStr after assignment (not a plain str)
+    assert isinstance(datasource.connection_string, ConfigStr), (
+        f"Expected ConfigStr, got {type(datasource.connection_string)}. "
+        "This indicates validate_assignment is not enabled."
+    )
+    assert datasource.connection_string.template_str == new_conn_str
+
+
+@pytest.mark.unit
+def test_connection_updating_plain_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "postgresql://user:${MY_PASSWORD}@localhost/db"
+    datasource = PostgresDatasource(
+        name="my_postgres",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    plain_conn_str = "postgresql://plainuser:plainpass@plainhost/plaindb"
+    datasource.connection_string = plain_conn_str
+    assert isinstance(datasource.connection_string, networks.PostgresDsn), (
+        f"Expected PostgresDsn for plain connection string, "
+        f"got {type(datasource.connection_string)}"
+    )

--- a/tests/datasource/fluent/test_redshift_datasource.py
+++ b/tests/datasource/fluent/test_redshift_datasource.py
@@ -4,8 +4,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from great_expectations.data_context import EphemeralDataContext
+from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.redshift_datasource import (
     RedshiftConnectionDetails,
+    RedshiftDatasource,
     RedshiftDsn,
     RedshiftSSLModes,
 )
@@ -100,3 +102,53 @@ def test_value_error_raised_if_invalid_connection_detail_inputs(
             database=database,
             sslmode=sslmode,  # type: ignore[arg-type] # Ignore this for purpose of the test
         )
+
+
+@pytest.mark.unit
+def test_connection_updating_templated_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "redshift+psycopg2://user:${MY_PASSWORD}@host.amazonaws.com:5439/database"
+    datasource = RedshiftDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    # Assign a new templated connection string directly
+    new_conn_str = (
+        "redshift+psycopg2://user:${MY_PASSWORD}@host.amazonaws.com:5439/database".replace(
+            "MY_", "NEW_"
+        )
+    )
+    datasource.connection_string = new_conn_str
+
+    # Verify it's still a ConfigStr after assignment (not a plain str)
+    assert isinstance(datasource.connection_string, ConfigStr), (
+        f"Expected ConfigStr, got {type(datasource.connection_string)}. "
+        "This indicates validate_assignment is not enabled."
+    )
+    assert datasource.connection_string.template_str == new_conn_str
+
+
+@pytest.mark.unit
+def test_connection_updating_plain_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "redshift+psycopg2://user:${MY_PASSWORD}@host.amazonaws.com:5439/database"
+    datasource = RedshiftDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    plain_conn_str = "redshift+psycopg2://plainuser:plainpass@plainhost.amazonaws.com:5439/plaindb"
+    datasource.connection_string = plain_conn_str
+    assert isinstance(datasource.connection_string, RedshiftDsn), (
+        f"Expected RedshiftDsn for plain connection string, "
+        f"got {type(datasource.connection_string)}"
+    )

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -20,7 +20,7 @@ from great_expectations.datasource.fluent import (
     SQLDatasource,
     TestConnectionError,
 )
-from great_expectations.datasource.fluent.config_str import ConfigStr
+from great_expectations.datasource.fluent.config_str import ConfigStr, ConfigUri
 from great_expectations.datasource.fluent.snowflake_datasource import (
     AccountIdentifier,
     SnowflakeDatasource,
@@ -800,6 +800,52 @@ def test_invalid_connection_string_raises_dsn_error(
         _ = SnowflakeDatasource(name="my_snowflake", connection_string=connection_string)
 
     assert expected_errors == exc_info.value.errors()
+
+
+@pytest.mark.unit
+def test_connection_updating_templated_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "snowflake://user:${MY_PASSWORD}@account/db/schema?warehouse=wh&role=role"
+    datasource = SnowflakeDatasource(
+        name="my_snowflake",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigUri
+    assert isinstance(datasource.connection_string, ConfigUri)
+    assert datasource.connection_string.template_str == conn_str
+
+    # Assign a new templated connection string directly
+    new_conn_str = "snowflake://newuser:${NEW_PASSWORD}@newaccount/newdb/newschema?warehouse=newwh&role=newrole"
+    datasource.connection_string = new_conn_str
+
+    # Verify it's still a ConfigUri after assignment (not a plain str)
+    assert isinstance(datasource.connection_string, ConfigUri), (
+        f"Expected ConfigUri, got {type(datasource.connection_string)}. "
+        "This indicates validate_assignment is not enabled."
+    )
+    assert datasource.connection_string.template_str == new_conn_str
+
+
+@pytest.mark.unit
+def test_connection_updating_plain_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "snowflake://user:${MY_PASSWORD}@account/db/schema?warehouse=wh&role=role"
+    datasource = SnowflakeDatasource(
+        name="my_snowflake",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigUri
+    assert isinstance(datasource.connection_string, ConfigUri)
+    assert datasource.connection_string.template_str == conn_str
+
+    plain_conn_str = "snowflake://plainuser:plainpass@plainaccount/plaindb/plainschema?warehouse=plainwh&role=plainrole"
+    datasource.connection_string = plain_conn_str
+    assert isinstance(datasource.connection_string, SnowflakeDsn), (
+        f"Expected SnowflakeDsn for plain connection string, "
+        f"got {type(datasource.connection_string)}"
+    )
 
 
 # TODO: Cleanup how we install test dependencies and remove this skipif

--- a/tests/datasource/fluent/test_sqlite_datasource.py
+++ b/tests/datasource/fluent/test_sqlite_datasource.py
@@ -11,6 +11,8 @@ from great_expectations.core.partitioners import (
     PartitionerConvertedDatetime,
 )
 from great_expectations.datasource.fluent import SqliteDatasource
+from great_expectations.datasource.fluent.config_str import ConfigStr
+from great_expectations.datasource.fluent.sqlite_datasource import SqliteDsn
 from tests.datasource.fluent.conftest import sqlachemy_execution_engine_mock_cls
 
 if TYPE_CHECKING:
@@ -181,3 +183,48 @@ def test_create_temp_table(empty_data_context, create_sqlite_source):
         asset = source.add_query_asset(name="query_asset", query="SELECT * from table")
         _ = asset.get_batch(asset.build_batch_request())
         assert source._execution_engine._create_temp_table is False
+
+
+@pytest.mark.unit
+def test_connection_updating_templated_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "sqlite:///${MY_DB_PATH}"
+    datasource = SqliteDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    # Assign a new templated connection string directly
+    new_conn_str = "sqlite:///${MY_DB_PATH}".replace("MY_", "NEW_")
+    datasource.connection_string = new_conn_str
+
+    # Verify it's still a ConfigStr after assignment (not a plain str)
+    assert isinstance(datasource.connection_string, ConfigStr), (
+        f"Expected ConfigStr, got {type(datasource.connection_string)}. "
+        "This indicates validate_assignment is not enabled."
+    )
+    assert datasource.connection_string.template_str == new_conn_str
+
+
+@pytest.mark.unit
+def test_connection_updating_plain_connection_string():
+    # Create datasource with templated connection string
+    conn_str = "sqlite:///${MY_DB_PATH}"
+    datasource = SqliteDatasource(
+        name="test_ds",
+        connection_string=conn_str,
+    )
+
+    # Verify initial connection_string is ConfigStr
+    assert isinstance(datasource.connection_string, ConfigStr)
+    assert datasource.connection_string.template_str == conn_str
+
+    plain_conn_str = "sqlite:///path/to/my.db"
+    datasource.connection_string = plain_conn_str
+    assert isinstance(datasource.connection_string, SqliteDsn), (
+        f"Expected SqliteDsn for plain connection string, got {type(datasource.connection_string)}"
+    )


### PR DESCRIPTION
This PR fixes a bug where assigning a new value to the snowflake connection string attr after instantiation failed to transform the connection str into a usable type. While the surfaced bug was specific to snowflake, the underlying issue could affect any SQL data source. This PR addresses the underlying issue across multiple SQL data sources.