### PR TITLE
[MAINTENANCE] Fix flaky validation definition test

### DIFF
--- a/tests/core/test_validation_definition.py
+++ b/tests/core/test_validation_definition.py
@@ -692,7 +692,7 @@ class TestValidationDefinitionSerialization:
         ],
     )
     def test_validation_definition_deserialization_bad_format(
-        self, serialized_config: dict, error_substring: str
+        self, context: EphemeralDataContext, serialized_config: dict, error_substring: str
     ):
         with pytest.raises(ValueError, match=f"{error_substring}*."):
             ValidationDefinition.parse_obj(serialized_config)


### PR DESCRIPTION
There was a race condition between raised errors because we were depending on a context from other tests.
