### PR TITLE
[MAINTENANCE] Skip tests for SQLA < 2 and Pandas >= 2.2

### DIFF
--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -13,7 +13,9 @@ import pathlib
 import shutil
 from typing import List
 
+import pandas
 import pytest
+import sqlalchemy
 from assets.scripts.build_gallery import execute_shell_command
 from docs.docusaurus.docs.components.examples_under_test import (
     docs_tests,
@@ -496,6 +498,24 @@ def _check_for_skipped_tests(  # noqa: C901, PLR0912 # FIXME CoP
     integration_test_fixture,
 ) -> None:
     """Enable scripts to be skipped based on pytest invocation flags."""
+    TESTS_TO_SKIP_FOR_SQLA_2_0_AND_PANDAS_2_2 = [
+        "expect_column_max_to_be_between_custom",
+        "partition_data_on_whole_table_snowflake",
+        "partition_data_on_whole_table_redshift",
+        "partition_data_on_datetime_redshift",
+        "partition_data_on_datetime_snowflake",
+        "deployment_patterns_redshift",
+    ]
+    IS_RUNNING_SQLA_2_0_AND_PANDAS_2_2 = (
+        sqlalchemy.__version__ < "2.0" and pandas.__version__ >= "2.2"
+    )
+    if (
+        IS_RUNNING_SQLA_2_0_AND_PANDAS_2_2
+        and integration_test_fixture.name in TESTS_TO_SKIP_FOR_SQLA_2_0_AND_PANDAS_2_2
+    ):
+        pytest.skip(
+            "This test requires sqlalchemy version 2.0 or higher and pandas version 2.2 or higher"
+        )
     dependencies = integration_test_fixture.backend_dependencies
     if not dependencies:
         return


### PR DESCRIPTION
Some tests are currently failing when using SQLAlchemy < 2 in combination with Pandas >= 2.2, due to dropped compatibility in Pandas.
To keep CI pipelines stable, these tests are being skipped under that version matrix for now.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
