### PR TITLE
[MAINTENANCE] Disable link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,22 +424,22 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
-      - name: Run broken link checker
-        uses: lycheeverse/lychee-action@v2.0.2
-        with:
-          # We decided to exclude all external HTTP requests but the ones that under the domain greatexpectations.io
-          # The reason is to avoid having network errors such as pages that throw 429 after too many requests (like Github)
-          # and to prevent other possible errors related to user agent or lychee capturing hrefs from metadata that don't resolve
-          # to a specific page (preconnects in JS)
-          args: >-
-            --method GET
-            --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
-            --max-concurrency 16
-            --max-retries 3
-            --accept '100..=103,200..=299,403'
-            --exclude='http.*'
-            --include='^https://(.+\.)?greatexpectations\.io/'
-            'docs/docusaurus/build/**/*.html'
+      # - name: Run broken link checker
+      #   uses: lycheeverse/lychee-action@v2.0.2
+      #   with:
+      #     # We decided to exclude all external HTTP requests but the ones that under the domain greatexpectations.io
+      #     # The reason is to avoid having network errors such as pages that throw 429 after too many requests (like Github)
+      #     # and to prevent other possible errors related to user agent or lychee capturing hrefs from metadata that don't resolve
+      #     # to a specific page (preconnects in JS)
+      #     args: >-
+      #       --method GET
+      #       --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+      #       --max-concurrency 16
+      #       --max-retries 3
+      #       --accept '100..=103,200..=299,403'
+      #       --exclude='http.*'
+      #       --include='^https://(.+\.)?greatexpectations\.io/'
+      #       'docs/docusaurus/build/**/*.html'
 
   docs-tests:
     needs: [check-actor-permissions]


### PR DESCRIPTION
This is giving way too many false positives to be useful.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
