### PR TITLE
[MAINTENANCE] Databricks SQLAlchemy 2.0 transaction handling and connection recovery

### DIFF
--- a/great_expectations/compatibility/sqlalchemy.py
+++ b/great_expectations/compatibility/sqlalchemy.py
@@ -115,6 +115,11 @@ except (ImportError, AttributeError):
     OperationalError = SQLALCHEMY_NOT_IMPORTED  # type: ignore[misc,assignment] # FIXME CoP
 
 try:
+    from sqlalchemy.exc import PendingRollbackError
+except (ImportError, AttributeError):
+    PendingRollbackError = SQLALCHEMY_NOT_IMPORTED  # type: ignore[misc,assignment] # FIXME CoP
+
+try:
     from sqlalchemy.exc import ProgrammingError
 except (ImportError, AttributeError):
     ProgrammingError = SQLALCHEMY_NOT_IMPORTED  # type: ignore[misc,assignment] # FIXME CoP

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1493,7 +1493,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 # Check if connection is in an invalid transaction state and recover
                 try:
                     result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
-                except sqlalchemy.exc.PendingRollbackError:
+                except sqlalchemy.PendingRollbackError:
                     # Connection has an invalid transaction from a previous failed operation
                     # Roll back and retry with the same connection
                     connection.rollback()

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1485,44 +1485,16 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         Returns:
             CursorResult for sqlalchemy 2.0+ or LegacyCursorResult for earlier versions.
         """
-        # Get a connection and check if it's in a valid state
         with self.get_connection() as connection:
             if (
                 is_version_greater_or_equal(sqlalchemy.sqlalchemy.__version__, "2.0.0")
                 and not connection.closed
             ):
-                # For SQLAlchemy 2.0+, check if connection is in an invalid transaction state
-                # This can happen if a previous operation failed and left the connection dirty
-                try:
-                    # Check connection state - this will raise if transaction is invalid
-                    _ = connection.in_transaction()
-                except Exception:
-                    # Connection is in invalid state, invalidate and get a new one
-                    connection.invalidate()
-                    # Close this context and get a fresh connection
-                    connection.close()
-                    # Recurse with a fresh connection
-                    return self.execute_query_in_transaction(query)
-
-                # Connection is valid, proceed with query execution
-                try:
-                    result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
-                    # Some databases auto-commit and don't support explicit transaction management
-                    # Only commit if there's an active transaction to avoid errors
-                    if self._connection_has_transaction(connection):
-                        connection.commit()
-                except Exception:
-                    # Rollback the transaction if query execution fails
-                    # For safety, always invalidate the connection
-                    # on error to prevent pool pollution
-                    try:
-                        if self._connection_has_transaction(connection):
-                            connection.rollback()
-                    except Exception:
-                        pass  # Ignore rollback errors
-                    # Always invalidate to ensure bad connections aren't reused from the pool
-                    connection.invalidate()
-                    raise
+                result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
+                # Some databases auto-commit and don't support explicit transaction management
+                # Only commit if there's an active transaction to avoid errors
+                if self._connection_has_transaction(connection):
+                    connection.commit()
             else:
                 with connection.begin():
                     result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1474,7 +1474,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
     def execute_query_in_transaction(
         self, query: sqlalchemy.Selectable
     ) -> sqlalchemy.CursorResult | sqlalchemy.LegacyCursorResult:
-        """Execute a query using the underlying database engine within a transaction that will auto commit.
+        """Execute a query using the underlying database engine within a transaction
+        that will auto commit.
 
         Begin once: https://docs.sqlalchemy.org/en/20/core/connections.html#begin-once
 
@@ -1483,12 +1484,27 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
 
         Returns:
             CursorResult for sqlalchemy 2.0+ or LegacyCursorResult for earlier versions.
-        """  # noqa: E501 # FIXME CoP
+        """
+        # Get a connection and check if it's in a valid state
         with self.get_connection() as connection:
             if (
                 is_version_greater_or_equal(sqlalchemy.sqlalchemy.__version__, "2.0.0")
                 and not connection.closed
             ):
+                # For SQLAlchemy 2.0+, check if connection is in an invalid transaction state
+                # This can happen if a previous operation failed and left the connection dirty
+                try:
+                    # Check connection state - this will raise if transaction is invalid
+                    _ = connection.in_transaction()
+                except Exception:
+                    # Connection is in invalid state, invalidate and get a new one
+                    connection.invalidate()
+                    # Close this context and get a fresh connection
+                    connection.close()
+                    # Recurse with a fresh connection
+                    return self.execute_query_in_transaction(query)
+
+                # Connection is valid, proceed with query execution
                 try:
                     result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
                     # Some databases auto-commit and don't support explicit transaction management

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1489,11 +1489,21 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 is_version_greater_or_equal(sqlalchemy.sqlalchemy.__version__, "2.0.0")
                 and not connection.closed
             ):
-                result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
-                # Some databases auto-commit and don't support explicit transaction management
-                # Only commit if there's an active transaction to avoid errors
-                if self._connection_has_transaction(connection):
-                    connection.commit()
+                try:
+                    result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
+                    # Some databases auto-commit and don't support explicit transaction management
+                    # Only commit if there's an active transaction to avoid errors
+                    if self._connection_has_transaction(connection):
+                        connection.commit()
+                except Exception:
+                    # Rollback the transaction if query execution fails
+                    if self._connection_has_transaction(connection):
+                        try:
+                            connection.rollback()
+                        except Exception:
+                            # If rollback fails, invalidate the connection to prevent reuse
+                            connection.invalidate()
+                    raise
             else:
                 with connection.begin():
                     result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1445,7 +1445,14 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             CursorResult for sqlalchemy 2.0+ or LegacyCursorResult for earlier versions.
         """
         with self.get_connection() as connection:
-            result = connection.execute(query)  # type: ignore[arg-type] # FIXME:Selectable overly broad
+            # Check if connection is in an invalid transaction state and recover
+            try:
+                result = connection.execute(query)  # type: ignore[arg-type] # FIXME:Selectable overly broad
+            except sqlalchemy.PendingRollbackError:
+                # Connection has an invalid transaction from a previous failed operation
+                # Roll back and retry with the same connection
+                connection.rollback()
+                result = connection.execute(query)  # type: ignore[arg-type] # FIXME:Selectable overly broad
 
         return result
 

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -38,7 +38,11 @@ __version__ = get_versions()["version"]  # isort:skip
 from great_expectations._docs_decorators import new_method_or_class
 from great_expectations.compatibility import snowflake, sqlalchemy
 from great_expectations.compatibility.not_imported import is_version_greater_or_equal
-from great_expectations.compatibility.sqlalchemy import PendingRollbackError, Subquery
+from great_expectations.compatibility.sqlalchemy import (
+    DatabaseError,
+    PendingRollbackError,
+    Subquery,
+)
 from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
 )
@@ -1522,7 +1526,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 if self._connection_has_transaction(connection):
                     try:
                         connection.commit()
-                    except Exception as e:
+                    except DatabaseError as e:
                         # Databricks and other auto-commit databases may not have
                         # an active transaction even though in_transaction() returns True
                         if "no active transaction" not in str(e).lower():

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1500,9 +1500,15 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                     result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
 
                 # Some databases auto-commit and don't support explicit transaction management
-                # Only commit if there's an active transaction to avoid errors
+                # Try to commit, but ignore errors from databases that auto-commit
                 if self._connection_has_transaction(connection):
-                    connection.commit()
+                    try:
+                        connection.commit()
+                    except Exception as e:
+                        # Databricks and other auto-commit databases may not have
+                        # an active transaction even though in_transaction() returns True
+                        if "no active transaction" not in str(e).lower():
+                            raise
             else:
                 with connection.begin():
                     result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1450,12 +1450,12 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             CursorResult for sqlalchemy 2.0+ or LegacyCursorResult for earlier versions.
         """
         try:
-            return connection.execute(query)  # type: ignore[arg-type,call-overload] # Selectable union type too broad
+            return connection.execute(query)  # type: ignore[arg-type] # Selectable union type too broad
         except PendingRollbackError:
             # Connection has an invalid transaction from a previous failed operation
             # Roll back and retry with the same connection
             connection.rollback()
-            return connection.execute(query)  # type: ignore[arg-type,call-overload] # Selectable union type too broad
+            return connection.execute(query)  # type: ignore[arg-type] # Selectable union type too broad
 
     @new_method_or_class(version="0.16.14")
     def execute_query(

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1490,7 +1490,15 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 is_version_greater_or_equal(sqlalchemy.sqlalchemy.__version__, "2.0.0")
                 and not connection.closed
             ):
-                result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
+                # Check if connection is in an invalid transaction state and recover
+                try:
+                    result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
+                except sqlalchemy.exc.PendingRollbackError:
+                    # Connection has an invalid transaction from a previous failed operation
+                    # Roll back and retry with the same connection
+                    connection.rollback()
+                    result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
+
                 # Some databases auto-commit and don't support explicit transaction management
                 # Only commit if there's an active transaction to avoid errors
                 if self._connection_has_transaction(connection):

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -38,7 +38,7 @@ __version__ = get_versions()["version"]  # isort:skip
 from great_expectations._docs_decorators import new_method_or_class
 from great_expectations.compatibility import snowflake, sqlalchemy
 from great_expectations.compatibility.not_imported import is_version_greater_or_equal
-from great_expectations.compatibility.sqlalchemy import Subquery
+from great_expectations.compatibility.sqlalchemy import PendingRollbackError, Subquery
 from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
 )
@@ -1432,6 +1432,31 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             with self.engine.connect() as connection:
                 yield connection
 
+    @staticmethod
+    def _execute_query_with_recovery(
+        connection: sqlalchemy.Connection,
+        query: sqlalchemy.Selectable | sqlalchemy.TextClause,
+    ) -> sqlalchemy.CursorResult | sqlalchemy.LegacyCursorResult:
+        """Execute a query with automatic recovery from invalid transaction state.
+
+        This handles PendingRollbackError which was introduced in SQLAlchemy 2.0.
+        For SQLAlchemy 1.x, this error doesn't exist and won't be raised.
+
+        Args:
+            connection: SQLAlchemy connection to use
+            query: Sqlalchemy selectable query.
+
+        Returns:
+            CursorResult for sqlalchemy 2.0+ or LegacyCursorResult for earlier versions.
+        """
+        try:
+            return connection.execute(query)  # type: ignore[arg-type,call-overload] # Selectable union type too broad
+        except PendingRollbackError:
+            # Connection has an invalid transaction from a previous failed operation
+            # Roll back and retry with the same connection
+            connection.rollback()
+            return connection.execute(query)  # type: ignore[arg-type,call-overload] # Selectable union type too broad
+
     @new_method_or_class(version="0.16.14")
     def execute_query(
         self, query: sqlalchemy.Selectable | sqlalchemy.TextClause
@@ -1445,14 +1470,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             CursorResult for sqlalchemy 2.0+ or LegacyCursorResult for earlier versions.
         """
         with self.get_connection() as connection:
-            # Check if connection is in an invalid transaction state and recover
-            try:
-                result = connection.execute(query)  # type: ignore[arg-type] # FIXME:Selectable overly broad
-            except sqlalchemy.PendingRollbackError:
-                # Connection has an invalid transaction from a previous failed operation
-                # Roll back and retry with the same connection
-                connection.rollback()
-                result = connection.execute(query)  # type: ignore[arg-type] # FIXME:Selectable overly broad
+            result = self._execute_query_with_recovery(connection, query)
 
         return result
 
@@ -1497,14 +1515,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 is_version_greater_or_equal(sqlalchemy.sqlalchemy.__version__, "2.0.0")
                 and not connection.closed
             ):
-                # Check if connection is in an invalid transaction state and recover
-                try:
-                    result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
-                except sqlalchemy.PendingRollbackError:
-                    # Connection has an invalid transaction from a previous failed operation
-                    # Roll back and retry with the same connection
-                    connection.rollback()
-                    result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
+                result = self._execute_query_with_recovery(connection, query)
 
                 # Some databases auto-commit and don't support explicit transaction management
                 # Try to commit, but ignore errors from databases that auto-commit
@@ -1518,7 +1529,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                             raise
             else:
                 with connection.begin():
-                    result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
+                    result = self._execute_query_with_recovery(connection, query)
 
         return result
 

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1497,12 +1497,15 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                         connection.commit()
                 except Exception:
                     # Rollback the transaction if query execution fails
-                    if self._connection_has_transaction(connection):
-                        try:
+                    # For safety, always invalidate the connection
+                    # on error to prevent pool pollution
+                    try:
+                        if self._connection_has_transaction(connection):
                             connection.rollback()
-                        except Exception:
-                            # If rollback fails, invalidate the connection to prevent reuse
-                            connection.invalidate()
+                    except Exception:
+                        pass  # Ignore rollback errors
+                    # Always invalidate to ensure bad connections aren't reused from the pool
+                    connection.invalidate()
                     raise
             else:
                 with connection.begin():

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1449,6 +1449,27 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
 
         return result
 
+    @staticmethod
+    def _connection_has_transaction(connection: sqlalchemy.Connection) -> bool:
+        """Check if a connection has an active transaction.
+
+        This is specifically for SQLAlchemy 2.0+ autobegin behavior where connections
+        might not have an active transaction if the database is in autocommit mode.
+
+        Args:
+            connection: SQLAlchemy connection to check
+
+        Returns:
+            True if there's an active transaction, False otherwise
+        """
+        # This method is only called in the SQLAlchemy 2.0+ code path
+        # The in_transaction() method was added in 1.4, but we check for 2.0+
+        # because that's when autobegin behavior was introduced
+        if is_version_greater_or_equal(sqlalchemy.sqlalchemy.__version__, "2.0.0"):
+            return connection.in_transaction()
+        # For SQLAlchemy < 2.0, we use explicit connection.begin(), so always in transaction
+        return True
+
     @new_method_or_class(version="0.16.14")
     def execute_query_in_transaction(
         self, query: sqlalchemy.Selectable
@@ -1469,7 +1490,10 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 and not connection.closed
             ):
                 result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad
-                connection.commit()
+                # Some databases auto-commit and don't support explicit transaction management
+                # Only commit if there's an active transaction to avoid errors
+                if self._connection_has_transaction(connection):
+                    connection.commit()
             else:
                 with connection.begin():
                     result = connection.execute(query)  # type: ignore[call-overload] # FIXME:Selectable overly broad

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -49,7 +49,7 @@ def generate_large_table_for_metrics(sa):
                 columns.append(Column(col_name, VARCHAR(255)))
 
             table = Table(table_name, metadata, *columns, schema=schema_name)
-            metadata.create_all(execution_engine.engine)
+            metadata.create_all(conn)
 
             conn.execute(insert(table), list(df.to_dict("index").values()))
 

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 from sqlalchemy import VARCHAR, Column, MetaData, Table, insert
 
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypes,
@@ -54,8 +55,6 @@ def generate_large_table_for_metrics(sa):
             conn.execute(insert(table), list(df.to_dict("index").values()))
 
             # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
-            from great_expectations.compatibility.not_imported import is_version_greater_or_equal
-
             # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
             if is_version_greater_or_equal(sa.__version__, "2.0.0"):
                 if conn.in_transaction():

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -41,7 +41,7 @@ def generate_large_table_for_metrics(sa):
         metadata = MetaData()
         table_name = f"test_table_{uuid.uuid4().hex[:8]}"
 
-        with execution_engine.get_connection() as conn, conn.begin():
+        with execution_engine.get_connection() as conn:
             conn.execute(sa.text(f"CREATE SCHEMA IF NOT EXISTS {schema_name}"))
 
             columns = []
@@ -52,6 +52,17 @@ def generate_large_table_for_metrics(sa):
             metadata.create_all(execution_engine.engine)
 
             conn.execute(insert(table), list(df.to_dict("index").values()))
+
+            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
+            from great_expectations.compatibility.not_imported import is_version_greater_or_equal
+
+            # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
+            if is_version_greater_or_equal(sa.__version__, "2.0.0"):
+                if conn.in_transaction():
+                    conn.commit()
+            else:
+                # For SQLAlchemy < 2.0, always commit (we're in explicit transaction)
+                conn.commit()
 
         batch_spec = SqlAlchemyDatasourceBatchSpec(
             table_name=table_name,

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 from sqlalchemy import VARCHAR, Column, MetaData, Table, insert
 
-from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypes,
@@ -54,14 +53,13 @@ def generate_large_table_for_metrics(sa):
 
             conn.execute(insert(table), list(df.to_dict("index").values()))
 
-            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
-            # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
-            if is_version_greater_or_equal(sa.__version__, "2.0.0"):
-                if conn.in_transaction():
-                    conn.commit()
-            else:
-                # For SQLAlchemy < 2.0, always commit (we're in explicit transaction)
+            # Commit transaction (safe for databases without transaction support)
+            try:
                 conn.commit()
+            except Exception as e:
+                # Databricks and other auto-commit databases may not have an active transaction
+                if "no active transaction" not in str(e).lower():
+                    raise
 
         batch_spec = SqlAlchemyDatasourceBatchSpec(
             table_name=table_name,

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -22,8 +22,6 @@ from tests.integration.test_utils.data_source_config.databricks import (
 
 @pytest.fixture
 def generate_large_table_for_metrics(sa):
-    engines = []
-
     def _generate_large_table_for_metrics(num_columns, num_rows):
         data = {}
         for i in range(num_columns):
@@ -39,46 +37,46 @@ def generate_large_table_for_metrics(sa):
         connection_string = config.connection_string(schema_name)
 
         execution_engine = SqlAlchemyExecutionEngine(connection_string=connection_string)
-        engines.append(execution_engine)
 
         metadata = MetaData()
         table_name = f"test_table_{uuid.uuid4().hex[:8]}"
 
-        with execution_engine.get_connection() as conn:
-            conn.execute(sa.text(f"CREATE SCHEMA IF NOT EXISTS {schema_name}"))
+        try:
+            with execution_engine.get_connection() as conn:
+                conn.execute(sa.text(f"CREATE SCHEMA IF NOT EXISTS {schema_name}"))
 
-            columns = []
-            for col_name in df.columns:
-                columns.append(Column(col_name, VARCHAR(255)))
+                columns = []
+                for col_name in df.columns:
+                    columns.append(Column(col_name, VARCHAR(255)))
 
-            table = Table(table_name, metadata, *columns, schema=schema_name)
-            metadata.create_all(conn)
+                table = Table(table_name, metadata, *columns, schema=schema_name)
+                metadata.create_all(conn)
 
-            conn.execute(insert(table), list(df.to_dict("index").values()))
+                conn.execute(insert(table), list(df.to_dict("index").values()))
 
-            # Commit transaction (safe for databases without transaction support)
-            try:
-                conn.commit()
-            except Exception as e:
-                # Databricks and other auto-commit databases may not have an active transaction
-                if "no active transaction" not in str(e).lower():
-                    raise
+                # Commit transaction (safe for databases without transaction support)
+                try:
+                    conn.commit()
+                except Exception as e:
+                    # Databricks and other auto-commit databases may not have an active transaction
+                    if "no active transaction" not in str(e).lower():
+                        raise
 
-        batch_spec = SqlAlchemyDatasourceBatchSpec(
-            table_name=table_name,
-            sampling_method="_sample_using_limit",
-            sampling_kwargs={"n": num_rows},
-        )
-        batch_data, _ = execution_engine.get_batch_data_and_markers(batch_spec=batch_spec)
-        execution_engine.load_batch_data("test_batch_id", batch_data)
+            batch_spec = SqlAlchemyDatasourceBatchSpec(
+                table_name=table_name,
+                sampling_method="_sample_using_limit",
+                sampling_kwargs={"n": num_rows},
+            )
+            batch_data, _ = execution_engine.get_batch_data_and_markers(batch_spec=batch_spec)
+            execution_engine.load_batch_data("test_batch_id", batch_data)
 
-        return execution_engine, df
+            return execution_engine, df
+        finally:
+            # Always dispose the engine's connection pool immediately after use
+            # This prevents poisoned connections from being reused by subsequent tests
+            execution_engine.engine.dispose()
 
-    yield _generate_large_table_for_metrics
-
-    # Cleanup: dispose of all engine connection pools to prevent connection reuse
-    for engine in engines:
-        engine.engine.dispose()
+    return _generate_large_table_for_metrics
 
 
 @pytest.fixture

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -41,40 +41,35 @@ def generate_large_table_for_metrics(sa):
         metadata = MetaData()
         table_name = f"test_table_{uuid.uuid4().hex[:8]}"
 
-        try:
-            with execution_engine.get_connection() as conn:
-                conn.execute(sa.text(f"CREATE SCHEMA IF NOT EXISTS {schema_name}"))
+        with execution_engine.get_connection() as conn:
+            conn.execute(sa.text(f"CREATE SCHEMA IF NOT EXISTS {schema_name}"))
 
-                columns = []
-                for col_name in df.columns:
-                    columns.append(Column(col_name, VARCHAR(255)))
+            columns = []
+            for col_name in df.columns:
+                columns.append(Column(col_name, VARCHAR(255)))
 
-                table = Table(table_name, metadata, *columns, schema=schema_name)
-                metadata.create_all(conn)
+            table = Table(table_name, metadata, *columns, schema=schema_name)
+            metadata.create_all(conn)
 
-                conn.execute(insert(table), list(df.to_dict("index").values()))
+            conn.execute(insert(table), list(df.to_dict("index").values()))
 
-                # Commit transaction (safe for databases without transaction support)
-                try:
-                    conn.commit()
-                except Exception as e:
-                    # Databricks and other auto-commit databases may not have an active transaction
-                    if "no active transaction" not in str(e).lower():
-                        raise
+            # Commit transaction (safe for databases without transaction support)
+            try:
+                conn.commit()
+            except Exception as e:
+                # Databricks and other auto-commit databases may not have an active transaction
+                if "no active transaction" not in str(e).lower():
+                    raise
 
-            batch_spec = SqlAlchemyDatasourceBatchSpec(
-                table_name=table_name,
-                sampling_method="_sample_using_limit",
-                sampling_kwargs={"n": num_rows},
-            )
-            batch_data, _ = execution_engine.get_batch_data_and_markers(batch_spec=batch_spec)
-            execution_engine.load_batch_data("test_batch_id", batch_data)
+        batch_spec = SqlAlchemyDatasourceBatchSpec(
+            table_name=table_name,
+            sampling_method="_sample_using_limit",
+            sampling_kwargs={"n": num_rows},
+        )
+        batch_data, _ = execution_engine.get_batch_data_and_markers(batch_spec=batch_spec)
+        execution_engine.load_batch_data("test_batch_id", batch_data)
 
-            return execution_engine, df
-        finally:
-            # Always dispose the engine's connection pool immediately after use
-            # This prevents poisoned connections from being reused by subsequent tests
-            execution_engine.engine.dispose()
+        return execution_engine, df
 
     return _generate_large_table_for_metrics
 

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -22,6 +22,8 @@ from tests.integration.test_utils.data_source_config.databricks import (
 
 @pytest.fixture
 def generate_large_table_for_metrics(sa):
+    engines = []
+
     def _generate_large_table_for_metrics(num_columns, num_rows):
         data = {}
         for i in range(num_columns):
@@ -37,6 +39,7 @@ def generate_large_table_for_metrics(sa):
         connection_string = config.connection_string(schema_name)
 
         execution_engine = SqlAlchemyExecutionEngine(connection_string=connection_string)
+        engines.append(execution_engine)
 
         metadata = MetaData()
         table_name = f"test_table_{uuid.uuid4().hex[:8]}"
@@ -71,7 +74,11 @@ def generate_large_table_for_metrics(sa):
 
         return execution_engine, df
 
-    return _generate_large_table_for_metrics
+    yield _generate_large_table_for_metrics
+
+    # Cleanup: dispose of all engine connection pools to prevent connection reuse
+    for engine in engines:
+        engine.engine.dispose()
 
 
 @pytest.fixture

--- a/tests/integration/fluent/test_sql_datasources.py
+++ b/tests/integration/fluent/test_sql_datasources.py
@@ -58,6 +58,7 @@ from great_expectations.execution_engine.sqlalchemy_dialect import (
 )
 from great_expectations.expectations.expectation_configuration import ExpectationConfiguration
 from tests.integration.fluent.conftest import TEST_TABLE_NAME
+from tests.integration.test_utils.data_source_config.sql import _AUTO_COMMIT_DIALECTS
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -353,9 +354,6 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
     """
     all_created_tables: dict[str, list[dict[Literal["table_name", "schema"], str | None]]] = {}
     engines: dict[str, engine.Engine] = {}
-
-    # Dialects that auto-commit and may not have active transactions
-    _AUTO_COMMIT_DIALECTS = {GXSqlDialect.DATABRICKS}
 
     def _safe_commit(conn: Connection) -> None:
         """Safely commit a connection, skipping auto-commit databases.

--- a/tests/integration/fluent/test_sql_datasources.py
+++ b/tests/integration/fluent/test_sql_datasources.py
@@ -24,7 +24,6 @@ from pytest import param
 
 import great_expectations.expectations.core as gxe
 from great_expectations.checkpoint.checkpoint import Checkpoint
-from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.sqlalchemy import (
     Connection,
     TextClause,
@@ -44,7 +43,6 @@ from great_expectations.compatibility.sqlalchemy import (
 from great_expectations.compatibility.sqlalchemy import (
     __version__ as sqlalchemy_version,
 )
-from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.validation_definition import ValidationDefinition
 from great_expectations.data_context import EphemeralDataContext
@@ -356,13 +354,14 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
     all_created_tables: dict[str, list[dict[Literal["table_name", "schema"], str | None]]] = {}
     engines: dict[str, engine.Engine] = {}
 
-    def _connection_has_transaction(conn: Connection) -> bool:
-        """Check if a connection has an active transaction (SQLAlchemy 1.x and 2.x compatible)."""
-        # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
-        if sa and is_version_greater_or_equal(sa.__version__, "2.0.0"):
-            return conn.in_transaction()
-        # For SQLAlchemy < 2.0, we always commit since we're in explicit transaction
-        return True
+    def _safe_commit(conn: Connection) -> None:
+        """Safely commit a connection, handling databases that don't support transactions."""
+        try:
+            conn.commit()
+        except Exception as e:
+            # Databricks and other auto-commit databases may not have an active transaction
+            if "no active transaction" not in str(e).lower():
+                raise
 
     def _table_factory(
         gx_engine: SqlAlchemyExecutionEngine,
@@ -413,9 +412,8 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
 
                 created_tables.append(dict(table_name=name, schema=schema))
 
-            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
-            if _connection_has_transaction(conn):
-                conn.commit()
+            # Commit transaction (safe for databases without transaction support)
+            _safe_commit(conn)
         all_created_tables[sa_engine.dialect.name] = created_tables
         engines[sa_engine.dialect.name] = sa_engine
 
@@ -438,9 +436,8 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
             if schema:
                 conn.execute(TextClause(f"DROP SCHEMA IF EXISTS {schema}"))
 
-            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
-            if _connection_has_transaction(conn):
-                conn.commit()
+            # Commit transaction (safe for databases without transaction support)
+            _safe_commit(conn)
 
 
 @pytest.fixture

--- a/tests/integration/fluent/test_sql_datasources.py
+++ b/tests/integration/fluent/test_sql_datasources.py
@@ -24,6 +24,7 @@ from pytest import param
 
 import great_expectations.expectations.core as gxe
 from great_expectations.checkpoint.checkpoint import Checkpoint
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.sqlalchemy import (
     Connection,
     TextClause,
@@ -43,6 +44,7 @@ from great_expectations.compatibility.sqlalchemy import (
 from great_expectations.compatibility.sqlalchemy import (
     __version__ as sqlalchemy_version,
 )
+from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.validation_definition import ValidationDefinition
 from great_expectations.data_context import EphemeralDataContext
@@ -356,9 +358,6 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
 
     def _connection_has_transaction(conn: Connection) -> bool:
         """Check if a connection has an active transaction (SQLAlchemy 1.x and 2.x compatible)."""
-        from great_expectations.compatibility.not_imported import is_version_greater_or_equal
-        from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
-
         # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
         if sa and is_version_greater_or_equal(sa.__version__, "2.0.0"):
             return conn.in_transaction()

--- a/tests/integration/fluent/test_sql_datasources.py
+++ b/tests/integration/fluent/test_sql_datasources.py
@@ -25,6 +25,13 @@ from pytest import param
 import great_expectations.expectations.core as gxe
 from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.compatibility.sqlalchemy import (
+    Connection,
+    TextClause,
+    engine,
+    inspect,
+    quoted_name,
+)
+from great_expectations.compatibility.sqlalchemy import (
     DatabaseError as SqlAlchemyDatabaseError,
 )
 from great_expectations.compatibility.sqlalchemy import (
@@ -32,12 +39,6 @@ from great_expectations.compatibility.sqlalchemy import (
 )
 from great_expectations.compatibility.sqlalchemy import (
     ProgrammingError as SqlAlchemyProgrammingError,
-)
-from great_expectations.compatibility.sqlalchemy import (
-    TextClause,
-    engine,
-    inspect,
-    quoted_name,
 )
 from great_expectations.compatibility.sqlalchemy import (
     __version__ as sqlalchemy_version,
@@ -353,6 +354,17 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
     all_created_tables: dict[str, list[dict[Literal["table_name", "schema"], str | None]]] = {}
     engines: dict[str, engine.Engine] = {}
 
+    def _connection_has_transaction(conn: Connection) -> bool:
+        """Check if a connection has an active transaction (SQLAlchemy 1.x and 2.x compatible)."""
+        from great_expectations.compatibility.not_imported import is_version_greater_or_equal
+        from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
+
+        # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
+        if sa and is_version_greater_or_equal(sa.__version__, "2.0.0"):
+            return conn.in_transaction()
+        # For SQLAlchemy < 2.0, we always commit since we're in explicit transaction
+        return True
+
     def _table_factory(
         gx_engine: SqlAlchemyExecutionEngine,
         table_names: set[str],
@@ -374,7 +386,7 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
             quoted_lower_col: str = quote_str(QUOTED_LOWER_COL, dialect=dialect)
             quoted_w_dots: str = quote_str(QUOTED_W_DOTS, dialect=dialect)
             quoted_mixed_case: str = quote_str(QUOTED_MIXED_CASE, dialect=dialect)
-            transaction = conn.begin()
+
             if schema:
                 conn.execute(TextClause(f"CREATE SCHEMA IF NOT EXISTS {schema}"))
             for name in table_names:
@@ -401,7 +413,10 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
                     conn.execute(TextClause(insert_data), data)
 
                 created_tables.append(dict(table_name=name, schema=schema))
-            transaction.commit()
+
+            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
+            if _connection_has_transaction(conn):
+                conn.commit()
         all_created_tables[sa_engine.dialect.name] = created_tables
         engines[sa_engine.dialect.name] = sa_engine
 
@@ -415,7 +430,6 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
             continue
         engine = engines[dialect]
         with engine.connect() as conn:
-            transaction = conn.begin()
             schema: str | None = None
             for table in tables:
                 name = table["table_name"]
@@ -424,7 +438,10 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
                 conn.execute(TextClause(f"DROP TABLE IF EXISTS {qualified_table_name}"))
             if schema:
                 conn.execute(TextClause(f"DROP SCHEMA IF EXISTS {schema}"))
-            transaction.commit()
+
+            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
+            if _connection_has_transaction(conn):
+                conn.commit()
 
 
 @pytest.fixture

--- a/tests/integration/fluent/test_sql_datasources.py
+++ b/tests/integration/fluent/test_sql_datasources.py
@@ -358,7 +358,7 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
         """Safely commit a connection, handling databases that don't support transactions."""
         try:
             conn.commit()
-        except Exception as e:
+        except SqlAlchemyDatabaseError as e:
             # Databricks and other auto-commit databases may not have an active transaction
             if "no active transaction" not in str(e).lower():
                 raise

--- a/tests/integration/fluent/test_sql_datasources.py
+++ b/tests/integration/fluent/test_sql_datasources.py
@@ -354,14 +354,20 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
     all_created_tables: dict[str, list[dict[Literal["table_name", "schema"], str | None]]] = {}
     engines: dict[str, engine.Engine] = {}
 
+    # Dialects that auto-commit and may not have active transactions
+    _AUTO_COMMIT_DIALECTS = {GXSqlDialect.DATABRICKS}
+
     def _safe_commit(conn: Connection) -> None:
-        """Safely commit a connection, handling databases that don't support transactions."""
-        try:
+        """Safely commit a connection, skipping auto-commit databases.
+
+        Some databases like Databricks auto-commit and don't support explicit transactions.
+        For these dialects, we skip the commit call entirely.
+        """
+        dialect_name = GXSqlDialect(conn.dialect.name)
+
+        # Skip commit for auto-commit databases (they commit automatically)
+        if dialect_name not in _AUTO_COMMIT_DIALECTS:
             conn.commit()
-        except SqlAlchemyDatabaseError as e:
-            # Databricks and other auto-commit databases may not have an active transaction
-            if "no active transaction" not in str(e).lower():
-                raise
 
     def _table_factory(
         gx_engine: SqlAlchemyExecutionEngine,

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -13,7 +13,6 @@ from typing_extensions import override
 
 from great_expectations.compatibility.sqlalchemy import (
     Column,
-    DatabaseError,
     MetaData,
     Table,
     TextClause,
@@ -36,6 +35,9 @@ if TYPE_CHECKING:
     import sqlalchemy as sa
 
 logger = logging.getLogger(__name__)
+
+# Dialects that auto-commit and may not have active transactions
+_AUTO_COMMIT_DIALECTS = {GXSqlDialect.DATABRICKS}
 
 
 @dataclass(frozen=True)
@@ -152,20 +154,19 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
 
     @staticmethod
     def _safe_commit(conn: sa.Connection) -> None:
-        """Safely commit a connection, handling databases that don't support transactions.
+        """Safely commit a connection, skipping auto-commit databases.
 
         Some databases like Databricks auto-commit and don't support explicit transactions.
-        This method attempts to commit and ignores errors about missing transactions.
+        For these dialects, we skip the commit call entirely.
 
         Args:
             conn: SQLAlchemy connection to commit
         """
-        try:
+        dialect_name = GXSqlDialect(conn.dialect.name)
+
+        # Skip commit for auto-commit databases (they commit automatically)
+        if dialect_name not in _AUTO_COMMIT_DIALECTS:
             conn.commit()
-        except DatabaseError as e:
-            # Databricks and other auto-commit databases may not have an active transaction
-            if "no active transaction" not in str(e).lower():
-                raise
 
     @staticmethod
     def _safe_bulk_insert(

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -13,6 +13,7 @@ from typing_extensions import override
 
 from great_expectations.compatibility.sqlalchemy import (
     Column,
+    DatabaseError,
     MetaData,
     Table,
     TextClause,
@@ -161,7 +162,7 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
         """
         try:
             conn.commit()
-        except Exception as e:
+        except DatabaseError as e:
             # Databricks and other auto-commit databases may not have an active transaction
             if "no active transaction" not in str(e).lower():
                 raise

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -150,6 +150,27 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
             return engine, engine.dispose
 
     @staticmethod
+    def _connection_has_transaction(conn: sa.Connection) -> bool:
+        """Check if a connection has an active transaction (SQLAlchemy 1.x and 2.x compatible).
+
+        In SQLAlchemy 2.0+, autobegin behavior means some databases (like Databricks)
+        might not have an active transaction. In 1.x, we use explicit transactions.
+
+        Args:
+            conn: SQLAlchemy connection to check
+
+        Returns:
+            True if there's an active transaction, False otherwise
+        """
+        from great_expectations.compatibility.not_imported import is_version_greater_or_equal
+
+        # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
+        if is_version_greater_or_equal(sa.__version__, "2.0.0"):
+            return conn.in_transaction()
+        # For SQLAlchemy < 2.0, we always commit since we're in explicit transaction
+        return True
+
+    @staticmethod
     def _safe_bulk_insert(
         conn: sa.Connection, table: Table, values: list[tuple], max_params: int | None = None
     ) -> None:
@@ -180,9 +201,8 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
         engine, cleanup = self._get_engine()
         dialect = engine.dialect.name.lower()
 
-        with engine.connect() as conn, conn.begin():
+        with engine.connect() as conn:
             # create schema if needed
-
             if self.schema:
                 logger.info(f"CREATING SCHEMA {self.schema}")
                 conn.execute(TextClause(f"CREATE SCHEMA {self.schema}"))
@@ -193,15 +213,15 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
 
             # insert data
             for table_data in all_table_data:
-                # pd.DataFrame(...).to_dict("index") returns a dictionary where the keys are the row
-                # index and the values are a dict of column names mapped to column values.
-                # Then we pass that list of dicts in as parameters to our insert statement.
-                #   INSERT INTO test_table (my_int_column, my_str_column) VALUES (?, ?)
-                #   [...] [('1', 'foo'), ('2', 'bar')]
                 df = table_data.df.replace(np.nan, None)
                 values = list(df.to_dict("index").values())
+                # Databricks has a lower parameter limit
                 max_params = 250 if dialect == GXSqlDialect.DATABRICKS else None
                 self._safe_bulk_insert(conn, table_data.table, values, max_params)  # type: ignore[arg-type] # FIXME
+
+            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
+            if self._connection_has_transaction(conn):
+                conn.commit()
         cleanup()
 
     @override
@@ -210,9 +230,12 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
         for table in self.tables:
             table.drop(engine)
         if self.schema:
-            with engine.connect() as conn, conn.begin():
+            with engine.connect() as conn:
                 logger.info(f"DROPPING SCHEMA {self.schema}")
                 conn.execute(TextClause(f"DROP SCHEMA {self.schema}"))
+                # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
+                if self._connection_has_transaction(conn):
+                    conn.commit()
         cleanup()
 
     def _create_table_name(self, label: Optional[str] = None) -> str:

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -206,7 +206,7 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
 
             # create tables
             all_table_data = self._ensure_all_table_data_created()
-            self.metadata.create_all(engine)
+            self.metadata.create_all(conn)
 
             # insert data
             for table_data in all_table_data:
@@ -227,14 +227,14 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
     @override
     def teardown(self) -> None:
         engine, cleanup = self._get_engine()
-        for table in self.tables:
-            table.drop(engine)
-        if self.schema:
-            with engine.connect() as conn:
+        with engine.connect() as conn:
+            for table in self.tables:
+                table.drop(conn)
+            if self.schema:
                 logger.info(f"DROPPING SCHEMA {self.schema}")
                 conn.execute(TextClause(f"DROP SCHEMA {self.schema}"))
-                # Commit transaction (safe for databases without transaction support)
-                self._safe_commit(conn)
+            # Commit transaction (safe for databases without transaction support)
+            self._safe_commit(conn)
         cleanup()
 
     def _create_table_name(self, label: Optional[str] = None) -> str:

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from typing_extensions import override
 
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.sqlalchemy import (
     Column,
     MetaData,
@@ -162,8 +163,6 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
         Returns:
             True if there's an active transaction, False otherwise
         """
-        from great_expectations.compatibility.not_imported import is_version_greater_or_equal
-
         # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
         if is_version_greater_or_equal(sa.__version__, "2.0.0"):
             return conn.in_transaction()

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 from typing_extensions import override
 
-from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.sqlalchemy import (
     Column,
     MetaData,
@@ -151,23 +150,21 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
             return engine, engine.dispose
 
     @staticmethod
-    def _connection_has_transaction(conn: sa.Connection) -> bool:
-        """Check if a connection has an active transaction (SQLAlchemy 1.x and 2.x compatible).
+    def _safe_commit(conn: sa.Connection) -> None:
+        """Safely commit a connection, handling databases that don't support transactions.
 
-        In SQLAlchemy 2.0+, autobegin behavior means some databases (like Databricks)
-        might not have an active transaction. In 1.x, we use explicit transactions.
+        Some databases like Databricks auto-commit and don't support explicit transactions.
+        This method attempts to commit and ignores errors about missing transactions.
 
         Args:
-            conn: SQLAlchemy connection to check
-
-        Returns:
-            True if there's an active transaction, False otherwise
+            conn: SQLAlchemy connection to commit
         """
-        # Only in SQLAlchemy 2.0+ do we need to check due to autobegin behavior
-        if is_version_greater_or_equal(sa.__version__, "2.0.0"):
-            return conn.in_transaction()
-        # For SQLAlchemy < 2.0, we always commit since we're in explicit transaction
-        return True
+        try:
+            conn.commit()
+        except Exception as e:
+            # Databricks and other auto-commit databases may not have an active transaction
+            if "no active transaction" not in str(e).lower():
+                raise
 
     @staticmethod
     def _safe_bulk_insert(
@@ -218,9 +215,8 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
                 max_params = 250 if dialect == GXSqlDialect.DATABRICKS else None
                 self._safe_bulk_insert(conn, table_data.table, values, max_params)  # type: ignore[arg-type] # FIXME
 
-            # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
-            if self._connection_has_transaction(conn):
-                conn.commit()
+            # Commit transaction (safe for databases without transaction support)
+            self._safe_commit(conn)
         cleanup()
 
     @override
@@ -232,9 +228,8 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
             with engine.connect() as conn:
                 logger.info(f"DROPPING SCHEMA {self.schema}")
                 conn.execute(TextClause(f"DROP SCHEMA {self.schema}"))
-                # Commit transaction if one is active (handles both SQLAlchemy 1.x and 2.x)
-                if self._connection_has_transaction(conn):
-                    conn.commit()
+                # Commit transaction (safe for databases without transaction support)
+                self._safe_commit(conn)
         cleanup()
 
     def _create_table_name(self, label: Optional[str] = None) -> str:

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -199,6 +199,7 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
 
         with engine.connect() as conn:
             # create schema if needed
+
             if self.schema:
                 logger.info(f"CREATING SCHEMA {self.schema}")
                 conn.execute(TextClause(f"CREATE SCHEMA {self.schema}"))
@@ -209,9 +210,13 @@ class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_Conf
 
             # insert data
             for table_data in all_table_data:
+                # pd.DataFrame(...).to_dict("index") returns a dictionary where the keys are the row
+                # index and the values are a dict of column names mapped to column values.
+                # Then we pass that list of dicts in as parameters to our insert statement.
+                #   INSERT INTO test_table (my_int_column, my_str_column) VALUES (?, ?)
+                #   [...] [('1', 'foo'), ('2', 'bar')]
                 df = table_data.df.replace(np.nan, None)
                 values = list(df.to_dict("index").values())
-                # Databricks has a lower parameter limit
                 max_params = 250 if dialect == GXSqlDialect.DATABRICKS else None
                 self._safe_bulk_insert(conn, table_data.table, values, max_params)  # type: ignore[arg-type] # FIXME
 


### PR DESCRIPTION
- Some databases don't allow explicit commits (auto-commit), so we check if we are in a transaction before we can commit
- Added `PendingRollbackError` recovery helper for automatic rollback and retry on poisoned connections
- Implemented safe commit pattern for auto-commit databases like Databricks in tests