### PR TITLE
[MAINTENANCE] Clean up datasource schemas that are over an hour old

### DIFF
--- a/scripts/cleanup/cleanup_big_query.py
+++ b/scripts/cleanup/cleanup_big_query.py
@@ -39,7 +39,7 @@ def cleanup_big_query(config: BigQueryConnectionConfig) -> None:
                 SELECT 'DROP SCHEMA ' || schema_name || ' CASCADE;'
                 FROM INFORMATION_SCHEMA.SCHEMATA
                 WHERE REGEXP_CONTAINS(schema_name, :schema_format)
-                AND creation_time < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 HOUR);
+                AND creation_time < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR);
                 """
             ),
             {"schema_format": SCHEMA_FORMAT},

--- a/scripts/cleanup/cleanup_databricks.py
+++ b/scripts/cleanup/cleanup_databricks.py
@@ -42,7 +42,7 @@ def cleanup_databricks(config: DatabricksConnectionConfig) -> None:
             FROM information_schema.schemata
             WHERE catalog_name = :catalog_name
             AND schema_name REGEXP :schema_pattern
-            AND created < CURRENT_TIMESTAMP() - INTERVAL 2 HOUR
+            AND created < CURRENT_TIMESTAMP() - INTERVAL 1 HOUR
             ORDER BY created DESC
             """
             ),

--- a/scripts/cleanup/cleanup_redshift.py
+++ b/scripts/cleanup/cleanup_redshift.py
@@ -43,7 +43,7 @@ def cleanup_redshift(config: RedshiftConnectionConfig) -> None:
                 FROM pg_tables t
                 JOIN SVV_TABLE_INFO i ON t.schemaname = i.schema AND t.tablename = i.table
                 WHERE t.tablename LIKE :table_pattern
-                AND i.create_time < DATEADD(hour, -2, GETDATE())
+                AND i.create_time < DATEADD(hour, -1, GETDATE())
                 """
             ),
             {"table_pattern": TABLE_PATTERN},

--- a/scripts/cleanup/cleanup_snowflake.py
+++ b/scripts/cleanup/cleanup_snowflake.py
@@ -40,7 +40,7 @@ def cleanup_snowflake(config: SnowflakeConnectionConfig) -> None:
                 f"SELECT 'DROP SCHEMA IF EXISTS ' || schema_name || ' CASCADE;' as drop_statement "
                 f"FROM INFORMATION_SCHEMA.SCHEMATA "
                 f"WHERE REGEXP_LIKE(schema_name, '{SCHEMA_FORMAT}') "
-                f"AND created < DATEADD(hour, -2, CURRENT_TIMESTAMP())"
+                f"AND created < DATEADD(hour, -1, CURRENT_TIMESTAMP())"
             )
         ).fetchall()
 


### PR DESCRIPTION
Before we waited till schemas were over 2 hours old, which was unnecessarily permissive.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
