### PR TITLE
[BUGFIX] Update pytest filter to handle google.api_core Python 3.10 end-of-life warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -645,7 +645,8 @@ filterwarnings = [
     "ignore: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.:pytest_benchmark.logger.PytestBenchmarkWarning",
     "ignore: No data was collected\\. \\(no-data-collected\\):coverage.exceptions.CoverageWarning",
     # Example Actual Warning: FutureWarning: You are using a Python version (3.9.23) past its end of life.
-    "ignore: You are using a Python version.*past its end of life:FutureWarning",
+    # Also matches: You are using a Python version (3.10.18) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04).
+    "ignore: You are using a Python version.*end of life:FutureWarning",
 
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]


### PR DESCRIPTION
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
