### PR TITLE
[MAINTENANCE] Reenable stale bot for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,29 +4,28 @@
 name: StaleBot
 
 on:
-  workflow_dispatch: # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#defining-inputs-for-manually-triggered-workflows
-  # schedule:
-  # - cron: '30 1 * * *'
+  schedule:
+    - cron: "0 0 * * *" # Runs at midnight UTC every day
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
           # General
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           operations-per-run: 1000
           days-before-stale: 30
           days-before-close: 60
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
 
-          # Scope
-          only-pr-labels: community
-          only-issue-labels: community
-          exempt-issue-labels: core-team, core-engineering-queue, documentation, triage, "help wanted", "DevRel Triage"
-          # exempt-pr-labels: "example label"  # This needs to be reviewed if we move to staling PRs
+          # exempt all issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
 
           # Issue messages
           stale-issue-message: >


### PR DESCRIPTION
This does a few things:
* Sets stale bot on a nightly schedule
* bumps it to the current version (10)
* includes all PRs regardless of tags
* excludes issues

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
