### PR TITLE
[BUGFIX] Prevent FROM DUAL from being added to a properly formatted ORACLE SQL query when using SQLAlchemy

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -4,7 +4,7 @@ import logging
 from typing import Literal, Optional, Tuple, overload
 
 from great_expectations.compatibility import sqlalchemy
-from great_expectations.compatibility.sqlalchemy import Selectable
+from great_expectations.compatibility.sqlalchemy import Selectable, TextClause
 from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
 )
@@ -66,7 +66,7 @@ class SqlAlchemyBatchData(BatchData):
         # Option 2
         query: None = ...,
         # Option 3
-        selectable: Selectable = ...,
+        selectable: Selectable | TextClause = ...,
         create_temp_table: bool = ...,
         temp_table_schema_name: Optional[str] = ...,
         use_quoted_name: bool = ...,
@@ -83,7 +83,7 @@ class SqlAlchemyBatchData(BatchData):
         # Option 2
         query: Optional[str] = None,
         # Option 3
-        selectable: Optional[Selectable] = None,
+        selectable: Optional[Selectable | TextClause] = None,
         create_temp_table: bool = True,
         temp_table_schema_name: Optional[str] = None,
         use_quoted_name: bool = False,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1270,7 +1270,9 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             partitioner_kwargs=partitioner_kwargs,
         )
 
-    def _build_selectable_from_batch_spec(self, batch_spec: BatchSpec) -> sqlalchemy.Selectable:
+    def _build_selectable_from_batch_spec(
+        self, batch_spec: BatchSpec
+        ) -> Union[sqlalchemy.Selectable, sqlalchemy.TextClause]:
         if batch_spec.get("query") is not None and batch_spec.get("sampling_method") is not None:
             raise ValueError(  # noqa: TRY003 # FIXME CoP
                 "Sampling is not supported on query data. "
@@ -1382,8 +1384,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
 
         create_temp_table: bool = batch_spec.get("create_temp_table", self._create_temp_table)
         # this is where partitioner components are added to the selectable
-        selectable: sqlalchemy.Selectable = self._build_selectable_from_batch_spec(
-            batch_spec=batch_spec
+        selectable: sqlalchemy.Selectable | sqlalchemy.TextClause = (
+            self._build_selectable_from_batch_spec(batch_spec=batch_spec)
         )
         # NOTE: what's being checked here is the presence of a `query` attribute, we could check this directly  # noqa: E501 # FIXME CoP
         # instead of doing an instance check

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1293,7 +1293,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 partition_clause = sa.true()
 
         # If the data_source_query_asset query needs no partitioning or sampling, we don't need to wrap it in another select statement with _subselectable. # noqa: E501
-        # We just trust and execute the query provided. # noqa: E501
+        # We just trust and execute the query provided.
         # At this point, query has already been verified as a valid "SELECT " statement in sql_datasource.py:970. # noqa: E501
         # This will prevent FROM DUAL being tacked on to the end of the intended query by sqlalchemy when using the OracleCX dialect. # noqa: E501
         if (

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1292,6 +1292,18 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             else:
                 partition_clause = sa.true()
 
+        # If the data_source_query_asset query needs no partitioning or sampling, we don't need to wrap it 
+        # in another select statement with _subselectable. We just trust and execute the query provided. 
+        # At this point, query has already been verified as a valid "SELECT " statement in sql_datasource.py:970.
+        # This will prevent FROM DUAL being tacked on to the end of the intended query by sqlalchemy when using the OracleCX dialect. 
+        if (
+            batch_spec.get("query") is not None
+            and batch_spec.get("sampling_method") is None
+            and "partitioner_method" not in batch_spec
+            and partition_clause is sa.true()
+        ):
+            return sa.text(batch_spec["query"])
+
         selectable: sqlalchemy.Selectable = self._subselectable(batch_spec)
         sampling_method: Optional[str] = batch_spec.get("sampling_method")
         if sampling_method is not None:

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1272,7 +1272,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
 
     def _build_selectable_from_batch_spec(
         self, batch_spec: BatchSpec
-        ) -> Union[sqlalchemy.Selectable, sqlalchemy.TextClause]:
+    ) -> Union[sqlalchemy.Selectable, sqlalchemy.TextClause]:
         if batch_spec.get("query") is not None and batch_spec.get("sampling_method") is not None:
             raise ValueError(  # noqa: TRY003 # FIXME CoP
                 "Sampling is not supported on query data. "

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1292,10 +1292,10 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             else:
                 partition_clause = sa.true()
 
-        # If the data_source_query_asset query needs no partitioning or sampling, we don't need to wrap it 
-        # in another select statement with _subselectable. We just trust and execute the query provided. 
-        # At this point, query has already been verified as a valid "SELECT " statement in sql_datasource.py:970.
-        # This will prevent FROM DUAL being tacked on to the end of the intended query by sqlalchemy when using the OracleCX dialect. 
+        # If the data_source_query_asset query needs no partitioning or sampling, we don't need to wrap it in another select statement with _subselectable. # noqa: E501
+        # We just trust and execute the query provided. # noqa: E501
+        # At this point, query has already been verified as a valid "SELECT " statement in sql_datasource.py:970. # noqa: E501
+        # This will prevent FROM DUAL being tacked on to the end of the intended query by sqlalchemy when using the OracleCX dialect. # noqa: E501
         if (
             batch_spec.get("query") is not None
             and batch_spec.get("sampling_method") is None


### PR DESCRIPTION
Add early return statement for _build_selectable_from_batch_spec

Addresses the common FROM DAUL addition problem found when using the SQL_Alchemy engine for ORACLE sources with a simple workaround.

**Tested against** 
- Oracle db 19c (19.3.0.0.0)
- Postgres 10.16

**Issue Links:** 
- https://github.com/great-expectations/great_expectations/issues/10948

- https://discourse.greatexpectations.io/t/oracle-query-asset-adds-from-dual-clause/1432


**Checks**
- [X] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [X] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [X] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
