### PR TITLE
[MAINTENANCE] restore null columns to rendered_content tables on multi-source expectations

### DIFF
--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -633,13 +633,17 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         for row in rows:
             output_row_values = []
             for col_name in col_names:
-                if row[col_name] is not None:
-                    output_row_values.append(
-                        RendererTableValue(
-                            schema=RendererSchema(type=RendererValueType.from_value(row[col_name])),
-                            value=row[col_name],
-                        )
+                col_value = row[col_name]
+                output_row_values.append(
+                    RendererTableValue(
+                        schema=RendererSchema(
+                            type=RendererValueType.from_value(col_value)
+                            if col_value is not None
+                            else RendererValueType.STRING
+                        ),
+                        value=col_value,
                     )
+                )
             output_rows.append(output_row_values)
 
         return [header_row, *output_rows]

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -921,7 +921,7 @@ def _create_table_rendered_atomic_content(
     params: dict[str, Any],
     col_names: list[str],
     col_types: list[RendererValueType],
-    rows: list[list[str]],
+    rows: list[list[Any]],
 ) -> RenderedAtomicContent:
     return RenderedAtomicContent(
         name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
@@ -948,6 +948,182 @@ def _create_table_rendered_atomic_content(
         ),
         value_type="TableType",
     )
+
+
+@multi_source_batch_setup(
+    multi_source_test_configs=SQLITE_ONLY,
+    base_data=pd.DataFrame({"col1": [1, 2], "col2": [None, 4], "col3": [5, None]}),
+    comparison_data=pd.DataFrame({"col1": [1, 3], "col2": [None, 6], "col3": [5, None]}),
+)
+def test_rendering_table_with_null_values(multi_source_batch: MultiSourceBatch):
+    """Test that tables with null values are rendered correctly with proper schema types."""
+    source_table = multi_source_batch.comparison_table_name
+    result = multi_source_batch.base_batch.validate(
+        gxe.ExpectQueryResultsToMatchComparison(
+            comparison_data_source_name=multi_source_batch.comparison_data_source_name,
+            comparison_query=f"SELECT col1, col2, col3 FROM {source_table}",
+            base_query="SELECT col1, col2, col3 FROM {batch}",
+        )
+    )
+    result.render()
+
+    # Expected: row with col1=1, col2=None, col3=5 matches
+    # Unexpected rows: [2, 4, None] (from base)
+    # Missing rows: [3, 6, None] (from comparison)
+    assert result.rendered_content == [
+        _create_table_rendered_atomic_content(
+            template="Unexpected rows found in current table: $row_count",
+            params={
+                "row_count": {
+                    "schema": RendererSchema(type=RendererValueType.NUMBER),
+                    "value": 1,
+                }
+            },
+            col_names=["col1", "col2", "col3"],
+            col_types=[
+                RendererValueType.NUMBER,
+                RendererValueType.NUMBER,
+                RendererValueType.STRING,
+            ],
+            rows=[
+                [2, 4, None],
+            ],
+        ),
+        _create_table_rendered_atomic_content(
+            template="Expected rows not found in current table: $row_count",
+            params={
+                "row_count": {
+                    "schema": RendererSchema(type=RendererValueType.NUMBER),
+                    "value": 1,
+                }
+            },
+            col_names=["col1", "col2", "col3"],
+            col_types=[
+                RendererValueType.NUMBER,
+                RendererValueType.NUMBER,
+                RendererValueType.STRING,
+            ],
+            rows=[
+                [3, 6, None],
+            ],
+        ),
+    ]
+
+
+@multi_source_batch_setup(
+    multi_source_test_configs=SQLITE_ONLY,
+    base_data=pd.DataFrame({"name": ["Alice", "Bob", "Charlie"], "age": [25, None, 30]}),
+    comparison_data=pd.DataFrame({"name": ["Alice", "Dave", "Eve"], "age": [25, 28, None]}),
+)
+def test_rendering_table_with_mixed_null_values(multi_source_batch: MultiSourceBatch):
+    """Test that tables with mixed null and non-null values render correctly."""
+    source_table = multi_source_batch.comparison_table_name
+    result = multi_source_batch.base_batch.validate(
+        gxe.ExpectQueryResultsToMatchComparison(
+            comparison_data_source_name=multi_source_batch.comparison_data_source_name,
+            comparison_query=f"SELECT name, age FROM {source_table}",
+            base_query="SELECT name, age FROM {batch}",
+        )
+    )
+    result.render()
+
+    # Expected: row ["Alice", 25] matches
+    # Unexpected rows: ["Bob", None], ["Charlie", 30] (from base)
+    # Missing rows: ["Dave", 28], ["Eve", None] (from comparison)
+    # Note: When null values are present, the actual rendering determines type per cell,
+    # not per column, so we manually construct the expected content
+    assert result.rendered_content == [
+        RenderedAtomicContent(
+            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
+            value=RenderedAtomicValue(
+                template="Unexpected rows found in current table: $row_count",
+                params={
+                    "row_count": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "value": 2,
+                    }
+                },
+                header_row=[
+                    RendererTableValue(
+                        schema=RendererSchema(type=RendererValueType.STRING),
+                        value="name",
+                    ),
+                    RendererTableValue(
+                        schema=RendererSchema(type=RendererValueType.STRING),
+                        value="age",
+                    ),
+                ],
+                table=[
+                    [
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.STRING),
+                            value="Bob",
+                        ),
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.STRING),
+                            value=None,
+                        ),
+                    ],
+                    [
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.STRING),
+                            value="Charlie",
+                        ),
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.NUMBER),
+                            value=30,
+                        ),
+                    ],
+                ],
+            ),
+            value_type="TableType",
+        ),
+        RenderedAtomicContent(
+            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
+            value=RenderedAtomicValue(
+                template="Expected rows not found in current table: $row_count",
+                params={
+                    "row_count": {
+                        "schema": RendererSchema(type=RendererValueType.NUMBER),
+                        "value": 2,
+                    }
+                },
+                header_row=[
+                    RendererTableValue(
+                        schema=RendererSchema(type=RendererValueType.STRING),
+                        value="name",
+                    ),
+                    RendererTableValue(
+                        schema=RendererSchema(type=RendererValueType.STRING),
+                        value="age",
+                    ),
+                ],
+                table=[
+                    [
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.STRING),
+                            value="Dave",
+                        ),
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.NUMBER),
+                            value=28,
+                        ),
+                    ],
+                    [
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.STRING),
+                            value="Eve",
+                        ),
+                        RendererTableValue(
+                            schema=RendererSchema(type=RendererValueType.STRING),
+                            value=None,
+                        ),
+                    ],
+                ],
+            ),
+            value_type="TableType",
+        ),
+    ]
 
 
 @multi_source_batch_setup(


### PR DESCRIPTION
The `rendered_content` for `expect_query_results_to_match_comparison` was excluding columns from the unexpected rows table if the column value was null, however the `headerColumns` list includes all columns irrespective of nullness. This leads to incorrect column/header mappings when rendering the table directly from the data.

This PR restores null columns to the unexpected rows table.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
