### PR TITLE
[MAINTENANCE] Keep `condition_parser` field intact for backwards compatibility

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -532,7 +532,6 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         if isinstance(row_condition, str) and is_great_expectations_condition_parser:
             condition_obj = _convert_string_to_condition(row_condition)
             values["row_condition"] = condition_obj
-            values.pop("condition_parser", None)
         return values
 
     @classmethod

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -732,7 +732,7 @@ class TestLegacyRowConditionTransformation:
         )
 
         assert expectation.row_condition == expected_condition
-        assert not hasattr(expectation, "condition_parser")
+        assert expectation.condition_parser == condition_parser
 
     def test_no_transformation_when_already_condition_object(self):
         original_condition = Column(name="age") > 18


### PR DESCRIPTION
We need this field on the Cloud side for conversion of single-condition `Conditions` to string syntax on old API versions.
