### PR TITLE
[MINORBUMP] Remove Pandas Upper Bound Constraint

### DIFF
--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,4 +1,3 @@
-pandas<2.2.0; python_version >= "3.9"
 pyarrow>=14; python_version >= "3.12"
 snowflake-connector-python>=3.5.0
 snowflake-sqlalchemy>=1.2.3,!=1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ numpy>=1.21.6; python_version == "3.9"
 numpy>=1.22.4; python_version >= "3.10"
 numpy>=1.26.0; python_version >= "3.12"
 packaging
-pandas>=1.1.3,<2.2; python_version == "3.9"
-pandas>=1.3.0,<2.2; python_version >= "3.10"
-pandas<2.2; python_version >= "3.12"
+pandas>=1.1.3; python_version == "3.9"
+pandas>=1.3.0; python_version >= "3.10"
+pandas; python_version >= "3.12"
 # analytics
 posthog>3
 # patch version updates `typing_extensions` to the needed version

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -251,5 +251,4 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
-        ("requirements.txt", "pandas", (("<", "2.2"),)),
     }

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 33
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 29
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -210,9 +210,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             "pyspark",
             (("<", "4.0"), (">=", "2.3.2")),
         ),
-        ("requirements-dev-snowflake.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
-        ("requirements-dev-sqlalchemy.txt", "pandas", (("<", "2.2.0"),)),
         ("requirements-dev-sqlalchemy.txt", "sqlalchemy", (("<", "2.0.0"),)),
         (
             "requirements-dev-sqlalchemy.txt",
@@ -238,7 +236,6 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
-        ("requirements-dev.txt", "pandas", (("<", "2.2.0"),)),
         (
             "requirements-dev.txt",
             "pyspark",


### PR DESCRIPTION
Removes the `<2.2` upper bound constraint on pandas, allowing GX Core to work with pandas `2.2.0` and above.

This change enables users to install and use newer versions of pandas (2.2.0+) with Great Expectations, providing access to the latest pandas features and bug fixes.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
