### PR TITLE
[MAINTENANCE] Add Condition type to row condition instances

### DIFF
--- a/great_expectations/alias_types.py
+++ b/great_expectations/alias_types.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Dict, List, Union
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
+    from great_expectations.expectations.conditions import Condition
+
 PathStr: TypeAlias = Union[str, pathlib.Path]
 JSONValues: TypeAlias = Union[
     Dict[str, "JSONValues"], List["JSONValues"], str, int, float, bool, None
 ]
+RowConditionType: TypeAlias = Union[str, "Condition", None]

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -300,6 +300,24 @@ class ExecutionEngine(ABC, Generic[TFilter]):
         """Resolve a bundle of metrics with the same compute Domain as part of a single trip to the compute engine."""  # noqa: E501 # FIXME CoP
         raise NotImplementedError
 
+    def _validate_row_condition(self, row_condition: Any) -> None:
+        """Validates that row_condition is not a Condition object.
+
+        Condition objects are not yet supported for row_condition. This will be
+        implemented in a future release. For now, only string-based conditions are supported.
+
+        Args:
+            row_condition: The row_condition value to validate
+
+        Raises:
+            GreatExpectationsError: If row_condition is a Condition object
+        """
+        if isinstance(row_condition, Condition):
+            raise gx_exceptions.GreatExpectationsError(  # noqa: TRY003
+                "Condition objects are not yet supported for row_condition. "
+                "This feature will be implemented in a future release."
+            )
+
     def get_domain_records(
         self,
         domain_kwargs: dict,

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -537,6 +537,8 @@ not {batch_spec.__class__.__name__}"""  # noqa: E501 # FIXME CoP
         # Filtering by row condition.
         row_condition = domain_kwargs.get("row_condition", None)
         if row_condition:
+            self._validate_row_condition(row_condition)
+
             condition_parser = domain_kwargs.get("condition_parser", None)
 
             if condition_parser == CONDITION_PARSER_PANDAS:

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -675,6 +675,8 @@ illegal.  Please check your config."""  # noqa: E501 # FIXME CoP
         # Filtering by row condition.
         row_condition = domain_kwargs.get("row_condition", None)
         if row_condition:
+            self._validate_row_condition(row_condition)
+
             condition_parser = domain_kwargs.get("condition_parser", None)
             if condition_parser == CONDITION_PARSER_SPARK:
                 data = data.filter(row_condition)

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -625,12 +625,15 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
 
         # Filtering by row condition.
         if "row_condition" in domain_kwargs and domain_kwargs["row_condition"] is not None:
+            row_condition = domain_kwargs["row_condition"]
+            self._validate_row_condition(row_condition)
+
             condition_parser = domain_kwargs["condition_parser"]
             if condition_parser in [
                 CONDITION_PARSER_GREAT_EXPECTATIONS,
                 CONDITION_PARSER_GREAT_EXPECTATIONS_DEPRECATED,
             ]:
-                parsed_condition = parse_condition_to_sqlalchemy(domain_kwargs["row_condition"])
+                parsed_condition = parse_condition_to_sqlalchemy(row_condition)
                 selectable = sa.select(sa.text("*")).select_from(selectable).where(parsed_condition)  # type: ignore[arg-type] # FIXME CoP
             else:
                 raise GreatExpectationsError(  # noqa: TRY003 # FIXME CoP

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type, Union
 
+from great_expectations.alias_types import RowConditionType  # noqa: TC001 # FIXME
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
-from great_expectations.expectations.conditions import Condition  # noqa: TC001 # FIXME
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -195,7 +195,7 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
     strict_max: Union[bool, SuiteParameterDict] = pydantic.Field(
         default=False, description=STRICT_MIN_DESCRIPTION
     )
-    row_condition: Union[str, Condition, None] = None
+    row_condition: RowConditionType = None
     condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -8,6 +8,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
+from great_expectations.expectations.conditions import Condition  # noqa: TC001 # FIXME
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -194,7 +195,7 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
     strict_max: Union[bool, SuiteParameterDict] = pydantic.Field(
         default=False, description=STRICT_MIN_DESCRIPTION
     )
-    row_condition: Union[str, None] = None
+    row_condition: Union[str, Condition, None] = None
     condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Type, Union
 
+from great_expectations.alias_types import RowConditionType  # noqa: TC001 # FIXME
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
-from great_expectations.expectations.conditions import Condition  # noqa: TC001 # FIXME
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -157,7 +157,7 @@ class ExpectTableRowCountToEqual(BatchExpectation):
     """  # noqa: E501 # FIXME CoP
 
     value: Union[int, SuiteParameterDict] = pydantic.Field(description=VALUE_DESCRIPTION)
-    row_condition: Union[str, Condition, None] = None
+    row_condition: RowConditionType = None
     condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -7,6 +7,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
+from great_expectations.expectations.conditions import Condition  # noqa: TC001 # FIXME
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -156,7 +157,7 @@ class ExpectTableRowCountToEqual(BatchExpectation):
     """  # noqa: E501 # FIXME CoP
 
     value: Union[int, SuiteParameterDict] = pydantic.Field(description=VALUE_DESCRIPTION)
-    row_condition: Union[str, None] = None
+    row_condition: Union[str, Condition, None] = None
     condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
 
+from great_expectations.alias_types import RowConditionType  # noqa: TC001 # FIXME
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
-from great_expectations.expectations.conditions import Condition  # noqa: TC001 # FIXME
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -178,7 +178,7 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
     other_table_name: Union[str, SuiteParameterDict] = pydantic.Field(
         description=OTHER_TABLE_NAME_DESCRIPTION
     )
-    row_condition: Union[str, Condition, None] = None
+    row_condition: RowConditionType = None
     condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -8,6 +8,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # noqa: TC001 # FIXME CoP
 )
+from great_expectations.expectations.conditions import Condition  # noqa: TC001 # FIXME
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_suite_parameter_string,
@@ -177,7 +178,7 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
     other_table_name: Union[str, SuiteParameterDict] = pydantic.Field(
         description=OTHER_TABLE_NAME_DESCRIPTION
     )
-    row_condition: Union[str, None] = None
+    row_condition: Union[str, Condition, None] = None
     condition_parser: Union[ConditionParser, None] = None
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -317,6 +324,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -317,6 +324,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -317,6 +324,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -345,6 +352,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -311,6 +318,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -311,6 +318,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -311,6 +318,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -311,6 +318,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -329,6 +336,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -105,7 +105,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -297,6 +304,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -105,7 +105,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -286,6 +293,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -105,7 +105,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -305,6 +312,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -298,6 +305,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -312,6 +319,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -273,6 +280,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         },
         "QuantileRange": {
             "title": "QuantileRange",

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -295,6 +302,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -311,6 +318,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -83,7 +83,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -312,6 +319,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -311,6 +318,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -274,6 +281,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -287,6 +294,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -327,6 +334,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -333,6 +340,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -272,6 +279,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -261,6 +268,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -274,6 +281,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -261,6 +268,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -272,6 +279,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -292,6 +299,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -272,6 +279,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -292,6 +299,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -333,6 +340,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -261,6 +268,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -271,6 +278,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -274,6 +281,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -271,6 +278,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -99,7 +99,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -274,6 +281,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -101,7 +101,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -273,6 +280,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -101,7 +101,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -294,6 +301,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -101,7 +101,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -276,6 +283,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -135,7 +135,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -294,6 +301,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -89,7 +89,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -251,6 +258,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -89,7 +89,14 @@
         },
         "row_condition": {
             "title": "Row Condition",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/definitions/Condition"
+                }
+            ]
         },
         "condition_parser": {
             "title": "Condition Parser",
@@ -249,6 +256,12 @@
                 "offset"
             ],
             "additionalProperties": false
+        },
+        "Condition": {
+            "title": "Condition",
+            "description": "Base class for conditions.",
+            "type": "object",
+            "properties": {}
         }
     }
 }

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -33,6 +33,7 @@ from typing_extensions import ParamSpec, TypeGuard, dataclass_transform
 
 from great_expectations import __version__ as ge_version
 from great_expectations._docs_decorators import public_api
+from great_expectations.alias_types import RowConditionType  # FIXME
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.pydantic import Field, ModelMetaclass, StrictStr
 from great_expectations.compatibility.typing_extensions import override
@@ -53,7 +54,9 @@ from great_expectations.exceptions import (
     InvalidExpectationConfigurationError,
     InvalidExpectationKwargsError,
 )
-from great_expectations.expectations.conditions import Condition
+from great_expectations.expectations.conditions import (
+    Condition,  # noqa: F401 # Required for RowConditionType runtime validation
+)
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
     parse_result_format,
@@ -1842,7 +1845,7 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
     """  # noqa: E501 # FIXME CoP
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
-    row_condition: Union[str, Condition, None] = None
+    row_condition: RowConditionType = None
     condition_parser: Union[ConditionParser, None] = None
 
     domain_keys: ClassVar[Tuple[str, ...]] = (
@@ -1890,7 +1893,7 @@ class ColumnMapExpectation(BatchExpectation, ABC):
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
     mostly: MostlyField = 1
-    row_condition: Union[str, Condition, None] = None
+    row_condition: RowConditionType = None
     condition_parser: Union[ConditionParser, None] = None
 
     catch_exceptions: bool = True
@@ -2155,7 +2158,7 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
     column_A: StrictStr = Field(min_length=1, description=COLUMN_A_DESCRIPTION)
     column_B: StrictStr = Field(min_length=1, description=COLUMN_B_DESCRIPTION)
     mostly: MostlyField = 1
-    row_condition: Union[str, Condition, None] = None
+    row_condition: RowConditionType = None
     condition_parser: Union[ConditionParser, None] = None
 
     catch_exceptions: bool = True
@@ -2420,7 +2423,7 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
 
     column_list: List[StrictStr] = pydantic.Field(description=COLUMN_LIST_DESCRIPTION)
     mostly: MostlyField = 1
-    row_condition: Union[str, Condition, None] = None
+    row_condition: RowConditionType = None
     condition_parser: Union[ConditionParser, None] = None
     ignore_row_if: Literal["all_values_are_missing", "any_value_is_missing", "never"] = (
         "all_values_are_missing"

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -53,6 +53,7 @@ from great_expectations.exceptions import (
     InvalidExpectationConfigurationError,
     InvalidExpectationKwargsError,
 )
+from great_expectations.expectations.conditions import Condition
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
     parse_result_format,
@@ -1841,7 +1842,7 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
     """  # noqa: E501 # FIXME CoP
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
-    row_condition: Union[str, None] = None
+    row_condition: Union[str, Condition, None] = None
     condition_parser: Union[ConditionParser, None] = None
 
     domain_keys: ClassVar[Tuple[str, ...]] = (
@@ -1889,7 +1890,7 @@ class ColumnMapExpectation(BatchExpectation, ABC):
 
     column: StrictStr = Field(min_length=1, description=COLUMN_DESCRIPTION)
     mostly: MostlyField = 1
-    row_condition: Union[str, None] = None
+    row_condition: Union[str, Condition, None] = None
     condition_parser: Union[ConditionParser, None] = None
 
     catch_exceptions: bool = True
@@ -2154,7 +2155,7 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
     column_A: StrictStr = Field(min_length=1, description=COLUMN_A_DESCRIPTION)
     column_B: StrictStr = Field(min_length=1, description=COLUMN_B_DESCRIPTION)
     mostly: MostlyField = 1
-    row_condition: Union[str, None] = None
+    row_condition: Union[str, Condition, None] = None
     condition_parser: Union[ConditionParser, None] = None
 
     catch_exceptions: bool = True
@@ -2419,7 +2420,7 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
 
     column_list: List[StrictStr] = pydantic.Field(description=COLUMN_LIST_DESCRIPTION)
     mostly: MostlyField = 1
-    row_condition: Union[str, None] = None
+    row_condition: Union[str, Condition, None] = None
     condition_parser: Union[ConditionParser, None] = None
     ignore_row_if: Literal["all_values_are_missing", "any_value_is_missing", "never"] = (
         "all_values_are_missing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -448,6 +448,7 @@ filterwarnings = [
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "ignore: pkg_resources is deprecated as an API:UserWarning",
+    "ignore: pkg_resources is deprecated as an API:DeprecationWarning",
 
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -449,8 +449,6 @@ filterwarnings = [
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "ignore: pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore: pkg_resources is deprecated as an API:UserWarning",
-    "ignore: pkg_resources is deprecated as an API:DeprecationWarning",
-
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation
     "ignore:Setting result format to COMPLETE for a SqlAlchemyDataset:UserWarning",


### PR DESCRIPTION
- Add the new Condition type to all `row_condition` instances in Expectations. 
- Update schemas
- Raise if Condition object is used for now.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
