### PR TITLE
[DOCS] Fix copy button including hidden setup code in create_an_expectation example

### DIFF
--- a/docs/docusaurus/docs/core/define_expectations/_examples/create_an_expectation.py
+++ b/docs/docusaurus/docs/core/define_expectations/_examples/create_an_expectation.py
@@ -11,13 +11,13 @@ def set_up_context_for_example(context):
 
 
 # EXAMPLE SCRIPT STARTS HERE:
-# <snippet name="docs/docusaurus/docs/core/define_expectations/_examples/create_an_expectation.py - full code example">
+
 import great_expectations as gx
 
 context = gx.get_context()
 # Hide this
 set_up_context_for_example(context)
-
+# <snippet name="docs/docusaurus/docs/core/define_expectations/_examples/create_an_expectation.py - full code example">
 # All Expectations are found in the `gx.expectations` module.
 # This Expectation has all values set in advance:
 # <snippet name="docs/docusaurus/docs/core/define_expectations/_examples/create_an_expectation.py - preset expectation">


### PR DESCRIPTION
## Description
Fixes the issue where clicking the copy button on the "full code example" snippet was copying hidden setup code that wasn't displayed in the documentation.

## Changes
- Moved the snippet tag to start after the `set_up_context_for_example(context)` line
- This ensures the copied code matches what's displayed in the docs

## Testing
- Verified the snippet tags are correctly positioned
- The hidden setup code is now outside the "full code example" snippet