### PR TITLE
[DOCS] Prevent copying hidden lines from code blocks when pressing copy button

### DIFF
--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -14,6 +14,7 @@ https://docusaurus.io/docs/installation#requirements
 Follow the [CONTRIBUTING_CODE](https://github.com/great-expectations/great_expectations/blob/develop/CONTRIBUTING_CODE.md) guide in the `great_expectations` repository to install dev dependencies.
 
 Then run the following command from the repository root to install the rest of the dependencies and build documentation locally (including prior versions) and start a development server:
+
 ```console
 invoke docs
 ```
@@ -67,12 +68,100 @@ The following are a few details about other files Docusaurus uses that you may w
 - `versioned_docs/`: Older versions of docs live here. These are copies of `docs/` from the moment when `docs invoke --version=<VERSION>` was run.
 - `versioned_sidebars/`: Older versions of sidebars live here. Similar to `versioned_docs/`
 
-sitemap.xml is not in the repo since it is built and uploaded by a netlify plugin during the documentation build process. 
+sitemap.xml is not in the repo since it is built and uploaded by a netlify plugin during the documentation build process.
+
+## Swizzled and Ejected Components
+
+This project uses Docusaurus's [swizzling feature](https://docusaurus.io/docs/swizzling) to customize theme components. Swizzling allows us to override default Docusaurus components with our own implementations.
+
+### Ejected Components
+
+**Ejected** components are fully copied into the project, giving complete control but requiring manual updates when Docusaurus upgrades.
+
+#### CodeBlock (`src/theme/CodeBlock/`)
+
+- **Status**: Fully ejected
+- **Reason**: Custom copy button behavior to exclude lines with `code-block-hide-line` class (configured via Prism magic comments)
+- **Modifications**: The copy button filters out hidden lines when copying code blocks
+- **Upgrade Impact**: **HIGH** - When upgrading Docusaurus, you must manually review and merge changes from the upstream CodeBlock component. Check the [Docusaurus changelog](https://github.com/facebook/docusaurus/blob/main/CHANGELOG.md) for CodeBlock-related changes.
+
+### Wrapped Components
+
+**Wrapped** components import the original via `@theme-original` and add custom behavior. These are safer and typically require less maintenance during upgrades.
+
+#### Admonition (`src/theme/Admonition/`)
+
+- **Status**: Wrapped
+- **Modifications**: Custom icons for different admonition types (info, note, tip, warning, caution, danger, cta)
+- **Upgrade Impact**: **LOW** - Wrapper should continue working unless Admonition API changes significantly
+
+#### DocSidebarItems (`src/theme/DocSidebarItems/`)
+
+- **Status**: Wrapped
+- **Modifications**: Mobile sidebar auto-close behavior when clicking sidebar items
+- **Upgrade Impact**: **LOW** - Wrapper should continue working unless DocSidebarItems API changes significantly
+
+#### SearchPage (`src/theme/SearchPage/`)
+
+- **Status**: Wrapped
+- **Modifications**: Currently a pass-through wrapper (may be customized in the future)
+- **Upgrade Impact**: **LOW**
+
+#### DocCategoryGeneratedIndexPage (`src/theme/DocCategoryGeneratedIndexPage/`)
+
+- **Status**: Wrapped
+- **Modifications**: Currently a pass-through wrapper (may be customized in the future)
+- **Upgrade Impact**: **LOW**
+
+#### NavbarItem Components (`src/theme/NavbarItem/`)
+
+- **Status**: Wrapped
+- **Components**: `DropdownNavbarItem`, `DocsVersionDropdownNavbarItem`, `ComponentTypes`
+- **Modifications**: Custom navbar item behavior
+- **Upgrade Impact**: **LOW** - Wrappers should continue working unless NavbarItem API changes significantly
+
+#### ColorModeToggle (`src/theme/Navbar/ColorModeToggle/`)
+
+- **Status**: Wrapped
+- **Modifications**: Custom color mode toggle behavior
+- **Upgrade Impact**: **LOW**
+
+### Upgrading Docusaurus
+
+When upgrading Docusaurus, follow these steps:
+
+1. **Review the Changelog**: Check the [Docusaurus changelog](https://github.com/facebook/docusaurus/blob/main/CHANGELOG.md) for breaking changes related to swizzled components.
+
+2. **Test Wrapped Components**: Wrapped components should continue working, but test them to ensure compatibility.
+
+3. **Manually Update Ejected Components**:
+
+   - For **CodeBlock**: This is the highest priority. You'll need to:
+     - Compare the new Docusaurus CodeBlock implementation with our custom version
+     - Manually merge any improvements, bug fixes, or API changes
+     - Ensure our custom copy button logic (filtering hidden lines) is preserved
+     - Test thoroughly to ensure code blocks render and copy correctly
+
+4. **Swizzle Command Reference**: To re-swizzle a component (useful for seeing what changed):
+
+   ```bash
+   cd docs/docusaurus
+   npm run swizzle @docusaurus/theme-classic <ComponentName> -- --danger
+   ```
+
+   Note: This will show you the latest version, but don't overwrite your customizations without careful review.
+
+5. **Testing Checklist**:
+   - [ ] Code blocks render correctly
+   - [ ] Copy button works and excludes hidden lines
+   - [ ] Admonitions display with custom icons
+   - [ ] Mobile sidebar behavior works
+   - [ ] Search functionality works
+   - [ ] Navbar components function correctly
 
 ## Documentation changes checklist
 
-1. For any pages you have moved or removed, update _redirects to point from the old to the new content location
-
+1. For any pages you have moved or removed, update \_redirects to point from the old to the new content location
 
 ## Versioning
 
@@ -84,8 +173,8 @@ To add a new version, follow these steps:
 1. Run `invoke docs version=<MAJOR.MINOR>` (substituting your new version numbers)
 1. Commit the new files in `versioned_docs/`, `versioned_sidebars/` and the change in `versions.json` to version control
 
-
 ## Versioning and docs build flow
+
 ```mermaid
 sequenceDiagram
     Participant Code
@@ -117,3 +206,4 @@ sequenceDiagram
         DocsBuild ->> Netlify: Deploy
         deactivate DocsBuild
     end
+```

--- a/docs/docusaurus/___test___/copyButton.test.js
+++ b/docs/docusaurus/___test___/copyButton.test.js
@@ -1,0 +1,356 @@
+import * as React from 'react'
+import { act } from 'react'
+import { test, describe, jest, beforeEach, afterEach } from '@jest/globals'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import CopyButton from '../src/theme/CodeBlock/Buttons/CopyButton'
+
+// Mock the dependencies
+jest.mock('@docusaurus/theme-common/internal', () => ({
+  useCodeBlockContext: jest.fn()
+}))
+
+jest.mock('@docusaurus/Translate', () => ({
+  translate: jest.fn(({ message }) => message)
+}))
+
+jest.mock('@theme/CodeBlock/Buttons/Button', () => {
+  return function MockButton ({ children, onClick, ...props }) {
+    return (
+      <button onClick={onClick} {...props}>
+        {children}
+      </button>
+    )
+  }
+})
+
+jest.mock('@theme/Icon/Copy', () => {
+  return function MockIconCopy () {
+    return <svg data-testid="icon-copy" />
+  }
+})
+
+jest.mock('@theme/Icon/Success', () => {
+  return function MockIconSuccess () {
+    return <svg data-testid="icon-success" />
+  }
+})
+
+// Import the mocked hook
+import { useCodeBlockContext } from '@docusaurus/theme-common/internal'
+
+describe('CodeBlock CopyButton', () => {
+  let mockWriteText
+  let clipboardData
+
+  beforeEach(() => {
+    clipboardData = ''
+    mockWriteText = jest.fn((text) => {
+      clipboardData = text
+      return Promise.resolve()
+    })
+    global.navigator.clipboard = {
+      writeText: mockWriteText
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+    clipboardData = ''
+    document.body.innerHTML = ''
+  })
+
+  const createCodeBlockDOM = (hasHiddenLines = false) => {
+    // Create the full DOM structure
+    const container = document.createElement('div')
+    container.className = 'codeBlockContent'
+    
+    const codeElement = document.createElement('code')
+    
+    if (hasHiddenLines) {
+      // Create visible line
+      const visibleLine = document.createElement('span')
+      visibleLine.className = 'token-line'
+      visibleLine.textContent = 'import great_expectations as gx'
+      codeElement.appendChild(visibleLine)
+      codeElement.appendChild(document.createElement('br'))
+      
+      // Create hidden line
+      const hiddenLine = document.createElement('span')
+      hiddenLine.className = 'code-block-hide-line token-line'
+      hiddenLine.textContent = 'set_up_context_for_example(context)'
+      codeElement.appendChild(hiddenLine)
+      codeElement.appendChild(document.createElement('br'))
+      
+      // Create another visible line
+      const visibleLine2 = document.createElement('span')
+      visibleLine2.className = 'token-line'
+      visibleLine2.textContent = 'preset_expectation = gx.expectations.ExpectColumnMaxToBeBetween('
+      codeElement.appendChild(visibleLine2)
+    } else {
+      // Simple code block without hidden lines
+      const line1 = document.createElement('span')
+      line1.className = 'token-line'
+      line1.textContent = 'import great_expectations as gx'
+      codeElement.appendChild(line1)
+      codeElement.appendChild(document.createElement('br'))
+      
+      const line2 = document.createElement('span')
+      line2.className = 'token-line'
+      line2.textContent = 'context = gx.get_context()'
+      codeElement.appendChild(line2)
+    }
+    
+    container.appendChild(codeElement)
+    
+    // Create button group container
+    const buttonGroup = document.createElement('div')
+    buttonGroup.className = 'buttonGroup'
+    container.appendChild(buttonGroup)
+    
+    document.body.appendChild(container)
+    
+    return { container, buttonGroup }
+  }
+
+  test('renders copy button', () => {
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: 'test code' }
+    })
+
+    render(<CopyButton />)
+    
+    const button = screen.getByRole('button', { name: /copy code to clipboard/i })
+    expect(button).toBeInTheDocument()
+  })
+
+  test('copies code to clipboard when clicked', async () => {
+    const testCode = 'import great_expectations as gx\ncontext = gx.get_context()'
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: testCode }
+    })
+
+    const { container, buttonGroup } = createCodeBlockDOM(false)
+    
+    // Render the button into the buttonGroup
+    const { container: renderContainer } = render(<CopyButton />, {
+      container: buttonGroup
+    })
+    
+    const copyButton = screen.getByRole('button', { name: /copy code to clipboard/i })
+    
+    await userEvent.click(copyButton)
+    
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalled()
+    })
+  })
+
+  test('filters out hidden lines when copying', async () => {
+    const originalCode = 'import great_expectations as gx\nset_up_context_for_example(context)\npreset_expectation = gx.expectations.ExpectColumnMaxToBeBetween('
+    
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: originalCode }
+    })
+
+    const { container, buttonGroup } = createCodeBlockDOM(true)
+    
+    // Render the button into the buttonGroup
+    render(<CopyButton />, {
+      container: buttonGroup
+    })
+    
+    const copyButton = screen.getByRole('button', { name: /copy code to clipboard/i })
+    
+    await userEvent.click(copyButton)
+    
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalled()
+      const copiedText = mockWriteText.mock.calls[0][0]
+      // Should not contain the hidden line
+      expect(copiedText).not.toContain('set_up_context_for_example')
+      // Should contain visible lines
+      expect(copiedText).toContain('import great_expectations as gx')
+      expect(copiedText).toContain('preset_expectation')
+    })
+  })
+
+  test('preserves line breaks when copying', async () => {
+    const testCode = 'line1\nline2\nline3'
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: testCode }
+    })
+
+    const { container, buttonGroup } = createCodeBlockDOM(false)
+    
+    // Render the button into the buttonGroup
+    render(<CopyButton />, {
+      container: buttonGroup
+    })
+    
+    const copyButton = screen.getByRole('button', { name: /copy code to clipboard/i })
+    
+    await userEvent.click(copyButton)
+    
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalled()
+      const copiedText = mockWriteText.mock.calls[0][0]
+      // Should contain newlines
+      expect(copiedText).toContain('\n')
+      // Should have multiple lines
+      const lines = copiedText.split('\n')
+      expect(lines.length).toBeGreaterThan(1)
+    })
+  })
+
+  test('falls back to original code if DOM structure is not found', async () => {
+    const testCode = 'import great_expectations as gx\nset_up_context_for_example(context)'
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: testCode }
+    })
+
+    render(<CopyButton />)
+    
+    const copyButton = screen.getByRole('button', { name: /copy code to clipboard/i })
+    
+    // Click without setting up DOM structure - should fall back to original code
+    await userEvent.click(copyButton)
+    
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalled()
+      // Should fall back to original code (may include hidden lines)
+      const copiedText = mockWriteText.mock.calls[0][0]
+      expect(copiedText).toBe(testCode)
+    })
+  })
+
+  test('shows copied state after clicking', async () => {
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: 'test code' }
+    })
+
+    const { container, buttonGroup } = createCodeBlockDOM(false)
+    
+    // Render the button into the buttonGroup
+    render(<CopyButton />, {
+      container: buttonGroup
+    })
+    
+    const copyButton = screen.getByRole('button', { name: /copy code to clipboard/i })
+    
+    await userEvent.click(copyButton)
+    
+    await waitFor(() => {
+      // Should show "Copied" aria-label after clicking
+      expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
+    })
+  })
+
+  test('resets copied state after timeout', async () => {
+    jest.useFakeTimers()
+    
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: 'test code' }
+    })
+
+    const { container, buttonGroup } = createCodeBlockDOM(false)
+    
+    // Render the button into the buttonGroup
+    render(<CopyButton />, {
+      container: buttonGroup
+    })
+    
+    const copyButton = screen.getByRole('button', { name: /copy code to clipboard/i })
+    
+    // Click with fake timers - wrap in act
+    await act(async () => {
+      await userEvent.click(copyButton, { delay: null })
+    })
+    
+    // Wait for copied state to appear - wrap in act
+    await act(async () => {
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
+      })
+    })
+    
+    // Fast-forward time by 1000ms - wrap in act
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    
+    // Wait for state to reset - wrap in act
+    await act(async () => {
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /copy code to clipboard/i })).toBeInTheDocument()
+      })
+    })
+    
+    jest.useRealTimers()
+  })
+
+  test('handles multiple hidden lines correctly', async () => {
+    const originalCode = 'line1\nhidden1\nline2\nhidden2\nline3'
+    
+    useCodeBlockContext.mockReturnValue({
+      metadata: { code: originalCode }
+    })
+
+    const container = document.createElement('div')
+    container.className = 'codeBlockContent'
+    const codeElement = document.createElement('code')
+    
+    // Create multiple lines with hidden ones
+    const lines = [
+      { text: 'line1', hidden: false },
+      { text: 'hidden1', hidden: true },
+      { text: 'line2', hidden: false },
+      { text: 'hidden2', hidden: true },
+      { text: 'line3', hidden: false }
+    ]
+    
+    lines.forEach(({ text, hidden }) => {
+      const span = document.createElement('span')
+      span.className = hidden ? 'code-block-hide-line token-line' : 'token-line'
+      span.textContent = text
+      codeElement.appendChild(span)
+      codeElement.appendChild(document.createElement('br'))
+    })
+    
+    container.appendChild(codeElement)
+    
+    // Create button group container
+    const buttonGroup = document.createElement('div')
+    buttonGroup.className = 'buttonGroup'
+    container.appendChild(buttonGroup)
+    
+    document.body.appendChild(container)
+    
+    // Render the button into the buttonGroup
+    render(<CopyButton />, {
+      container: buttonGroup
+    })
+    
+    const copyButton = screen.getByRole('button', { name: /copy code to clipboard/i })
+    
+    await userEvent.click(copyButton)
+    
+    await waitFor(
+      () => {
+        expect(mockWriteText).toHaveBeenCalled()
+        const copiedText = mockWriteText.mock.calls[0][0]
+        // Should not contain hidden lines
+        expect(copiedText).not.toContain('hidden1')
+        expect(copiedText).not.toContain('hidden2')
+        // Should contain visible lines
+        expect(copiedText).toContain('line1')
+        expect(copiedText).toContain('line2')
+        expect(copiedText).toContain('line3')
+      },
+      { timeout: 3000 }
+    )
+  })
+})
+

--- a/docs/docusaurus/jest.setup.js
+++ b/docs/docusaurus/jest.setup.js
@@ -7,3 +7,21 @@ jest.mock('@docusaurus/useBaseUrl', () =>
     }
   })
 )
+
+// Suppress ReactDOMTestUtils.act deprecation warning from @testing-library/react
+// This is a known issue with React Testing Library's internal usage
+// We're already using React.act correctly in our tests
+const originalError = console.error
+console.error = (...args) => {
+  const message = args[0]
+  if (
+    (typeof message === 'string' &&
+      (message.includes('ReactDOMTestUtils.act is deprecated') ||
+       message.includes('The current testing environment is not configured to support act'))) ||
+    (args.length > 0 && typeof args[args.length - 1] === 'string' &&
+      args[args.length - 1].includes('react-dom/test-utils'))
+  ) {
+    return
+  }
+  originalError.call(console, ...args)
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/Button/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/Button/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import clsx from 'clsx';
+export default function CodeBlockButton({className, ...props}) {
+  return (
+    <button type="button" {...props} className={clsx('clean-btn', className)} />
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/CopyButton/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/CopyButton/index.js
@@ -1,0 +1,64 @@
+import React, {useCallback, useState, useRef, useEffect} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Button from '@theme/CodeBlock/Buttons/Button';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
+import styles from './styles.module.css';
+function title() {
+  return translate({
+    id: 'theme.CodeBlock.copy',
+    message: 'Copy',
+    description: 'The copy button label on code blocks',
+  });
+}
+function ariaLabel(isCopied) {
+  return isCopied
+    ? translate({
+        id: 'theme.CodeBlock.copied',
+        message: 'Copied',
+        description: 'The copied button label on code blocks',
+      })
+    : translate({
+        id: 'theme.CodeBlock.copyButtonAriaLabel',
+        message: 'Copy code to clipboard',
+        description: 'The ARIA label for copy code blocks button',
+      });
+}
+function useCopyButton() {
+  const {
+    metadata: {code},
+  } = useCodeBlockContext();
+  const [isCopied, setIsCopied] = useState(false);
+  const copyTimeout = useRef(undefined);
+  const copyCode = useCallback(() => {
+    navigator.clipboard.writeText(code).then(() => {
+      setIsCopied(true);
+      copyTimeout.current = window.setTimeout(() => {
+        setIsCopied(false);
+      }, 1000);
+    });
+  }, [code]);
+  useEffect(() => () => window.clearTimeout(copyTimeout.current), []);
+  return {copyCode, isCopied};
+}
+export default function CopyButton({className}) {
+  const {copyCode, isCopied} = useCopyButton();
+  return (
+    <Button
+      aria-label={ariaLabel(isCopied)}
+      title={title()}
+      className={clsx(
+        className,
+        styles.copyButton,
+        isCopied && styles.copyButtonCopied,
+      )}
+      onClick={copyCode}>
+      <span className={styles.copyButtonIcons} aria-hidden="true">
+        <IconCopy className={styles.copyButtonIcon} />
+        <IconSuccess className={styles.copyButtonSuccessIcon} />
+      </span>
+    </Button>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/CopyButton/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/CopyButton/index.js
@@ -26,14 +26,73 @@ function ariaLabel(isCopied) {
         description: 'The ARIA label for copy code blocks button',
       });
 }
+/**
+ * Filters out lines with the 'code-block-hide-line' class from the code block.
+ * This respects Prism magic comments that hide lines from display.
+ * @param {string} originalCode - Fallback code string if DOM access fails
+ * @param {HTMLElement} buttonElement - The button element that triggered the copy
+ * @returns {string} - The filtered code with hidden lines removed, or originalCode if filtering fails
+ */
+function filterHiddenLines(originalCode, buttonElement) {
+  // We need DOM access to filter hidden lines. If we can't access the DOM,
+  // we fall back to the original code (which may include hidden lines).
+  if (!buttonElement) {
+    return originalCode;
+  }
+
+  // Find the code block container by traversing up the DOM
+  // Structure: button -> buttonGroup -> codeBlockContent -> Container -> code block
+  const codeBlockContent = buttonElement.closest('[class*="codeBlockContent"]');
+  if (!codeBlockContent) {
+    return originalCode;
+  }
+
+  // Find the <code> element within the code block
+  const codeElement = codeBlockContent.querySelector('code');
+  if (!codeElement) {
+    return originalCode;
+  }
+
+  // Clone the code element to avoid modifying the original
+  const clonedCode = codeElement.cloneNode(true);
+
+  // Remove all spans with the 'code-block-hide-line' class
+  const hiddenLines = clonedCode.querySelectorAll('.code-block-hide-line');
+  hiddenLines.forEach((line) => {
+    // Remove the line span and its trailing <br> if present
+    // Lines are structured as: <span class="...">content</span><br />
+    const nextSibling = line.nextSibling;
+    if (nextSibling && nextSibling.nodeName === 'BR') {
+      nextSibling.remove();
+    }
+    line.remove();
+  });
+
+  // Replace all <br> tags with newlines before extracting text
+  // textContent doesn't convert <br> to newlines, so we need to do it manually
+  const brElements = clonedCode.querySelectorAll('br');
+  brElements.forEach((br) => {
+    br.replaceWith('\n');
+  });
+
+  // Extract text content from the cleaned clone
+  const filteredCode = clonedCode.textContent || clonedCode.innerText;
+  return filteredCode || originalCode;
+}
+
 function useCopyButton() {
   const {
     metadata: {code},
   } = useCodeBlockContext();
   const [isCopied, setIsCopied] = useState(false);
   const copyTimeout = useRef(undefined);
-  const copyCode = useCallback(() => {
-    navigator.clipboard.writeText(code).then(() => {
+  const copyCode = useCallback((event) => {
+    // Get the button element from the event
+    const buttonElement = event?.currentTarget;
+    
+    // Filter out hidden lines before copying
+    const filteredCode = filterHiddenLines(code, buttonElement);
+    navigator.clipboard.writeText(filteredCode).then(() => {
       setIsCopied(true);
       copyTimeout.current = window.setTimeout(() => {
         setIsCopied(false);

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
@@ -1,0 +1,40 @@
+:global(.theme-code-block:hover) .copyButtonCopied {
+  opacity: 1 !important;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all var(--ifm-transition-fast) ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/WordWrapButton/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/WordWrapButton/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Button from '@theme/CodeBlock/Buttons/Button';
+import IconWordWrap from '@theme/Icon/WordWrap';
+import styles from './styles.module.css';
+export default function WordWrapButton({className}) {
+  const {wordWrap} = useCodeBlockContext();
+  const canShowButton = wordWrap.isEnabled || wordWrap.isCodeScrollable;
+  if (!canShowButton) {
+    return false;
+  }
+  const title = translate({
+    id: 'theme.CodeBlock.wordWrapToggle',
+    message: 'Toggle word wrap',
+    description:
+      'The title attribute for toggle word wrapping button of code block lines',
+  });
+  return (
+    <Button
+      onClick={() => wordWrap.toggle()}
+      className={clsx(
+        className,
+        wordWrap.isEnabled && styles.wordWrapButtonEnabled,
+      )}
+      aria-label={title}
+      title={title}>
+      <IconWordWrap className={styles.wordWrapButtonIcon} aria-hidden="true" />
+    </Button>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/WordWrapButton/styles.module.css
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/WordWrapButton/styles.module.css
@@ -1,0 +1,8 @@
+.wordWrapButtonIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.wordWrapButtonEnabled .wordWrapButtonIcon {
+  color: var(--ifm-color-primary);
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import clsx from 'clsx';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import CopyButton from '@theme/CodeBlock/Buttons/CopyButton';
+import WordWrapButton from '@theme/CodeBlock/Buttons/WordWrapButton';
+import styles from './styles.module.css';
+// Code block buttons are not server-rendered on purpose
+// Adding them to the initial HTML is useless and expensive (due to JSX SVG)
+// They are hidden by default and require React  to become interactive
+export default function CodeBlockButtons({className}) {
+  return (
+    <BrowserOnly>
+      {() => (
+        <div className={clsx(className, styles.buttonGroup)}>
+          <WordWrapButton />
+          <CopyButton />
+        </div>
+      )}
+    </BrowserOnly>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Buttons/styles.module.css
+++ b/docs/docusaurus/src/theme/CodeBlock/Buttons/styles.module.css
@@ -1,0 +1,30 @@
+.buttonGroup {
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  /* rtl:ignore */
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.buttonGroup button:focus-visible,
+.buttonGroup button:hover {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .buttonGroup button {
+  opacity: 0.4;
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Container/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Container/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames, usePrismTheme} from '@docusaurus/theme-common';
+import {getPrismCssVariables} from '@docusaurus/theme-common/internal';
+import styles from './styles.module.css';
+export default function CodeBlockContainer({as: As, ...props}) {
+  const prismTheme = usePrismTheme();
+  const prismCssVariables = getPrismCssVariables(prismTheme);
+  return (
+    <As
+      // Polymorphic components are hard to type, without `oneOf` generics
+      {...props}
+      style={prismCssVariables}
+      className={clsx(
+        props.className,
+        styles.codeBlockContainer,
+        ThemeClassNames.common.codeBlock,
+      )}
+    />
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Container/styles.module.css
+++ b/docs/docusaurus/src/theme/CodeBlock/Container/styles.module.css
@@ -1,0 +1,7 @@
+.codeBlockContainer {
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  margin-bottom: var(--ifm-leading);
+  box-shadow: var(--ifm-global-shadow-lw);
+  border-radius: var(--ifm-code-border-radius);
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Content/Element.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Content/Element.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import clsx from 'clsx';
+import Container from '@theme/CodeBlock/Container';
+import styles from './styles.module.css';
+// TODO Docusaurus v4: move this component at the root?
+// This component only handles a rare edge-case: <pre><MyComp/></pre> in MDX
+// <pre> tags in markdown map to CodeBlocks. They may contain JSX children.
+// When children is not a simple string, we just return a styled block without
+// actually highlighting.
+export default function CodeBlockJSX({children, className}) {
+  return (
+    <Container
+      as="pre"
+      tabIndex={0}
+      className={clsx(styles.codeBlockStandalone, 'thin-scrollbar', className)}>
+      <code className={styles.codeBlockLines}>{children}</code>
+    </Container>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Content/String.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Content/String.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {
+  CodeBlockContextProvider,
+  createCodeBlockMetadata,
+  useCodeWordWrap,
+} from '@docusaurus/theme-common/internal';
+import CodeBlockLayout from '@theme/CodeBlock/Layout';
+function useCodeBlockMetadata(props) {
+  const {prism} = useThemeConfig();
+  return createCodeBlockMetadata({
+    code: props.children,
+    className: props.className,
+    metastring: props.metastring,
+    magicComments: prism.magicComments,
+    defaultLanguage: prism.defaultLanguage,
+    language: props.language,
+    title: props.title,
+    showLineNumbers: props.showLineNumbers,
+  });
+}
+// TODO Docusaurus v4: move this component at the root?
+export default function CodeBlockString(props) {
+  const metadata = useCodeBlockMetadata(props);
+  const wordWrap = useCodeWordWrap();
+  return (
+    <CodeBlockContextProvider metadata={metadata} wordWrap={wordWrap}>
+      <CodeBlockLayout />
+    </CodeBlockContextProvider>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Content/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Content/index.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import {usePrismTheme} from '@docusaurus/theme-common';
+import {Highlight} from 'prism-react-renderer';
+import Line from '@theme/CodeBlock/Line';
+import styles from './styles.module.css';
+// TODO Docusaurus v4: remove useless forwardRef
+const Pre = React.forwardRef((props, ref) => {
+  return (
+    <pre
+      ref={ref}
+      /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+      tabIndex={0}
+      {...props}
+      className={clsx(props.className, styles.codeBlock, 'thin-scrollbar')}
+    />
+  );
+});
+function Code(props) {
+  const {metadata} = useCodeBlockContext();
+  return (
+    <code
+      {...props}
+      className={clsx(
+        props.className,
+        styles.codeBlockLines,
+        metadata.lineNumbersStart !== undefined &&
+          styles.codeBlockLinesWithNumbering,
+      )}
+      style={{
+        ...props.style,
+        counterReset:
+          metadata.lineNumbersStart === undefined
+            ? undefined
+            : `line-count ${metadata.lineNumbersStart - 1}`,
+      }}
+    />
+  );
+}
+export default function CodeBlockContent({className: classNameProp}) {
+  const {metadata, wordWrap} = useCodeBlockContext();
+  const prismTheme = usePrismTheme();
+  const {code, language, lineNumbersStart, lineClassNames} = metadata;
+  return (
+    <Highlight theme={prismTheme} code={code} language={language}>
+      {({className, style, tokens: lines, getLineProps, getTokenProps}) => (
+        <Pre
+          ref={wordWrap.codeBlockRef}
+          className={clsx(classNameProp, className)}
+          style={style}>
+          <Code>
+            {lines.map((line, i) => (
+              <Line
+                key={i}
+                line={line}
+                getLineProps={getLineProps}
+                getTokenProps={getTokenProps}
+                classNames={lineClassNames[i]}
+                showLineNumbers={lineNumbersStart !== undefined}
+              />
+            ))}
+          </Code>
+        </Pre>
+      )}
+    </Highlight>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Content/styles.module.css
+++ b/docs/docusaurus/src/theme/CodeBlock/Content/styles.module.css
@@ -1,0 +1,28 @@
+.codeBlock {
+  --ifm-pre-background: var(--prism-background-color);
+  margin: 0;
+  padding: 0;
+}
+
+.codeBlockStandalone {
+  padding: 0;
+}
+
+.codeBlockLines {
+  font: inherit;
+  /* rtl:ignore */
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
+}
+
+.codeBlockLinesWithNumbering {
+  display: table;
+  padding: var(--ifm-pre-padding) 0;
+}
+
+@media print {
+  .codeBlockLines {
+    white-space: pre-wrap;
+  }
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Layout/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Layout/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Container from '@theme/CodeBlock/Container';
+import Title from '@theme/CodeBlock/Title';
+import Content from '@theme/CodeBlock/Content';
+import Buttons from '@theme/CodeBlock/Buttons';
+import styles from './styles.module.css';
+export default function CodeBlockLayout({className}) {
+  const {metadata} = useCodeBlockContext();
+  return (
+    <Container as="div" className={clsx(className, metadata.className)}>
+      {metadata.title && (
+        <div className={styles.codeBlockTitle}>
+          <Title>{metadata.title}</Title>
+        </div>
+      )}
+      <div className={styles.codeBlockContent}>
+        <Content />
+        <Buttons />
+      </div>
+    </Container>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Layout/styles.module.css
+++ b/docs/docusaurus/src/theme/CodeBlock/Layout/styles.module.css
@@ -1,0 +1,20 @@
+.codeBlockContent {
+  position: relative;
+  /* rtl:ignore */
+  direction: ltr;
+  border-radius: inherit;
+}
+
+.codeBlockTitle {
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-size: var(--ifm-code-font-size);
+  font-weight: 500;
+  padding: 0.75rem var(--ifm-pre-padding);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.codeBlockTitle + .codeBlockContent .codeBlock {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Line/Token/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Line/Token/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+// Pass-through components that users can swizzle and customize
+export default function CodeBlockLineToken({line, token, ...props}) {
+  return <span {...props} />;
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Line/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Line/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import clsx from 'clsx';
+import LineToken from '@theme/CodeBlock/Line/Token';
+import styles from './styles.module.css';
+// Replaces '\n' by ''
+// Historical code, not sure why we even need this :/
+function fixLineBreak(line) {
+  const singleLineBreakToken =
+    line.length === 1 && line[0].content === '\n' ? line[0] : undefined;
+  if (singleLineBreakToken) {
+    return [{...singleLineBreakToken, content: ''}];
+  }
+  return line;
+}
+export default function CodeBlockLine({
+  line: lineProp,
+  classNames,
+  showLineNumbers,
+  getLineProps,
+  getTokenProps,
+}) {
+  const line = fixLineBreak(lineProp);
+  const lineProps = getLineProps({
+    line,
+    className: clsx(classNames, showLineNumbers && styles.codeLine),
+  });
+  const lineTokens = line.map((token, key) => {
+    const tokenProps = getTokenProps({token});
+    return (
+      <LineToken key={key} {...tokenProps} line={line} token={token}>
+        {tokenProps.children}
+      </LineToken>
+    );
+  });
+  return (
+    <span {...lineProps}>
+      {showLineNumbers ? (
+        <>
+          <span className={styles.codeLineNumber} />
+          <span className={styles.codeLineContent}>{lineTokens}</span>
+        </>
+      ) : (
+        lineTokens
+      )}
+      <br />
+    </span>
+  );
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Line/styles.module.css
+++ b/docs/docusaurus/src/theme/CodeBlock/Line/styles.module.css
@@ -1,0 +1,45 @@
+/* Intentionally has zero specificity, so that to be able to override
+the background in custom CSS file due bug https://github.com/facebook/docusaurus/issues/3678 */
+:where(:root) {
+  --docusaurus-highlighted-code-line-bg: rgb(72 77 91);
+}
+
+:where([data-theme='dark']) {
+  --docusaurus-highlighted-code-line-bg: rgb(100 100 100);
+}
+
+:global(.theme-code-block-highlighted-line) {
+  background-color: var(--docusaurus-highlighted-code-line-bg);
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}
+
+.codeLine {
+  display: table-row;
+  counter-increment: line-count;
+}
+
+.codeLineNumber {
+  display: table-cell;
+  text-align: right;
+  width: 1%;
+  position: sticky;
+  left: 0;
+  padding: 0 var(--ifm-pre-padding);
+  background: var(--ifm-pre-background);
+  overflow-wrap: normal;
+}
+
+.codeLineNumber::before {
+  content: counter(line-count);
+  opacity: 0.4;
+}
+
+:global(.theme-code-block-highlighted-line) .codeLineNumber::before {
+  opacity: 0.8;
+}
+
+.codeLineContent {
+  padding-right: var(--ifm-pre-padding);
+}

--- a/docs/docusaurus/src/theme/CodeBlock/Title/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/Title/index.js
@@ -1,0 +1,4 @@
+// Just a pass-through component that users can swizzle and customize
+export default function CodeBlockTitle({children}) {
+  return children;
+}

--- a/docs/docusaurus/src/theme/CodeBlock/index.js
+++ b/docs/docusaurus/src/theme/CodeBlock/index.js
@@ -1,0 +1,32 @@
+import React, {isValidElement} from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import ElementContent from '@theme/CodeBlock/Content/Element';
+import StringContent from '@theme/CodeBlock/Content/String';
+/**
+ * Best attempt to make the children a plain string so it is copyable. If there
+ * are react elements, we will not be able to copy the content, and it will
+ * return `children` as-is; otherwise, it concatenates the string children
+ * together.
+ */
+function maybeStringifyChildren(children) {
+  if (React.Children.toArray(children).some((el) => isValidElement(el))) {
+    return children;
+  }
+  // The children is now guaranteed to be one/more plain strings
+  return Array.isArray(children) ? children.join('') : children;
+}
+export default function CodeBlock({children: rawChildren, ...props}) {
+  // The Prism theme on SSR is always the default theme but the site theme can
+  // be in a different mode. React hydration doesn't update DOM styles that come
+  // from SSR. Hence force a re-render after mounting to apply the current
+  // relevant styles.
+  const isBrowser = useIsBrowser();
+  const children = maybeStringifyChildren(rawChildren);
+  const CodeBlockComp =
+    typeof children === 'string' ? StringContent : ElementContent;
+  return (
+    <CodeBlockComp key={String(isBrowser)} {...props}>
+      {children}
+    </CodeBlockComp>
+  );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -637,12 +637,8 @@ filterwarnings = [
     "ignore: The load_credentials_from_file method is deprecated because of a potential security risk.:DeprecationWarning",
     # google.* libraries
     # Example Actual Warning:
-    # FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.api_core past that date.
-    "ignore: You are using a Python version \\(3\\.10.*\\) which Google will stop supporting in new releases of google.api_core:FutureWarning",
-    # google.cloud.secretmanager_v1
-    # Example Actual Warning:
-    # FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.cloud.secretmanager_v1 once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.cloud.secretmanager_v1 past that date.
-    "ignore: You are using a Python version \\(3\\.10.*\\) which Google will stop supporting in new releases of google.cloud.secretmanager_v1:FutureWarning",
+    # FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.* once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates past that date.
+    "ignore: You are using a Python version \\(3\\.10.*\\) which Google will stop supporting in new releases of google:FutureWarning",
     # sqlalchemy
     # Example Actual Warning:
     # sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -638,7 +638,11 @@ filterwarnings = [
     # google.api_core
     # Example Actual Warning:
     # FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.api_core past that date.
-    "ignore: You are using a Python version.*which Google will stop supporting in new releases of google.api_core:FutureWarning",
+    "ignore: You are using a Python version \\(3\\.10.*\\) which Google will stop supporting in new releases of google.api_core:FutureWarning",
+    # google.cloud.secretmanager_v1
+    # Example Actual Warning:
+    # FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.cloud.secretmanager_v1 once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.cloud.secretmanager_v1 past that date.
+    "ignore: You are using a Python version \\(3\\.10.*\\) which Google will stop supporting in new releases of google.cloud.secretmanager_v1:FutureWarning",
     # sqlalchemy
     # Example Actual Warning:
     # sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)


### PR DESCRIPTION
**Note: This PR looks big but it's mostly ejected code from docusaurus. I've added PR comments to highlight the actual code that got added.**

Currently when someone hits the copy button on a code block in the docs site they get hidden lines. The hidden lines come from our Prism config. The logic to copy a code block comes from docusaurus. Because they come from different libraries there isn't a configuration we can set to not copy the hidden lines. Instead docusaurus provides a "swizzle" feature where you can eject the javascript logic and then customize it. We've done this. All our changes to the ejected files lives in: `index.js`. We've added the function `filterHiddenLines` and then call it in `useCopyButton`.

We've updated the README with details about updating docusaurus now that we have an ejected logic. We've also added tests for our custom logic.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
