### PR TITLE
[MAINTENANCE] always pull gx cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,7 @@ jobs:
 
       - name: Start services
         run: |
-          docker compose --progress quiet -f assets/docker/mercury/docker-compose.yml up -d --wait --wait-timeout 150 && \
+          docker compose --progress quiet -f assets/docker/mercury/docker-compose.yml up --pull always -d --wait --wait-timeout 150 && \
           docker compose --progress quiet -f assets/docker/spark/docker-compose.yml up -d --wait --wait-timeout 90
 
       - name: Show logs for debugging


### PR DESCRIPTION
https://github.com/great-expectations/great_expectations/pull/11395 is failing because it is pulling an old version of gx cloud. The github action runs from develop, so the change to `pull always` needs to be made separately.