### PR TITLE
[MAINTENANCE] Pin pact-python due to install error on 3.12 of 3.0.

### DIFF
--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -4,7 +4,8 @@ flaky>=3.7.0 # for docs-integration tests that access cloud-resources that acces
 flask>=1.0.0 # for s3 test only (with moto)
 freezegun>=0.3.15
 moto[sns,s3]>=4.2.13,<5.0
-pact-python>=2.0.1
+# Issue installing pact-python: https://github.com/pact-foundation/pact-python/issues/1275
+pact-python>=2.0.1,<3
 pyfakefs>=4.5.1
 pytest>=8.2.1
 pytest-benchmark>=3.4.1

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 33
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 37
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -204,6 +204,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-dremio.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev-lite.txt", "pact-python", (("<", "3"), (">=", "2.0.1"))),
         ("requirements-dev-pagerduty.txt", "pypd", (("==", "1.1.0"),)),
         (
             "requirements-dev-spark.txt",
@@ -212,6 +213,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ),
         ("requirements-dev-snowflake.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev-sqlalchemy.txt", "pact-python", (("<", "3"), (">=", "2.0.1"))),
         ("requirements-dev-sqlalchemy.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev-sqlalchemy.txt", "sqlalchemy", (("<", "2.0.0"),)),
         (
@@ -233,11 +235,13 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-test.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev-test.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev-test.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev-test.txt", "pact-python", (("<", "3"), (">=", "2.0.1"))),
         ("requirements-dev.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements-dev.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
+        ("requirements-dev.txt", "pact-python", (("<", "3"), (">=", "2.0.1"))),
         ("requirements-dev.txt", "pandas", (("<", "2.2.0"),)),
         (
             "requirements-dev.txt",


### PR DESCRIPTION
This pact-python ticket tracks this error. I will fill in details there after I see whether this resolves the issue for us.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
