### PR TITLE
[MAINTENANCE] Fix test assertions for Numpy 2 compatibility

### DIFF
--- a/tests/datasource/fluent/test_batch.py
+++ b/tests/datasource/fluent/test_batch.py
@@ -46,7 +46,7 @@ def test_batch_validate_expectation(pandas_setup: Tuple[AbstractDataContext, Bat
     # Validate
     result = batch.validate(expectation)
     # Asserts on result
-    assert result.success is True
+    assert result.success
 
 
 @pytest.mark.filesystem
@@ -66,7 +66,7 @@ def test_batch_validate_expectation_suite(
     # Validate
     result = batch.validate(suite)
     # Asserts on result
-    assert result.success is True
+    assert result.success
 
 
 @pytest.mark.filesystem
@@ -88,7 +88,7 @@ def test_batch_validate_expectation_with_expectation_params(
         },
     )
     # Asserts on result
-    assert result.success is True
+    assert result.success
 
 
 @pytest.mark.filesystem
@@ -115,7 +115,7 @@ def test_batch_validate_expectation_suite_with_expectation_params(
         },
     )
     # Asserts on result
-    assert result.success is True
+    assert result.success
 
 
 @pytest.mark.filesystem
@@ -131,11 +131,11 @@ def test_batch_validate_with_updated_expectation(
     # Validate
     result = batch.validate(expectation)
     # Asserts on result
-    assert result.success is False
+    assert not result.success
     # Update expectation and validate
     expectation.mostly = 0.95
     result = batch.validate(expectation)
-    assert result.success is True
+    assert result.success
 
 
 @pytest.mark.filesystem
@@ -150,7 +150,7 @@ def test_batch_validate_expectation_suite_with_updated_expectation(
     # Validate
     result = batch.validate(suite)
     # Asserts on result
-    assert result.success is False
+    assert not result.success
     # Update suite and validate
     assert len(suite.expectations) == 1
 
@@ -163,7 +163,7 @@ def test_batch_validate_expectation_suite_with_updated_expectation(
     assert suite.expectations[0].mostly == 0.95
 
     result = batch.validate(suite)
-    assert result.success is True
+    assert result.success
 
 
 class TestBatchValidateExpectation:
@@ -180,7 +180,7 @@ class TestBatchValidateExpectation:
         _, batch = pandas_setup
         result = batch.validate(expectation, result_format="BOOLEAN_ONLY")
 
-        assert result.success is True
+        assert result.success
         assert len(result.result) == 0
 
     @pytest.mark.filesystem
@@ -192,7 +192,7 @@ class TestBatchValidateExpectation:
         _, batch = pandas_setup
         summary_result = batch.validate(expectation, result_format="SUMMARY")
 
-        assert summary_result.success is True
+        assert summary_result.success
         assert len(summary_result.result) > 0
 
     @pytest.mark.filesystem
@@ -204,7 +204,7 @@ class TestBatchValidateExpectation:
         _, batch = pandas_setup
         result = batch.validate(expectation, result_format="COMPLETE")
 
-        assert result.success is True
+        assert result.success
         assert "unexpected_index_list" in result.result
 
 
@@ -225,7 +225,7 @@ class TestBatchValidateExpectationSuite:
         _, batch = pandas_setup
         result = batch.validate(suite, result_format="BOOLEAN_ONLY")
 
-        assert result.success is True
+        assert result.success
         assert len(result.results[0].result) == 0
 
     @pytest.mark.filesystem
@@ -237,7 +237,7 @@ class TestBatchValidateExpectationSuite:
         _, batch = pandas_setup
         summary_result = batch.validate(suite, result_format="SUMMARY")
 
-        assert summary_result.success is True
+        assert summary_result.success
         assert len(summary_result.results[0].result) > 0
 
     @pytest.mark.filesystem
@@ -249,7 +249,7 @@ class TestBatchValidateExpectationSuite:
         _, batch = pandas_setup
         result = batch.validate(suite, result_format="COMPLETE")
 
-        assert result.success is True
+        assert result.success
         assert "unexpected_index_list" in result.results[0].result
 
 


### PR DESCRIPTION
Fix boolean assertions for NumPy 2.x compatibility by using truthiness checks instead of identity comparisons.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
