### PR TITLE
[MAINTENANCE] Only install mssql drivers when needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,9 +244,6 @@ jobs:
           # Authorize access to Google Cloud with a service account
           ./google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
-      - name: Install mssql odbc driver
-        run: ./scripts/install_mssql_odbc_driver.sh
-
       - name: Install cloud dependencies
         if: ${{ matrix.start_services }}
         run: |
@@ -710,6 +707,7 @@ jobs:
           invoke deps --gx-install -m '${{ matrix.markers }}' -r test
 
       - name: Install mssql odbc driver
+        if: matrix.markers == 'mssql'
         run: ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,7 +707,7 @@ jobs:
           invoke deps --gx-install -m '${{ matrix.markers }}' -r test
 
       - name: Install mssql odbc driver
-        if: ${{ matrix.markers == 'mssql' }}
+        if: matrix.markers == 'mssql'
         run: ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,7 +707,7 @@ jobs:
           invoke deps --gx-install -m '${{ matrix.markers }}' -r test
 
       - name: Install mssql odbc driver
-        if: matrix.markers == 'mssql'
+        if: ${{ matrix.markers == 'mssql' }}
         run: ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,14 +721,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run the tests
-        run: |
-          if [ "${{ matrix.markers }}" == "mssql" ]; then
-            # Make mssql tests optional - exit 0 even if tests fail
-            # TODO: remove this once microsoft package repository issues are fixed
-            invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports || exit 0
-          else
-            invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports
-          fi
+        run: invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports
 
       # upload coverage report to codecov
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,17 +706,22 @@ jobs:
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
           invoke deps --gx-install -m '${{ matrix.markers }}' -r test
 
+      - name: Debug matrix markers value
+        run: |
+          echo "=========================================="
+          echo "DEBUG: matrix.markers = '${{ matrix.markers }}'"
+          echo "This debug step always runs (no if condition)"
+          echo "=========================================="
+
       - name: Install mssql odbc driver
         run: |
-          echo "=== DEBUG: Starting mssql driver installation step ==="
-          echo "DEBUG: matrix.markers = '${{ matrix.markers }}'"
-          echo "DEBUG: Checking if '${{ matrix.markers }}' equals 'mssql'"
+          echo "Inside Install mssql odbc driver step"
+          echo "Marker value: '${{ matrix.markers }}'"
           if [ "${{ matrix.markers }}" != "mssql" ]; then
-            echo "=== DEBUG: Marker is NOT mssql, skipping installation ==="
-            echo "Skipping mssql driver installation - marker is '${{ matrix.markers }}', not 'mssql'"
+            echo "Marker '${{ matrix.markers }}' is NOT 'mssql' - SKIPPING installation"
             exit 0
           fi
-          echo "=== DEBUG: Marker is mssql, proceeding with installation ==="
+          echo "Marker is 'mssql' - proceeding with installation"
           ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,8 +721,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run the tests
-        continue-on-error: ${{ matrix.markers == 'mssql' }}
-        run: invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports
+        run: |
+          if [ "${{ matrix.markers }}" == "mssql" ]; then
+            # Make mssql tests optional - exit 0 even if tests fail
+            # TODO: remove this once microsoft package repository issues are fixed
+            invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports || exit 0
+          else
+            invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports
+          fi
 
       # upload coverage report to codecov
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,7 +708,10 @@ jobs:
 
       - name: Install mssql odbc driver
         if: ${{ matrix.markers == 'mssql' }}
-        run: ./scripts/install_mssql_odbc_driver.sh
+        run: |
+          echo "DEBUG: matrix.markers value is: '${{ matrix.markers }}'"
+          echo "DEBUG: Condition should check if '${{ matrix.markers }}' == 'mssql'"
+          ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,9 @@ jobs:
           # Authorize access to Google Cloud with a service account
           ./google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
+      - name: Install mssql odbc driver
+        run: ./scripts/install_mssql_odbc_driver.sh
+
       - name: Install cloud dependencies
         if: ${{ matrix.start_services }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,10 +708,15 @@ jobs:
 
       - name: Install mssql odbc driver
         run: |
+          echo "=== DEBUG: Starting mssql driver installation step ==="
+          echo "DEBUG: matrix.markers = '${{ matrix.markers }}'"
+          echo "DEBUG: Checking if '${{ matrix.markers }}' equals 'mssql'"
           if [ "${{ matrix.markers }}" != "mssql" ]; then
+            echo "=== DEBUG: Marker is NOT mssql, skipping installation ==="
             echo "Skipping mssql driver installation - marker is '${{ matrix.markers }}', not 'mssql'"
             exit 0
           fi
+          echo "=== DEBUG: Marker is mssql, proceeding with installation ==="
           ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,7 +708,6 @@ jobs:
 
       - name: Install mssql odbc driver
         if: matrix.markers == 'mssql'
-        continue-on-error: true
         run: ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials
@@ -722,6 +721,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run the tests
+        continue-on-error: ${{ matrix.markers == 'mssql' }}
         run: invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports
 
       # upload coverage report to codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,10 +707,11 @@ jobs:
           invoke deps --gx-install -m '${{ matrix.markers }}' -r test
 
       - name: Install mssql odbc driver
-        if: ${{ matrix.markers == 'mssql' }}
         run: |
-          echo "DEBUG: matrix.markers value is: '${{ matrix.markers }}'"
-          echo "DEBUG: Condition should check if '${{ matrix.markers }}' == 'mssql'"
+          if [ "${{ matrix.markers }}" != "mssql" ]; then
+            echo "Skipping mssql driver installation - marker is '${{ matrix.markers }}', not 'mssql'"
+            exit 0
+          fi
           ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
           ./google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
       - name: Install mssql odbc driver
+        continue-on-error: true
         run: ./scripts/install_mssql_odbc_driver.sh
 
       - name: Install cloud dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,10 +244,6 @@ jobs:
           # Authorize access to Google Cloud with a service account
           ./google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
-      - name: Install mssql odbc driver
-        continue-on-error: true
-        run: ./scripts/install_mssql_odbc_driver.sh
-
       - name: Install cloud dependencies
         if: ${{ matrix.start_services }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,23 +706,10 @@ jobs:
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
           invoke deps --gx-install -m '${{ matrix.markers }}' -r test
 
-      - name: Debug matrix markers value
-        run: |
-          echo "=========================================="
-          echo "DEBUG: matrix.markers = '${{ matrix.markers }}'"
-          echo "This debug step always runs (no if condition)"
-          echo "=========================================="
-
       - name: Install mssql odbc driver
-        run: |
-          echo "Inside Install mssql odbc driver step"
-          echo "Marker value: '${{ matrix.markers }}'"
-          if [ "${{ matrix.markers }}" != "mssql" ]; then
-            echo "Marker '${{ matrix.markers }}' is NOT 'mssql' - SKIPPING installation"
-            exit 0
-          fi
-          echo "Marker is 'mssql' - proceeding with installation"
-          ./scripts/install_mssql_odbc_driver.sh
+        if: matrix.markers == 'mssql'
+        continue-on-error: true
+        run: ./scripts/install_mssql_odbc_driver.sh
 
       - name: Configure ECR AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/scripts/install_mssql_odbc_driver.sh
+++ b/scripts/install_mssql_odbc_driver.sh
@@ -10,7 +10,7 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 
 # Download the package to configure the Microsoft repo
-curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)/packages-microsoft-prod.deb
+curl -sSL --retry 2 -O https://packages.microsoft.com/config/ubuntu/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)/packages-microsoft-prod.deb
 
 sudo dpkg --force-confdef --force-confold -i packages-microsoft-prod.deb
 # Delete the file

--- a/scripts/install_mssql_odbc_driver.sh
+++ b/scripts/install_mssql_odbc_driver.sh
@@ -3,19 +3,33 @@
 if ! [[ "18.04 20.04 22.04 24.04" == *"$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)"* ]];
 then
     echo "Ubuntu $(grep VERSION_ID /etc/os-release | cut -d '"' -f 2) is not currently supported.";
-    exit;
+    exit 1;
 fi
 
 # Set non-interactive mode to avoid prompts in CI
 export DEBIAN_FRONTEND=noninteractive
 
+UBUNTU_VERSION=$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)
+PACKAGE_FILE="packages-microsoft-prod.deb"
+
 # Download the package to configure the Microsoft repo
-curl -sSL --retry 2 -O https://packages.microsoft.com/config/ubuntu/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)/packages-microsoft-prod.deb
+if ! curl -sSL --connect-timeout 10 --max-time 30 -o "$PACKAGE_FILE" "https://packages.microsoft.com/config/ubuntu/${UBUNTU_VERSION}/packages-microsoft-prod.deb"; then
+    echo "Warning: Failed to download Microsoft packages repository configuration. packages.microsoft.com may be down."
+    exit 1
+fi
 
-sudo dpkg --force-confdef --force-confold -i packages-microsoft-prod.deb
+# Verify the file was downloaded
+if [ ! -f "$PACKAGE_FILE" ] || [ ! -s "$PACKAGE_FILE" ]; then
+    echo "Warning: Downloaded file is missing or empty."
+    exit 1
+fi
+
+sudo dpkg --force-confdef --force-confold -i "$PACKAGE_FILE" || true
 # Delete the file
-rm packages-microsoft-prod.deb
+rm -f "$PACKAGE_FILE"
 
-sudo apt-get update
-sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
-sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18
+sudo apt-get update || true
+
+# Install packages, continuing even if they fail due to network issues
+sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 || echo "Warning: Failed to install msodbcsql18"
+sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18 || echo "Warning: Failed to install mssql-tools18"

--- a/tasks.py
+++ b/tasks.py
@@ -827,15 +827,13 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         # these installs are handled by the CI
         requirement_files=(
             "reqs/requirements-dev-test.txt",
-            "reqs/requirements-dev-mssql.txt",
             "reqs/requirements-dev-mysql.txt",
             "reqs/requirements-dev-postgresql.txt",
             # "Deprecated API features detected" warning/error for test_docs[split_data_on_whole_table_bigquery] when pandas>=2.0  # noqa: E501
             "reqs/requirements-dev-trino.txt",
         ),
-        services=("postgresql", "mssql", "mysql", "trino"),
+        services=("postgresql", "mysql", "trino"),
         extra_pytest_args=(
-            "--mssql",
             "--mysql",
             "--postgresql",
             "--trino",


### PR DESCRIPTION
[packages.microsoft.com](https://packages.microsoft.com) was down, but now it's fixed. This PR removes the dependency from CI where possible.

Successful CI workflow run: [https://github.com/great-expectations/great_expectations/actions/runs/18921336814/job/54023634797](https://github.com/great-expectations/great_expectations/actions/runs/18921336814/job/54023634797)

- Only install mssql driver on mssql marker
- Improve error handling in bash script
- Rip mssql dependencies out of docs tests
-----------------
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated