### PR TITLE
[MAINTENANCE] Don't allow `bool` values in `Column.is_in( )` / `Column.is_not_in()`

### DIFF
--- a/great_expectations/expectations/conditions.py
+++ b/great_expectations/expectations/conditions.py
@@ -205,7 +205,7 @@ class ComparisonCondition(Condition):
     def _validate_parameter_element_types(parameter: Iterable[Any], operator: Operator) -> None:
         """Validate that all elements in parameter are compatible types."""
         numeric_types = {int, float}
-        allowed_types = numeric_types | {str, bool}
+        allowed_types = numeric_types | {str}
         parameter_iter = iter(parameter)
         try:
             first_value = next(parameter_iter)

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -182,7 +182,6 @@ class TestInSetOperatorParameterValidator:
             pytest.param([1.0, 2.5, 3.14], id="list of floats"),
             pytest.param([1, 2.5, 3], id="mixed ints and floats"),
             pytest.param(["a", "b", "c"], id="list of strings"),
-            pytest.param([True, False], id="list of bools"),
             pytest.param((1, 2, 3), id="tuple of ints"),
             pytest.param({1, 2, 3}, id="set of ints"),
             pytest.param([], id="empty list"),
@@ -245,8 +244,11 @@ class TestInSetOperatorParameterValidator:
         "parameter",
         [
             pytest.param([1, "a"], id="int and string"),
-            pytest.param(["a", True], id="string and bool"),
-            pytest.param([True, 1], id="bool and int"),
+            pytest.param([True, False], id="bool values not allowed"),
+            pytest.param(
+                [datetime.now(tz=timezone.utc), datetime.now(tz=timezone.utc)],
+                id="datetime values not allowed",
+            ),
         ],
     )
     def test_mixed_types_raise_error(self, parameter):

--- a/tests/expectations/test_condition_validators.py
+++ b/tests/expectations/test_condition_validators.py
@@ -231,6 +231,7 @@ class TestInSetOperatorParameterValidator:
             pytest.param([1, {"a": 2}], id="dict"),
             pytest.param([1, None], id="None"),
             pytest.param([1, datetime.now(tz=timezone.utc)], id="datetime"),
+            pytest.param([1, True], id="bool values not allowed"),
         ],
     )
     def test_invalid_element_types_raise_error(self, parameter):
@@ -244,11 +245,6 @@ class TestInSetOperatorParameterValidator:
         "parameter",
         [
             pytest.param([1, "a"], id="int and string"),
-            pytest.param([True, False], id="bool values not allowed"),
-            pytest.param(
-                [datetime.now(tz=timezone.utc), datetime.now(tz=timezone.utc)],
-                id="datetime values not allowed",
-            ),
         ],
     )
     def test_mixed_types_raise_error(self, parameter):


### PR DESCRIPTION
Don't allow `bool` values in `Column.is_in( )` / `Column.is_not_in()`