### PR TITLE
[MAINTENANCE] Add `RedshiftConnectionDetails` to type stub

### DIFF
--- a/great_expectations/datasource/fluent/sources.pyi
+++ b/great_expectations/datasource/fluent/sources.pyi
@@ -48,7 +48,10 @@ from great_expectations.datasource.fluent.interfaces import (
     DataAsset,
     Datasource,
 )
-from great_expectations.datasource.fluent.redshift_datasource import RedshiftDsn
+from great_expectations.datasource.fluent.redshift_datasource import (
+    RedshiftConnectionDetails,
+    RedshiftDsn,
+)
 from great_expectations.datasource.fluent.snowflake_datasource import (
     ConnectionDetails as SnowflakeConnectionDetails,
 )
@@ -329,7 +332,7 @@ class DataSourceManager:
         name: Optional[str] = None,
         datasource: Optional[Datasource] = None,
         *,
-        connection_string: Union[ConfigStr, RedshiftDsn] = ...,
+        connection_string: Union[ConfigStr, RedshiftDsn, RedshiftConnectionDetails] = ...,
         create_temp_table: bool = True,
     ) -> PostgresDatasource: ...
     def update_redshift(
@@ -338,7 +341,7 @@ class DataSourceManager:
         name: Optional[str] = None,
         datasource: Optional[Datasource] = None,
         *,
-        connection_string: Union[ConfigStr, RedshiftDsn] = ...,
+        connection_string: Union[ConfigStr, RedshiftDsn, RedshiftConnectionDetails] = ...,
         create_temp_table: bool = True,
     ) -> PostgresDatasource: ...
     def add_or_update_redshift(
@@ -347,7 +350,7 @@ class DataSourceManager:
         name: Optional[str] = None,
         datasource: Optional[Datasource] = None,
         *,
-        connection_string: Union[ConfigStr, RedshiftDsn] = ...,
+        connection_string: Union[ConfigStr, RedshiftDsn, RedshiftConnectionDetails] = ...,
         create_temp_table: bool = True,
     ) -> PostgresDatasource: ...
     def delete_redshift(


### PR DESCRIPTION
This is an acceptable way to get a Redshift data source, but the type checker complains about it.