### PR TITLE
[MAINTENANCE] Constrain `row_condition` groups

### DIFF
--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -131,18 +131,10 @@ class Condition(BaseModel):
 
     def __and__(self, other: Condition) -> AndCondition:
         """Construct an AndCondition"""
-        # We flatten nested AndConditions because logical ANDs are associative.
-        new_conditions = []
-        for cond in [self, other]:
-            if isinstance(cond, AndCondition):
-                new_conditions.extend(cond.conditions)
-            else:
-                new_conditions.append(cond)
-        return AndCondition(conditions=new_conditions)
+        return AndCondition(conditions=[self, other])
 
     def __or__(self, other: Condition) -> OrCondition:
         """Construct an OrCondition"""
-        # We can't flatten nested OrConditions because logical ORs are non-associative.
         return OrCondition(conditions=[self, other])
 
 
@@ -297,6 +289,8 @@ def _validate_and_condition(row_condition: AndCondition) -> AndCondition:
         raise AndContainsOrError()
 
     # Flatten nested AndConditions
+    # We only flatten nested AndConditions because
+    # logical ANDs are associative, while logical ORs are non-associative.
     flattened_conditions = _flatten_and_conditions(row_condition.conditions)
 
     # Count total conditions

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -24,6 +24,29 @@ class InvalidConditionTypeError(TypeError):
         super().__init__(f"Invalid condition type: {type(value)}")
 
 
+class AndContainsOrError(ValueError):
+    """Raised when an AND group contains OR conditions."""
+
+    def __init__(self):
+        super().__init__("AND groups cannot contain OR conditions")
+
+
+class NestedOrError(ValueError):
+    """Raised when OR groups contain nested OR conditions."""
+
+    def __init__(self):
+        super().__init__("OR groups cannot contain nested OR conditions")
+
+
+class TooManyConditionsError(ValueError):
+    """Raised when the number of conditions exceeds the maximum allowed."""
+
+    def __init__(self, count: int, max_conditions: int):
+        super().__init__(
+            f"{max_conditions} conditions is the maximum, but {count} conditions are defined"
+        )
+
+
 class Operator(str, Enum):
     EQUAL = "=="
     NOT_EQUAL = "!="
@@ -212,3 +235,126 @@ class OrCondition(Condition):
 RowConditionType: TypeAlias = Union[
     str, ComparisonCondition, NullityCondition, AndCondition, OrCondition, None
 ]
+
+
+# Maximum number of conditions allowed in a row_condition
+MAX_CONDITIONS = 100
+
+
+def _count_total_conditions(conditions: List[Condition]) -> int:
+    """Recursively count all conditions including nested ones."""
+    count = 0
+    for condition in conditions:
+        if isinstance(condition, (AndCondition, OrCondition)):
+            count += _count_total_conditions(condition.conditions)
+        else:
+            count += 1
+    return count
+
+
+def _flatten_and_conditions(conditions: List[Condition]) -> List[Condition]:
+    """Flatten nested AndConditions within a list of conditions."""
+    flattened = []
+    for condition in conditions:
+        if isinstance(condition, AndCondition):
+            # Recursively flatten nested AndConditions
+            flattened.extend(_flatten_and_conditions(condition.conditions))
+        else:
+            flattened.append(condition)
+    return flattened
+
+
+def _contains_or_in_and(condition: Condition) -> bool:
+    """Check if an AndCondition contains any OrConditions."""
+    if isinstance(condition, AndCondition):
+        for cond in condition.conditions:
+            if isinstance(cond, OrCondition):
+                return True
+            # Recursively check nested AndConditions
+            if isinstance(cond, AndCondition) and _contains_or_in_and(cond):
+                return True
+    return False
+
+
+def _contains_nested_or(condition: Condition) -> bool:
+    """Check if an OrCondition contains nested OrConditions."""
+    if isinstance(condition, OrCondition):
+        for cond in condition.conditions:
+            if isinstance(cond, OrCondition):
+                return True
+            # Also check if any nested AndConditions contain OrConditions
+            # (which would create a nested OR structure)
+            if isinstance(cond, AndCondition):
+                for and_cond in cond.conditions:
+                    if isinstance(and_cond, OrCondition):
+                        # This is an OR within an AND within an OR, which creates nested ORs
+                        return True
+    return False
+
+
+def _validate_and_condition(row_condition: AndCondition) -> AndCondition:
+    """Validate AndCondition constraints."""
+    # Check for OrConditions within AndConditions
+    if _contains_or_in_and(row_condition):
+        raise AndContainsOrError()
+
+    # Flatten nested AndConditions
+    flattened_conditions = _flatten_and_conditions(row_condition.conditions)
+
+    # Count total conditions
+    total_count = _count_total_conditions(flattened_conditions)
+    if total_count > MAX_CONDITIONS:
+        raise TooManyConditionsError(total_count, MAX_CONDITIONS)
+
+    # Return flattened AndCondition
+    return AndCondition(conditions=flattened_conditions)
+
+
+def _validate_or_condition(row_condition: OrCondition) -> OrCondition:
+    """Validate OrCondition constraints."""
+    # Check for nested OrConditions
+    if _contains_nested_or(row_condition):
+        raise NestedOrError()
+
+    # Count total conditions
+    total_count = _count_total_conditions(row_condition.conditions)
+    if total_count > MAX_CONDITIONS:
+        raise TooManyConditionsError(total_count, MAX_CONDITIONS)
+
+    return row_condition
+
+
+def validate_row_condition(row_condition: RowConditionType) -> RowConditionType:
+    """Validate row_condition according to GX Cloud UI constraints.
+
+    1. Flatten nested AndConditions within AndConditions
+    2. Raise error if OrConditions are nested within AndConditions
+    3. Raise error if OrConditions are nested within OrConditions
+    4. Raise error if total conditions exceed MAX_CONDITIONS
+
+    Args:
+        row_condition: The row condition to validate
+
+    Returns:
+        The validated (and possibly flattened) row condition
+
+    Raises:
+        ValueError: If the row condition violates any constraints
+    """
+    # String conditions and None are always valid
+    if row_condition is None or isinstance(row_condition, str):
+        return row_condition
+
+    # Simple conditions (Comparison, Nullity) are always valid
+    if isinstance(row_condition, (ComparisonCondition, NullityCondition)):
+        return row_condition
+
+    # Validate AndCondition
+    if isinstance(row_condition, AndCondition):
+        return _validate_and_condition(row_condition)
+
+    # Validate OrCondition
+    if isinstance(row_condition, OrCondition):
+        return _validate_or_condition(row_condition)
+
+    return row_condition

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -367,4 +367,4 @@ def validate_row_condition(row_condition: RowConditionType) -> RowConditionType:
     if isinstance(row_condition, OrCondition):
         return _validate_or_condition(row_condition)
 
-    return row_condition
+    raise ValueError(f"Invalid row condition type: {type(row_condition)}")

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -130,6 +130,8 @@ class Condition(BaseModel):
         return result
 
     def __and__(self, other: Condition) -> AndCondition:
+        """Construct an AndCondition"""
+        # We flatten nested AndConditions because logical ANDs are associative.
         new_conditions = []
         for cond in [self, other]:
             if isinstance(cond, AndCondition):
@@ -139,6 +141,8 @@ class Condition(BaseModel):
         return AndCondition(conditions=new_conditions)
 
     def __or__(self, other: Condition) -> OrCondition:
+        """Construct an OrCondition"""
+        # We can't flatten nested OrConditions because logical ORs are non-associative.
         return OrCondition(conditions=[self, other])
 
 

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -327,8 +327,8 @@ def validate_row_condition(row_condition: RowConditionType) -> RowConditionType:
     if row_condition is None or isinstance(row_condition, str):
         return row_condition
 
-    # Simple conditions (Comparison, Nullity) are always valid
-    if isinstance(row_condition, (ComparisonCondition, NullityCondition)):
+    # Single condition types are always valid
+    if isinstance(row_condition, (ComparisonCondition, NullityCondition, PassThroughCondition)):
         return row_condition
 
     # Validate total condition count

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -139,13 +139,7 @@ class Condition(BaseModel):
         return AndCondition(conditions=new_conditions)
 
     def __or__(self, other: Condition) -> OrCondition:
-        new_conditions = []
-        for cond in [self, other]:
-            if isinstance(cond, OrCondition):
-                new_conditions.extend(cond.conditions)
-            else:
-                new_conditions.append(cond)
-        return OrCondition(conditions=new_conditions)
+        return OrCondition(conditions=[self, other])
 
 
 class NullityCondition(Condition):

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -367,4 +367,4 @@ def validate_row_condition(row_condition: RowConditionType) -> RowConditionType:
     if isinstance(row_condition, OrCondition):
         return _validate_or_condition(row_condition)
 
-    raise ValueError(f"Invalid row condition type: {type(row_condition)}")
+    raise InvalidConditionTypeError(row_condition)

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -293,11 +293,6 @@ def _validate_and_condition(row_condition: AndCondition) -> AndCondition:
     # logical ANDs are associative, while logical ORs are non-associative.
     flattened_conditions = _flatten_and_conditions(row_condition.conditions)
 
-    # Count total conditions
-    total_count = _count_total_conditions(flattened_conditions)
-    if total_count > MAX_CONDITIONS:
-        raise TooManyConditionsError(total_count, MAX_CONDITIONS)
-
     # Return flattened AndCondition
     return AndCondition(conditions=flattened_conditions)
 
@@ -307,11 +302,6 @@ def _validate_or_condition(row_condition: OrCondition) -> OrCondition:
     # Check for nested OrConditions
     if _contains_nested_or(row_condition):
         raise NestedOrError()
-
-    # Count total conditions
-    total_count = _count_total_conditions(row_condition.conditions)
-    if total_count > MAX_CONDITIONS:
-        raise TooManyConditionsError(total_count, MAX_CONDITIONS)
 
     return row_condition
 
@@ -340,6 +330,11 @@ def validate_row_condition(row_condition: RowConditionType) -> RowConditionType:
     # Simple conditions (Comparison, Nullity) are always valid
     if isinstance(row_condition, (ComparisonCondition, NullityCondition)):
         return row_condition
+
+    # Validate total condition count
+    total_count = _count_total_conditions(row_condition.conditions)
+    if total_count > MAX_CONDITIONS:
+        raise TooManyConditionsError(total_count, MAX_CONDITIONS)
 
     # Validate AndCondition
     if isinstance(row_condition, AndCondition):

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -60,6 +60,7 @@ from great_expectations.expectations.conditions import (
     NullityCondition,
     Operator,
     RowConditionType,  # Required for RowConditionType runtime validation
+    validate_row_condition,
 )
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
@@ -1719,6 +1720,16 @@ class BatchExpectation(Expectation, ABC):
     metric_dependencies: ClassVar[Tuple[str, ...]] = ()
     domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.TABLE
     args_keys: ClassVar[Tuple[str, ...]] = ()
+
+    @pydantic.validator("row_condition", check_fields=False)
+    def _validate_row_condition(cls, v):
+        """Validate row_condition according to GX Cloud UI constraints.
+
+        This validator applies to all subclasses that define a row_condition field.
+        check_fields=False allows this to work even though row_condition is not
+        defined on BatchExpectation itself.
+        """
+        return validate_row_condition(v)
 
     class Config:
         @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -644,6 +644,8 @@ filterwarnings = [
     "ignore: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception",
     "ignore: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.:pytest_benchmark.logger.PytestBenchmarkWarning",
     "ignore: No data was collected\\. \\(no-data-collected\\):coverage.exceptions.CoverageWarning",
+    # Example Actual Warning: FutureWarning: You are using a Python version (3.9.23) past its end of life.
+    "ignore: You are using a Python version.*past its end of life:FutureWarning",
 
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -16,12 +16,10 @@ class TestAndConditionValidator:
 
     def test_flatten_nested_and_conditions(self):
         """Test that nested AndConditions are flattened when passed to Expectation."""
-        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 & column_3 == 8)
         column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
 
-        # Use Python operators to build conditions
         row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
 
         # Pass to an Expectation - should flatten
@@ -34,15 +32,13 @@ class TestAndConditionValidator:
 
     def test_error_on_or_within_and(self):
         """Test that OrConditions nested within AndConditions raise error in Expectation."""
-        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 | column_3 == 8)
         column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
 
-        # Use Python operators - OR within AND
+        # OR within AND
         row_condition = (column_1 < 8) & ((column_2 > 8) | (column_3 == 8))
 
-        # This should raise ValueError when passed to Expectation
         with pytest.raises(ValueError, match="AND groups cannot contain OR conditions"):
             ExpectColumnValuesToBeInSet(
                 column="test_column", value_set=["a", "b"], row_condition=row_condition
@@ -50,14 +46,12 @@ class TestAndConditionValidator:
 
     def test_error_on_nested_or_within_or_within_and(self):
         """Test that nested OR structures are caught by validation."""
+        column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
-        column_4 = Column(name="column_4")
 
-        # Manually create nested OrCondition (not using operators)
-        nested_or = (column_2 > 8) | ((column_3 == 8) | (column_4 == 9))
+        nested_or = (column_1 > 8) | ((column_2 == 8) | (column_3 == 9))
 
-        # This should fail when passed to Expectation
         with pytest.raises(ValueError, match="OR groups cannot contain nested OR conditions"):
             ExpectColumnValuesToBeInSet(
                 column="test_column", value_set=["a", "b"], row_condition=nested_or
@@ -129,7 +123,6 @@ class TestOrConditionValidator:
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
 
-        # Manually create nested OrCondition (not using operators)
         nested_or_cond = (column_1 < 8) | ((column_2 > 8) | (column_3 == 8))
 
         # This should raise ValueError when passed to Expectation

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -199,25 +199,6 @@ class TestOrConditionValidator:
             )
 
 
-class TestConditionOperators:
-    """Test that the & and | operators work correctly with validation."""
-
-    def test_and_operator_flattens_correctly(self):
-        """Test that using the & operator flattens nested AndConditions."""
-        column_1 = Column(name="column_1")
-        column_2 = Column(name="column_2")
-        column_3 = Column(name="column_3")
-
-        # Create nested structure using & operator
-        row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
-
-        # Pass to Expectation - should flatten to 3 conditions
-        expectation = ExpectColumnValuesToBeInSet(
-            column="test_column", value_set=["a", "b"], row_condition=row_condition
-        )
-        assert len(expectation.row_condition.conditions) == 3
-
-
 class TestValidatorAppliesAcrossExpectations:
     """Test that the validator applies to all BatchExpectation subclasses with row_condition."""
 

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -44,6 +44,10 @@ class TestAndConditionValidator:
                 column="test_column", value_set=["a", "b"], row_condition=row_condition
             )
 
+
+class TestOrConditionValidator:
+    """Tests for OrCondition validator when passed to Expectation."""
+
     def test_error_on_nested_or_within_or_within_and(self):
         """Test that nested OR structures are caught by validation."""
         column_1 = Column(name="column_1")
@@ -57,79 +61,9 @@ class TestAndConditionValidator:
                 column="test_column", value_set=["a", "b"], row_condition=nested_or
             )
 
-    def test_error_on_more_than_100_conditions(self):
-        """Test that more than 100 conditions raises error in Expectation."""
-        column = Column(name="column_1")
 
-        # Create 101 conditions using & operator
-        row_condition = column == 0
-        for i in range(1, 101):
-            row_condition = row_condition & (column == i)
-
-        with pytest.raises(
-            ValueError, match="100 conditions is the maximum, but 101 conditions are defined"
-        ):
-            ExpectColumnValuesToBeInSet(
-                column="test_column", value_set=["a", "b"], row_condition=row_condition
-            )
-
-    def test_exactly_100_conditions_allowed(self):
-        """Test that exactly 100 conditions is allowed in Expectation."""
-        column = Column(name="column_1")
-
-        # Create exactly 100 conditions using & operator
-        row_condition = column == 0
-        for i in range(1, 100):
-            row_condition = row_condition & (column == i)
-
-        # This should not raise an error
-        expectation = ExpectColumnValuesToBeInSet(
-            column="test_column", value_set=["a", "b"], row_condition=row_condition
-        )
-        assert len(expectation.row_condition.conditions) == 100
-
-    def test_nested_conditions_count_towards_limit(self):
-        """Test that nested conditions are counted towards the 100 limit in Expectation."""
-        column = Column(name="column_1")
-
-        # Create nested structure: 50 conditions & (nested 51 conditions)
-        # First group of 50
-        first_group = column == 0
-        for i in range(1, 50):
-            first_group = first_group & (column == i)
-
-        # Second nested group of 51
-        second_group = column == 50
-        for i in range(51, 101):
-            second_group = second_group & (column == i)
-
-        # Combine them - total: 50 + 51 = 101 conditions (flattening occurs)
-        row_condition = first_group & second_group
-
-        with pytest.raises(
-            ValueError, match="100 conditions is the maximum, but 101 conditions are defined"
-        ):
-            ExpectColumnValuesToBeInSet(
-                column="test_column", value_set=["a", "b"], row_condition=row_condition
-            )
-
-
-class TestOrConditionValidator:
-    """Tests for OrCondition validator when passed to Expectation."""
-
-    def test_error_on_nested_or_conditions(self):
-        """Test that manually created nested OR structures are caught by validation."""
-        column_1 = Column(name="column_1")
-        column_2 = Column(name="column_2")
-        column_3 = Column(name="column_3")
-
-        nested_or_cond = (column_1 < 8) | ((column_2 > 8) | (column_3 == 8))
-
-        # This should raise ValueError when passed to Expectation
-        with pytest.raises(ValueError, match="OR groups cannot contain nested OR conditions"):
-            ExpectColumnValuesToBeInSet(
-                column="test_column", value_set=["a", "b"], row_condition=nested_or_cond
-            )
+class TestTotalConditionCountValidator:
+    """Tests for total condition count validator when passed to Expectation."""
 
     def test_error_on_more_than_100_conditions(self):
         """Test that more than 100 conditions raises error in Expectation."""

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -1,0 +1,283 @@
+"""Tests for condition validators on row_condition in Expectations."""
+
+import pytest
+
+from great_expectations.expectations.conditions import Column
+from great_expectations.expectations.core import (
+    ExpectColumnValuesToBeInSet,
+    ExpectTableRowCountToEqual,
+)
+
+
+class TestAndConditionValidator:
+    """Tests for AndCondition validator when passed to Expectation."""
+
+    def test_flatten_nested_and_conditions(self):
+        """Test that nested AndConditions are flattened when passed to Expectation."""
+        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 & column_3 == 8)
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # Use Python operators to build conditions
+        row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
+
+        # Pass to an Expectation - should flatten
+        expectation = ExpectColumnValuesToBeInSet(
+            column="test_column", value_set=["a", "b"], row_condition=row_condition
+        )
+
+        # Verify flattening occurred - should have 3 conditions instead of nested structure
+        assert len(expectation.row_condition.conditions) == 3
+
+    def test_error_on_or_within_and(self):
+        """Test that OrConditions nested within AndConditions raise error in Expectation."""
+        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 | column_3 == 8)
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # Use Python operators - OR within AND
+        row_condition = (column_1 < 8) & ((column_2 > 8) | (column_3 == 8))
+
+        # This should raise ValueError when passed to Expectation
+        with pytest.raises(ValueError, match="AND groups cannot contain OR conditions"):
+            ExpectColumnValuesToBeInSet(
+                column="test_column", value_set=["a", "b"], row_condition=row_condition
+            )
+
+    def test_error_on_nested_or_within_or_within_and(self):
+        """Test that manually created nested OR structures are caught by validation."""
+        # Note: Normal use of the | operator automatically flattens, so this tests
+        # the edge case where someone manually constructs a nested structure
+        from great_expectations.expectations.conditions import OrCondition
+
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+        column_4 = Column(name="column_4")
+
+        # Manually create nested OrCondition (not using operators)
+        nested_or = (column_3 == 8) | (column_4 == 9)
+        outer_or = OrCondition(conditions=[column_2 > 8, nested_or])
+
+        # This should fail when passed to Expectation
+        with pytest.raises(ValueError, match="OR groups cannot contain nested OR conditions"):
+            ExpectColumnValuesToBeInSet(
+                column="test_column", value_set=["a", "b"], row_condition=outer_or
+            )
+
+    def test_error_on_more_than_100_conditions(self):
+        """Test that more than 100 conditions raises error in Expectation."""
+        column = Column(name="column_1")
+
+        # Create 101 conditions using & operator
+        row_condition = column == 0
+        for i in range(1, 101):
+            row_condition = row_condition & (column == i)
+
+        with pytest.raises(
+            ValueError, match="100 conditions is the maximum, but 101 conditions are defined"
+        ):
+            ExpectColumnValuesToBeInSet(
+                column="test_column", value_set=["a", "b"], row_condition=row_condition
+            )
+
+    def test_exactly_100_conditions_allowed(self):
+        """Test that exactly 100 conditions is allowed in Expectation."""
+        column = Column(name="column_1")
+
+        # Create exactly 100 conditions using & operator
+        row_condition = column == 0
+        for i in range(1, 100):
+            row_condition = row_condition & (column == i)
+
+        # This should not raise an error
+        expectation = ExpectColumnValuesToBeInSet(
+            column="test_column", value_set=["a", "b"], row_condition=row_condition
+        )
+        assert len(expectation.row_condition.conditions) == 100
+
+    def test_nested_conditions_count_towards_limit(self):
+        """Test that nested conditions are counted towards the 100 limit in Expectation."""
+        column = Column(name="column_1")
+
+        # Create nested structure: 50 conditions & (nested 51 conditions)
+        # First group of 50
+        first_group = column == 0
+        for i in range(1, 50):
+            first_group = first_group & (column == i)
+
+        # Second nested group of 51
+        second_group = column == 50
+        for i in range(51, 101):
+            second_group = second_group & (column == i)
+
+        # Combine them - total: 50 + 51 = 101 conditions (flattening occurs)
+        row_condition = first_group & second_group
+
+        with pytest.raises(
+            ValueError, match="100 conditions is the maximum, but 101 conditions are defined"
+        ):
+            ExpectColumnValuesToBeInSet(
+                column="test_column", value_set=["a", "b"], row_condition=row_condition
+            )
+
+
+class TestOrConditionValidator:
+    """Tests for OrCondition validator when passed to Expectation."""
+
+    def test_error_on_nested_or_conditions(self):
+        """Test that manually created nested OR structures are caught by validation."""
+        # Note: Normal use of the | operator automatically flattens, so this tests
+        # the edge case where someone manually constructs a nested structure
+        from great_expectations.expectations.conditions import OrCondition
+
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # Manually create nested OrCondition (not using operators)
+        nested_or = (column_2 > 8) | (column_3 == 8)
+        outer_or = OrCondition(conditions=[column_1 < 8, nested_or])
+
+        # This should raise ValueError when passed to Expectation
+        with pytest.raises(ValueError, match="OR groups cannot contain nested OR conditions"):
+            ExpectColumnValuesToBeInSet(
+                column="test_column", value_set=["a", "b"], row_condition=outer_or
+            )
+
+    def test_error_on_more_than_100_conditions(self):
+        """Test that more than 100 conditions raises error in Expectation."""
+        column = Column(name="column_1")
+
+        # Create 101 conditions using | operator
+        row_condition = column == 0
+        for i in range(1, 101):
+            row_condition = row_condition | (column == i)
+
+        with pytest.raises(
+            ValueError, match="100 conditions is the maximum, but 101 conditions are defined"
+        ):
+            ExpectColumnValuesToBeInSet(
+                column="test_column", value_set=["a", "b"], row_condition=row_condition
+            )
+
+    def test_exactly_100_conditions_allowed(self):
+        """Test that exactly 100 conditions is allowed in Expectation."""
+        column = Column(name="column_1")
+
+        # Create exactly 100 conditions using | operator
+        row_condition = column == 0
+        for i in range(1, 100):
+            row_condition = row_condition | (column == i)
+
+        # This should not raise an error
+        expectation = ExpectColumnValuesToBeInSet(
+            column="test_column", value_set=["a", "b"], row_condition=row_condition
+        )
+        assert len(expectation.row_condition.conditions) == 100
+
+    def test_nested_and_conditions_count_towards_limit(self):
+        """Test that nested AndConditions within OR are counted towards the 100 limit."""
+        column = Column(name="column_1")
+
+        # Create first AND group with 50 conditions
+        first_and_group = column == 0
+        for i in range(1, 50):
+            first_and_group = first_and_group & (column == i)
+
+        # Create second AND group with 51 conditions
+        second_and_group = column == 50
+        for i in range(51, 101):
+            second_and_group = second_and_group & (column == i)
+
+        # Combine with OR - total: 50 + 51 = 101 conditions
+        row_condition = first_and_group | second_and_group
+
+        with pytest.raises(
+            ValueError, match="100 conditions is the maximum, but 101 conditions are defined"
+        ):
+            ExpectColumnValuesToBeInSet(
+                column="test_column", value_set=["a", "b"], row_condition=row_condition
+            )
+
+    def test_or_condition_with_and_conditions_allowed(self):
+        """Test that OrConditions can contain AndConditions in Expectation."""
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # Use Python operators: (column_1 < 8) | (column_2 > 8 & column_3 == 8)
+        row_condition = (column_1 < 8) | ((column_2 > 8) & (column_3 == 8))
+
+        # This should be allowed
+        expectation = ExpectColumnValuesToBeInSet(
+            column="test_column", value_set=["a", "b"], row_condition=row_condition
+        )
+        assert len(expectation.row_condition.conditions) == 2
+
+
+class TestConditionOperators:
+    """Test that the & and | operators work correctly with validation."""
+
+    def test_and_operator_flattens_correctly(self):
+        """Test that using the & operator flattens nested AndConditions."""
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # Create nested structure using & operator
+        row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
+
+        # Pass to Expectation - should flatten to 3 conditions
+        expectation = ExpectColumnValuesToBeInSet(
+            column="test_column", value_set=["a", "b"], row_condition=row_condition
+        )
+        assert len(expectation.row_condition.conditions) == 3
+
+    def test_or_operator_flattens_correctly(self):
+        """Test that the | operator flattens OrConditions."""
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # The | operator should flatten, so this creates a flat OrCondition
+        row_condition = (column_1 < 8) | (column_2 > 8) | (column_3 == 8)
+
+        # This should work fine in an Expectation
+        expectation = ExpectColumnValuesToBeInSet(
+            column="test_column", value_set=["a", "b"], row_condition=row_condition
+        )
+        assert len(expectation.row_condition.conditions) == 3
+
+
+class TestValidatorAppliesAcrossExpectations:
+    """Test that the validator applies to all BatchExpectation subclasses with row_condition."""
+
+    def test_validator_applies_to_core_expectations(self):
+        """Test that expectations in core/ directory also get validated."""
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # Create condition using Python operators: column_1 < 8 & (column_2 > 8 | column_3 == 8)
+        row_condition = (column_1 < 8) & ((column_2 > 8) | (column_3 == 8))
+
+        # This should raise ValueError even for ExpectTableRowCountToEqual
+        with pytest.raises(ValueError, match="AND groups cannot contain OR conditions"):
+            ExpectTableRowCountToEqual(value=10, row_condition=row_condition)
+
+    def test_validator_flattens_in_core_expectations(self):
+        """Test that flattening works for expectations in core/ directory."""
+        column_1 = Column(name="column_1")
+        column_2 = Column(name="column_2")
+        column_3 = Column(name="column_3")
+
+        # Use Python operators to create nested structure
+        row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
+
+        # Pass to ExpectTableRowCountToEqual - should flatten
+        expectation = ExpectTableRowCountToEqual(value=10, row_condition=row_condition)
+
+        # Verify flattening occurred
+        assert len(expectation.row_condition.conditions) == 3

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -49,23 +49,18 @@ class TestAndConditionValidator:
             )
 
     def test_error_on_nested_or_within_or_within_and(self):
-        """Test that manually created nested OR structures are caught by validation."""
-        # Note: Normal use of the | operator automatically flattens, so this tests
-        # the edge case where someone manually constructs a nested structure
-        from great_expectations.expectations.conditions import OrCondition
-
+        """Test that nested OR structures are caught by validation."""
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
         column_4 = Column(name="column_4")
 
         # Manually create nested OrCondition (not using operators)
-        nested_or = (column_3 == 8) | (column_4 == 9)
-        outer_or = OrCondition(conditions=[column_2 > 8, nested_or])
+        nested_or = (column_2 > 8) | ((column_3 == 8) | (column_4 == 9))
 
         # This should fail when passed to Expectation
         with pytest.raises(ValueError, match="OR groups cannot contain nested OR conditions"):
             ExpectColumnValuesToBeInSet(
-                column="test_column", value_set=["a", "b"], row_condition=outer_or
+                column="test_column", value_set=["a", "b"], row_condition=nested_or
             )
 
     def test_error_on_more_than_100_conditions(self):

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -8,16 +8,20 @@ from great_expectations.expectations.core import (
     ExpectTableRowCountToEqual,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestAndConditionValidator:
     """Tests for AndCondition validator when passed to Expectation."""
 
     def test_flatten_nested_and_conditions(self):
         """Test that nested AndConditions are flattened when passed to Expectation."""
+        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 & column_3 == 8)
         column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
 
+        # Use Python operators to build conditions
         row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
 
         # Pass to an Expectation - should flatten
@@ -30,6 +34,7 @@ class TestAndConditionValidator:
 
     def test_error_on_or_within_and(self):
         """Test that OrConditions nested within AndConditions raise error in Expectation."""
+        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 | column_3 == 8)
         column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
@@ -125,32 +130,27 @@ class TestOrConditionValidator:
 
     def test_error_on_nested_or_conditions(self):
         """Test that manually created nested OR structures are caught by validation."""
-        # Note: Normal use of the | operator automatically flattens, so this tests
-        # the edge case where someone manually constructs a nested structure
-        from great_expectations.expectations.conditions import OrCondition
-
         column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
 
         # Manually create nested OrCondition (not using operators)
-        nested_or = (column_2 > 8) | (column_3 == 8)
-        outer_or = OrCondition(conditions=[column_1 < 8, nested_or])
+        nested_or_cond = (column_1 < 8) | ((column_2 > 8) | (column_3 == 8))
 
         # This should raise ValueError when passed to Expectation
         with pytest.raises(ValueError, match="OR groups cannot contain nested OR conditions"):
             ExpectColumnValuesToBeInSet(
-                column="test_column", value_set=["a", "b"], row_condition=outer_or
+                column="test_column", value_set=["a", "b"], row_condition=nested_or_cond
             )
 
     def test_error_on_more_than_100_conditions(self):
         """Test that more than 100 conditions raises error in Expectation."""
         column = Column(name="column_1")
 
-        # Create 101 conditions using | operator
+        # Create 101 conditions
         row_condition = column == 0
         for i in range(1, 101):
-            row_condition = row_condition | (column == i)
+            row_condition = row_condition & (column == i)
 
         with pytest.raises(
             ValueError, match="100 conditions is the maximum, but 101 conditions are defined"
@@ -163,10 +163,10 @@ class TestOrConditionValidator:
         """Test that exactly 100 conditions is allowed in Expectation."""
         column = Column(name="column_1")
 
-        # Create exactly 100 conditions using | operator
+        # Create exactly 100 condition
         row_condition = column == 0
         for i in range(1, 100):
-            row_condition = row_condition | (column == i)
+            row_condition = row_condition & (column == i)
 
         # This should not raise an error
         expectation = ExpectColumnValuesToBeInSet(
@@ -212,21 +212,6 @@ class TestConditionOperators:
         row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
 
         # Pass to Expectation - should flatten to 3 conditions
-        expectation = ExpectColumnValuesToBeInSet(
-            column="test_column", value_set=["a", "b"], row_condition=row_condition
-        )
-        assert len(expectation.row_condition.conditions) == 3
-
-    def test_or_operator_flattens_correctly(self):
-        """Test that the | operator flattens OrConditions."""
-        column_1 = Column(name="column_1")
-        column_2 = Column(name="column_2")
-        column_3 = Column(name="column_3")
-
-        # The | operator should flatten, so this creates a flat OrCondition
-        row_condition = (column_1 < 8) | (column_2 > 8) | (column_3 == 8)
-
-        # This should work fine in an Expectation
         expectation = ExpectColumnValuesToBeInSet(
             column="test_column", value_set=["a", "b"], row_condition=row_condition
         )

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -14,12 +14,10 @@ class TestAndConditionValidator:
 
     def test_flatten_nested_and_conditions(self):
         """Test that nested AndConditions are flattened when passed to Expectation."""
-        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 & column_3 == 8)
         column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
 
-        # Use Python operators to build conditions
         row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
 
         # Pass to an Expectation - should flatten
@@ -32,7 +30,6 @@ class TestAndConditionValidator:
 
     def test_error_on_or_within_and(self):
         """Test that OrConditions nested within AndConditions raise error in Expectation."""
-        # Create conditions using Column API: column_1 < 8 & (column_2 > 8 | column_3 == 8)
         column_1 = Column(name="column_1")
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
@@ -201,21 +198,6 @@ class TestOrConditionValidator:
                 column="test_column", value_set=["a", "b"], row_condition=row_condition
             )
 
-    def test_or_condition_with_and_conditions_allowed(self):
-        """Test that OrConditions can contain AndConditions in Expectation."""
-        column_1 = Column(name="column_1")
-        column_2 = Column(name="column_2")
-        column_3 = Column(name="column_3")
-
-        # Use Python operators: (column_1 < 8) | (column_2 > 8 & column_3 == 8)
-        row_condition = (column_1 < 8) | ((column_2 > 8) & (column_3 == 8))
-
-        # This should be allowed
-        expectation = ExpectColumnValuesToBeInSet(
-            column="test_column", value_set=["a", "b"], row_condition=row_condition
-        )
-        assert len(expectation.row_condition.conditions) == 2
-
 
 class TestConditionOperators:
     """Test that the & and | operators work correctly with validation."""
@@ -260,24 +242,8 @@ class TestValidatorAppliesAcrossExpectations:
         column_2 = Column(name="column_2")
         column_3 = Column(name="column_3")
 
-        # Create condition using Python operators: column_1 < 8 & (column_2 > 8 | column_3 == 8)
         row_condition = (column_1 < 8) & ((column_2 > 8) | (column_3 == 8))
 
         # This should raise ValueError even for ExpectTableRowCountToEqual
         with pytest.raises(ValueError, match="AND groups cannot contain OR conditions"):
             ExpectTableRowCountToEqual(value=10, row_condition=row_condition)
-
-    def test_validator_flattens_in_core_expectations(self):
-        """Test that flattening works for expectations in core/ directory."""
-        column_1 = Column(name="column_1")
-        column_2 = Column(name="column_2")
-        column_3 = Column(name="column_3")
-
-        # Use Python operators to create nested structure
-        row_condition = (column_1 < 8) & ((column_2 > 8) & (column_3 == 8))
-
-        # Pass to ExpectTableRowCountToEqual - should flatten
-        expectation = ExpectTableRowCountToEqual(value=10, row_condition=row_condition)
-
-        # Verify flattening occurred
-        assert len(expectation.row_condition.conditions) == 3

--- a/tests/expectations/test_conditions.py
+++ b/tests/expectations/test_conditions.py
@@ -33,72 +33,12 @@ class TestCondition:
         result = condition_a & condition_b
         assert result == AndCondition(conditions=[condition_a, condition_b])
 
-    def test_and_with_and_on_left(sef):
-        condition_a = Condition()
-        condition_b = Condition()
-        condition_c = Condition()
-
-        left_condition = AndCondition(conditions=[condition_a, condition_b])
-
-        result = left_condition & condition_c
-        assert result == AndCondition(conditions=[condition_a, condition_b, condition_c])
-
-    def test_and_with_and_on_right(sef):
-        condition_a = Condition()
-        condition_b = Condition()
-        condition_c = Condition()
-
-        right_condition = AndCondition(conditions=[condition_b, condition_c])
-
-        result = condition_a & right_condition
-        assert result == AndCondition(conditions=[condition_a, condition_b, condition_c])
-
     def test_or_with_two_conditions(sef):
         condition_a = Condition()
         condition_b = Condition()
 
         result = condition_a | condition_b
         assert result == OrCondition(conditions=[condition_a, condition_b])
-
-    def test_or_with_or_on_left(sef):
-        condition_a = Condition()
-        condition_b = Condition()
-        condition_c = Condition()
-
-        left_condition = OrCondition(conditions=[condition_a, condition_b])
-
-        result = left_condition | condition_c
-        assert result == OrCondition(conditions=[condition_a, condition_b, condition_c])
-
-    def test_or_with_or_on_right(sef):
-        condition_a = Condition()
-        condition_b = Condition()
-        condition_c = Condition()
-
-        right_condition = OrCondition(conditions=[condition_b, condition_c])
-
-        result = condition_a | right_condition
-        assert result == OrCondition(conditions=[condition_a, condition_b, condition_c])
-
-    def test_flattening_and(self):
-        """Test that OrCondition flattens nested AndConditions."""
-        cond1 = Condition()
-        cond2 = Condition()
-        cond3 = Condition()
-
-        result = cond1 & cond2 & cond3
-
-        assert result == AndCondition(conditions=[cond1, cond2, cond3])
-
-    def test_flattening_or(self):
-        """Test that OrCondition flattens nested AndConditions."""
-        cond1 = Condition()
-        cond2 = Condition()
-        cond3 = Condition()
-
-        result = cond1 | cond2 | cond3
-
-        assert result == OrCondition(conditions=[cond1, cond2, cond3])
 
 
 class TestAndCondition:
@@ -358,35 +298,6 @@ class TestComplexExpressions:
                 AndCondition(conditions=[cond3, cond4]),
             ]
         )
-
-    def test_multiple_ands_flatten(self):
-        """Test that multiple ANDs flatten into a single AndCondition."""
-        col1 = Column(name="age")
-        col2 = Column(name="status")
-        col3 = Column(name="score")
-        col4 = Column(name="city")
-
-        cond1 = col1 > 18
-        cond2 = col2 == "active"
-        cond3 = col3 >= 80
-        cond4 = col4 == "NYC"
-
-        result = cond1 & cond2 & cond3 & cond4
-
-        assert result == AndCondition(conditions=[cond1, cond2, cond3, cond4])
-
-    def test_multiple_ors_flatten(self):
-        """Test that multiple ORs flatten into a single OrCondition."""
-        col1 = Column(name="status")
-
-        cond1 = col1 == "active"
-        cond2 = col1 == "pending"
-        cond3 = col1 == "approved"
-        cond4 = col1 == "verified"
-
-        result = cond1 | cond2 | cond3 | cond4
-
-        assert result == OrCondition(conditions=[cond1, cond2, cond3, cond4])
 
 
 class TestConditionSerialization:


### PR DESCRIPTION
- If users attempt to pass `AndCondition`s nested within `AndCondition`s, we should flatten them.
- If users attempt to pass `OrCondition`s nested within `AndCondition`s, we should raise an error.
- If users attempt to pass `OrCondition`s nested within `OrCondition`s, we should raise an error. Flattening them doesn’t work in this case because logical ORs are non-associative, while logical ANDs are associative.
- If users attempt to pass more than 100 Conditions, we should raise an error.