### PR TITLE
[MAINTENANCE] Make docker-compose health check hit endpoint

### DIFF
--- a/assets/docker/mercury/docker-compose.yml
+++ b/assets/docker/mercury/docker-compose.yml
@@ -118,6 +118,12 @@ services:
         condition: service_completed_successfully
       localstack:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "--max-time", "2", "http://localhost:6002/"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 90s
     entrypoint:
       - /bin/bash
       - -c
@@ -133,8 +139,10 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
-      - mercury-service-api
-      - mercury-service-api-v1
+      mercury-service-api:
+        condition: service_healthy
+      mercury-service-api-v1:
+        condition: service_healthy
   localstack:
     container_name: localstack
     image: localstack/localstack

--- a/assets/docker/mercury/docker-compose.yml
+++ b/assets/docker/mercury/docker-compose.yml
@@ -72,8 +72,7 @@ services:
         python -m tests.utils.dev_db_seed_script
         gunicorn mercury.api:get_app\(\) --config ./gunicorn.conf.py --workers=1
     healthcheck:
-      test:
-        ["CMD", "curl", "-f", "--max-time", "2", "http://localhost:6001/status"]
+      test: ["CMD", "curl", "-f", "--max-time", "2", "http://localhost:6001/"]
       interval: 5s
       timeout: 3s
       retries: 30

--- a/assets/docker/mercury/docker-compose.yml
+++ b/assets/docker/mercury/docker-compose.yml
@@ -72,10 +72,11 @@ services:
         python -m tests.utils.dev_db_seed_script
         gunicorn mercury.api:get_app\(\) --config ./gunicorn.conf.py --workers=1
     healthcheck:
-      test: bash -c ':> /dev/tcp/0.0.0.0/6001' || exit 1
+      test: ["CMD", "curl", "-f", "--max-time", "2", "http://localhost:6001/"]
       interval: 5s
-      timeout: 2s
-      retries: 20
+      timeout: 3s
+      retries: 30
+      start_period: 90s
     depends_on:
       db-provisioner:
         condition: service_completed_successfully

--- a/assets/docker/mercury/docker-compose.yml
+++ b/assets/docker/mercury/docker-compose.yml
@@ -72,7 +72,8 @@ services:
         python -m tests.utils.dev_db_seed_script
         gunicorn mercury.api:get_app\(\) --config ./gunicorn.conf.py --workers=1
     healthcheck:
-      test: ["CMD", "curl", "-f", "--max-time", "2", "http://localhost:6001/"]
+      test:
+        ["CMD", "curl", "-f", "--max-time", "2", "http://localhost:6001/status"]
       interval: 5s
       timeout: 3s
       retries: 30


### PR DESCRIPTION
The previous check only verified the port was open.

This should fix errors we've seen getting 502s in CI.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
