### PR TITLE
[MAINTENANCE] Handle `None` parameter in `Condition`s

### DIFF
--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Union
 
-from great_expectations.compatibility.pydantic import BaseModel, Field, validator
+from great_expectations.compatibility.pydantic import BaseModel, Field, root_validator, validator
 from great_expectations.compatibility.typing_extensions import override
 
 if TYPE_CHECKING:
@@ -84,30 +84,24 @@ class Column(BaseModel):
 
     @override
     def __eq__(self, other: Parameter) -> ComparisonCondition:  # type: ignore[override]
-        self._validate_parameter(other, Operator.EQUAL)
         return ComparisonCondition(column=self, operator=Operator.EQUAL, parameter=other)
 
     @override
     def __ne__(self, other: Parameter) -> ComparisonCondition:  # type: ignore[override]
-        self._validate_parameter(other, Operator.NOT_EQUAL)
         return ComparisonCondition(column=self, operator=Operator.NOT_EQUAL, parameter=other)
 
     def __lt__(self, other: Parameter) -> ComparisonCondition:
-        self._validate_parameter(other, Operator.LESS_THAN)
         return ComparisonCondition(column=self, operator=Operator.LESS_THAN, parameter=other)
 
     def __le__(self, other: Parameter) -> ComparisonCondition:
-        self._validate_parameter(other, Operator.LESS_THAN_OR_EQUAL)
         return ComparisonCondition(
             column=self, operator=Operator.LESS_THAN_OR_EQUAL, parameter=other
         )
 
     def __gt__(self, other: Parameter) -> ComparisonCondition:
-        self._validate_parameter(other, Operator.GREATER_THAN)
         return ComparisonCondition(column=self, operator=Operator.GREATER_THAN, parameter=other)
 
     def __ge__(self, other: Parameter) -> ComparisonCondition:
-        self._validate_parameter(other, Operator.GREATER_THAN_OR_EQUAL)
         return ComparisonCondition(
             column=self, operator=Operator.GREATER_THAN_OR_EQUAL, parameter=other
         )
@@ -123,17 +117,6 @@ class Column(BaseModel):
 
     def is_not_null(self) -> NullityCondition:
         return NullityCondition(column=self, is_null=False)
-
-    def _validate_parameter(self, parameter: Parameter, operator: Operator) -> Parameter:
-        if parameter is None:
-            if operator == Operator.EQUAL:
-                suggestion = "Did you mean to use Column.is_null()?"
-            elif operator == Operator.NOT_EQUAL:
-                suggestion = "Did you mean to use Column.is_not_null()?"
-            else:
-                suggestion = None
-            raise InvalidParameterTypeError(parameter, suggestion)
-        return parameter
 
 
 class Condition(BaseModel):
@@ -182,11 +165,19 @@ class ComparisonCondition(Condition):
     operator: Operator
     parameter: Parameter = Field(...)
 
-    @validator("parameter")
-    def _validate_parameter_not_none(cls, v):
-        if v is None:
-            raise InvalidParameterTypeError(v)
-        return v
+    @root_validator
+    def _validate_parameter_not_none(cls, values):
+        parameter = values.get("parameter")
+        operator = values.get("operator")
+        if parameter is None:
+            if operator == Operator.EQUAL:
+                suggestion = "Did you mean to use Column.is_null()?"
+            elif operator == Operator.NOT_EQUAL:
+                suggestion = "Did you mean to use Column.is_not_null()?"
+            else:
+                suggestion = None
+            raise InvalidParameterTypeError(parameter, suggestion)
+        return values
 
     @override
     def __repr__(self):

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Union, overload
 
 from great_expectations.compatibility.pydantic import BaseModel, Field, validator
 from great_expectations.compatibility.typing_extensions import override
@@ -47,6 +47,13 @@ class TooManyConditionsError(ValueError):
         )
 
 
+class InvalidParameterTypeError(TypeError):
+    """Raised when the type of the parameter is invalid."""
+
+    def __init__(self, parameter: Any):
+        super().__init__(f"Invalid Parameter type: {type(parameter)}")
+
+
 class Operator(str, Enum):
     EQUAL = "=="
     NOT_EQUAL = "!="
@@ -72,12 +79,28 @@ class Column(BaseModel):
     def __hash__(self) -> int:
         return hash(self.name)
 
-    @override
-    def __eq__(self, other: Parameter) -> ComparisonCondition:  # type: ignore[override]
-        return ComparisonCondition(column=self, operator=Operator.EQUAL, parameter=other)
+    @overload  # type: ignore[override]
+    def __eq__(self, other: None) -> NullityCondition: ...
+
+    @overload  # type: ignore[override]
+    def __eq__(self, other: Parameter) -> ComparisonCondition: ...
 
     @override
-    def __ne__(self, other: Parameter) -> ComparisonCondition:  # type: ignore[override]
+    def __eq__(self, other: Parameter) -> ComparisonCondition | NullityCondition:  # type: ignore[override]
+        if other is None:
+            return NullityCondition(column=self, is_null=True)
+        return ComparisonCondition(column=self, operator=Operator.EQUAL, parameter=other)
+
+    @overload  # type: ignore[override]
+    def __ne__(self, other: None) -> NullityCondition: ...
+
+    @overload  # type: ignore[override]
+    def __ne__(self, other: Parameter) -> ComparisonCondition: ...
+
+    @override
+    def __ne__(self, other: Parameter) -> ComparisonCondition | NullityCondition:  # type: ignore[override]
+        if other is None:
+            return NullityCondition(column=self, is_null=False)
         return ComparisonCondition(column=self, operator=Operator.NOT_EQUAL, parameter=other)
 
     def __lt__(self, other: Parameter) -> ComparisonCondition:
@@ -153,7 +176,13 @@ class ComparisonCondition(Condition):
     type: Literal["comparison"] = Field(default="comparison")
     column: Column
     operator: Operator
-    parameter: Parameter
+    parameter: Parameter = Field(...)
+
+    @validator("parameter")
+    def _validate_parameter_not_none(cls, v):
+        if v is None:
+            raise InvalidParameterTypeError(v)
+        return v
 
     @override
     def __repr__(self):

--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Union, overload
+from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Union
 
 from great_expectations.compatibility.pydantic import BaseModel, Field, validator
 from great_expectations.compatibility.typing_extensions import override
@@ -50,8 +50,11 @@ class TooManyConditionsError(ValueError):
 class InvalidParameterTypeError(TypeError):
     """Raised when the type of the parameter is invalid."""
 
-    def __init__(self, parameter: Any):
-        super().__init__(f"Invalid Parameter type: {type(parameter)}")
+    def __init__(self, parameter: Any, suggestion: str | None = None):
+        message = f"Invalid Parameter type: {type(parameter)}"
+        if suggestion:
+            message += f". {suggestion}"
+        super().__init__(message)
 
 
 class Operator(str, Enum):
@@ -79,42 +82,32 @@ class Column(BaseModel):
     def __hash__(self) -> int:
         return hash(self.name)
 
-    @overload  # type: ignore[override]
-    def __eq__(self, other: None) -> NullityCondition: ...
-
-    @overload  # type: ignore[override]
-    def __eq__(self, other: Parameter) -> ComparisonCondition: ...
-
     @override
-    def __eq__(self, other: Parameter) -> ComparisonCondition | NullityCondition:  # type: ignore[override]
-        if other is None:
-            return NullityCondition(column=self, is_null=True)
+    def __eq__(self, other: Parameter) -> ComparisonCondition:  # type: ignore[override]
+        self._validate_parameter(other, Operator.EQUAL)
         return ComparisonCondition(column=self, operator=Operator.EQUAL, parameter=other)
 
-    @overload  # type: ignore[override]
-    def __ne__(self, other: None) -> NullityCondition: ...
-
-    @overload  # type: ignore[override]
-    def __ne__(self, other: Parameter) -> ComparisonCondition: ...
-
     @override
-    def __ne__(self, other: Parameter) -> ComparisonCondition | NullityCondition:  # type: ignore[override]
-        if other is None:
-            return NullityCondition(column=self, is_null=False)
+    def __ne__(self, other: Parameter) -> ComparisonCondition:  # type: ignore[override]
+        self._validate_parameter(other, Operator.NOT_EQUAL)
         return ComparisonCondition(column=self, operator=Operator.NOT_EQUAL, parameter=other)
 
     def __lt__(self, other: Parameter) -> ComparisonCondition:
+        self._validate_parameter(other, Operator.LESS_THAN)
         return ComparisonCondition(column=self, operator=Operator.LESS_THAN, parameter=other)
 
     def __le__(self, other: Parameter) -> ComparisonCondition:
+        self._validate_parameter(other, Operator.LESS_THAN_OR_EQUAL)
         return ComparisonCondition(
             column=self, operator=Operator.LESS_THAN_OR_EQUAL, parameter=other
         )
 
     def __gt__(self, other: Parameter) -> ComparisonCondition:
+        self._validate_parameter(other, Operator.GREATER_THAN)
         return ComparisonCondition(column=self, operator=Operator.GREATER_THAN, parameter=other)
 
     def __ge__(self, other: Parameter) -> ComparisonCondition:
+        self._validate_parameter(other, Operator.GREATER_THAN_OR_EQUAL)
         return ComparisonCondition(
             column=self, operator=Operator.GREATER_THAN_OR_EQUAL, parameter=other
         )
@@ -130,6 +123,17 @@ class Column(BaseModel):
 
     def is_not_null(self) -> NullityCondition:
         return NullityCondition(column=self, is_null=False)
+
+    def _validate_parameter(self, parameter: Parameter, operator: Operator) -> Parameter:
+        if parameter is None:
+            if operator == Operator.EQUAL:
+                suggestion = "Did you mean to use Column.is_null()?"
+            elif operator == Operator.NOT_EQUAL:
+                suggestion = "Did you mean to use Column.is_not_null()?"
+            else:
+                suggestion = None
+            raise InvalidParameterTypeError(parameter, suggestion)
+        return parameter
 
 
 class Condition(BaseModel):

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToBeInSet.json
@@ -390,7 +390,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToContainSet.json
@@ -390,7 +390,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnDistinctValuesToEqualSet.json
@@ -390,7 +390,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnKLDivergenceToBeLessThan.json
@@ -418,7 +418,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMaxToBeBetween.json
@@ -384,7 +384,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMeanToBeBetween.json
@@ -384,7 +384,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMedianToBeBetween.json
@@ -384,7 +384,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMinToBeBetween.json
@@ -384,7 +384,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnMostCommonValueToBeInSet.json
@@ -402,7 +402,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesAToBeGreaterThanB.json
@@ -370,7 +370,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeEqual.json
@@ -359,7 +359,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnPairValuesToBeInSet.json
@@ -378,7 +378,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfNonNullValuesToBeBetween.json
@@ -371,7 +371,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnProportionOfUniqueValuesToBeBetween.json
@@ -385,7 +385,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnQuantileValuesToBeBetween.json
@@ -346,7 +346,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnStdevToBeBetween.json
@@ -368,7 +368,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnSumToBeBetween.json
@@ -384,7 +384,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnUniqueValueCountToBeBetween.json
@@ -385,7 +385,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToBeBetween.json
@@ -384,7 +384,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueLengthsToEqual.json
@@ -347,7 +347,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValueZScoresToBeLessThan.json
@@ -360,7 +360,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeBetween.json
@@ -400,7 +400,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInSet.json
@@ -406,7 +406,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeInTypeList.json
@@ -345,7 +345,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeNull.json
@@ -334,7 +334,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeOfType.json
@@ -347,7 +347,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToBeUnique.json
@@ -334,7 +334,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePattern.json
@@ -345,7 +345,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchLikePatternList.json
@@ -365,7 +365,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegex.json
@@ -345,7 +345,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToMatchRegexList.json
@@ -365,7 +365,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeInSet.json
@@ -406,7 +406,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotBeNull.json
@@ -334,7 +334,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePattern.json
@@ -344,7 +344,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchLikePatternList.json
@@ -347,7 +347,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegex.json
@@ -344,7 +344,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnValuesToNotMatchRegexList.json
@@ -347,7 +347,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
+++ b/great_expectations/expectations/core/schemas/ExpectCompoundColumnsToBeUnique.json
@@ -346,7 +346,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectMulticolumnSumToEqual.json
@@ -367,7 +367,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
+++ b/great_expectations/expectations/core/schemas/ExpectSelectColumnValuesToBeUniqueWithinRecord.json
@@ -349,7 +349,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToBeBetween.json
@@ -367,7 +367,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqual.json
@@ -324,7 +324,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
+++ b/great_expectations/expectations/core/schemas/ExpectTableRowCountToEqualOtherTable.json
@@ -322,7 +322,8 @@
             },
             "required": [
                 "column",
-                "operator"
+                "operator",
+                "parameter"
             ]
         },
         "NullityCondition": {

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.expectations.conditions import Column
 from great_expectations.expectations.core import (
     ExpectColumnValuesToBeInSet,
@@ -135,3 +136,31 @@ class TestValidatorAppliesAcrossExpectations:
         # This should raise ValueError even for ExpectTableRowCountToEqual
         with pytest.raises(ValueError, match="AND groups cannot contain OR conditions"):
             ExpectTableRowCountToEqual(value=10, row_condition=row_condition)
+
+
+class TestComparisonConditionValidators:
+    @pytest.mark.parametrize(
+        "operator_func",
+        [
+            pytest.param(
+                lambda col: col == None,  # noqa: E711  # testing invalid syntax
+                id="eq - Linting error - `is None` is pythonic, "
+                "but that only compares to singleton instance",
+            ),
+            pytest.param(
+                lambda col: col != None,  # noqa: E711  # testing invalid syntax
+                id="ne - Linting error - `is None` is pythonic, "
+                "but that only compares to singleton instance",
+            ),
+            pytest.param(lambda col: col < None, id="lt - Nonsense"),
+            pytest.param(lambda col: col <= None, id="le - Nonsense"),
+            pytest.param(lambda col: col > None, id="gt - Nonsense"),
+            pytest.param(lambda col: col >= None, id="ge - Nonsense"),
+        ],
+    )
+    def test_column_operators_with_none_raises_error(self, operator_func):
+        """Test that Column operators with None parameter raise InvalidParameterTypeError."""
+        col = Column(name="status")
+
+        with pytest.raises(ValidationError):
+            operator_func(col)

--- a/tests/expectations/test_conditions.py
+++ b/tests/expectations/test_conditions.py
@@ -10,7 +10,6 @@ from great_expectations.expectations.conditions import (
     Condition,
     ConditionParserError,
     InvalidConditionTypeError,
-    InvalidParameterTypeError,
     NullityCondition,
     Operator,
     OrCondition,
@@ -174,32 +173,6 @@ class TestColumn:
         result = col.is_not_null()
 
         assert result == NullityCondition(column=col, is_null=False)
-
-    @pytest.mark.parametrize(
-        "operator_func",
-        [
-            pytest.param(
-                lambda col: col == None,  # noqa: E711  # testing invalid syntax
-                id="eq - Linting error - `is None` is pythonic, "
-                "but that only compares to singleton instance",
-            ),
-            pytest.param(
-                lambda col: col != None,  # noqa: E711  # testing invalid syntax
-                id="ne - Linting error - `is None` is pythonic, "
-                "but that only compares to singleton instance",
-            ),
-            pytest.param(lambda col: col < None, id="lt - Nonsense"),
-            pytest.param(lambda col: col <= None, id="le - Nonsense"),
-            pytest.param(lambda col: col > None, id="gt - Nonsense"),
-            pytest.param(lambda col: col >= None, id="ge - Nonsense"),
-        ],
-    )
-    def test_column_operators_with_none_raises_error(self, operator_func):
-        """Test that Column operators with None parameter raise InvalidParameterTypeError."""
-        col = Column(name="status")
-
-        with pytest.raises(InvalidParameterTypeError):
-            operator_func(col)
 
 
 class TestComparisonCondition:

--- a/tests/expectations/test_conditions.py
+++ b/tests/expectations/test_conditions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.expectations.conditions import (
     AndCondition,
     Column,
@@ -9,6 +10,7 @@ from great_expectations.expectations.conditions import (
     Condition,
     ConditionParserError,
     InvalidConditionTypeError,
+    InvalidParameterTypeError,
     NullityCondition,
     Operator,
     OrCondition,
@@ -173,6 +175,32 @@ class TestColumn:
 
         assert result == NullityCondition(column=col, is_null=False)
 
+    @pytest.mark.parametrize(
+        "operator_func",
+        [
+            pytest.param(
+                lambda col: col == None,  # noqa: E711  # testing invalid syntax
+                id="eq - Linting error - `is None` is pythonic, "
+                "but that only compares to singleton instance",
+            ),
+            pytest.param(
+                lambda col: col != None,  # noqa: E711  # testing invalid syntax
+                id="ne - Linting error - `is None` is pythonic, "
+                "but that only compares to singleton instance",
+            ),
+            pytest.param(lambda col: col < None, id="lt - Nonsense"),
+            pytest.param(lambda col: col <= None, id="le - Nonsense"),
+            pytest.param(lambda col: col > None, id="gt - Nonsense"),
+            pytest.param(lambda col: col >= None, id="ge - Nonsense"),
+        ],
+    )
+    def test_column_operators_with_none_raises_error(self, operator_func):
+        """Test that Column operators with None parameter raise InvalidParameterTypeError."""
+        col = Column(name="status")
+
+        with pytest.raises(InvalidParameterTypeError):
+            operator_func(col)
+
 
 class TestComparisonCondition:
     def test_repr_equal_operator(self):
@@ -228,6 +256,12 @@ class TestComparisonCondition:
         )
 
         assert repr(cond) == "status NOT_IN (inactive, deleted)"
+
+    def test_comparison_condition_with_none_parameter_raises_error(self):
+        col = Column(name="status")
+
+        with pytest.raises(ValidationError):
+            ComparisonCondition(column=col, operator=Operator.NOT_EQUAL, parameter=None)
 
 
 class TestNullityCondition:


### PR DESCRIPTION
- Handle `None` parameter in `Condition`s
- Passing `None` after any `Column` operator is invalid
- Has the effect of making `parameter` required on the `ComparisonCondition` schema

Linters complain about expressions like `column == None`, because `None` is a global singleton instance. In python, comparisons against `None` are expected to be done like `column is None`. We have no way to control the behavior of `column is None`, because the `is` operator cannot be overloaded like the `==` operator. We implemented `column.is_null()` and `column.is_not_null()` to handle this.