### PR TITLE
[MAINTENANCE] Improve local type checking developer experience

### DIFF
--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -255,7 +255,7 @@ class SphinxInvokeDocsBuilder:
         for external_ref in external_refs:
             url = external_ref.string
             url_parts = urlparse(url)
-            url_path = url_parts.path.strip("/").split("/")
+            url_path = str(url_parts.path).strip("/").split("/")
             url_text = url_path[-1]
 
             formatted_text = url_text.replace("_", " ").title()
@@ -272,7 +272,7 @@ class SphinxInvokeDocsBuilder:
         for internal_ref in internal_refs:
             href = internal_ref["href"]
 
-            split_href = href.split("#")
+            split_href = str(href).split("#")
             href_path = pathlib.Path(split_href[0])
 
             if str(href_path) == ".":

--- a/great_expectations/compatibility/pandas_compatibility.py
+++ b/great_expectations/compatibility/pandas_compatibility.py
@@ -17,7 +17,7 @@ def execute_pandas_to_datetime(  # noqa: PLR0913 # FIXME CoP
     utc: bool | None = None,
     format: str | None = None,
     exact: bool = True,
-    unit: str | None = None,
+    unit: Literal["D", "s", "ms", "us", "ns"] | None = None,
     infer_datetime_format: bool = False,
     origin="unix",
     cache: bool = True,

--- a/great_expectations/compatibility/pyparsing.py
+++ b/great_expectations/compatibility/pyparsing.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-import pyparsing
-
 try:
     from pyparsing import DelimitedList
 except ImportError:
@@ -20,14 +18,6 @@ except ImportError:
         dictOf as dict_of,  # noqa: F401  # import used externally via compatibility import
     )
 
-# Determine which API is available at import time
-try:
-    _test_parser = pyparsing.Literal("test")
-    _test_parser.set_parse_action(lambda: None)
-    _USE_NEW_PYPARSING_API = True
-except AttributeError:
-    _USE_NEW_PYPARSING_API = False
-
 
 def set_parse_action(parser: Any, action: Callable) -> Any:
     """Compatibility wrapper for set_parse_action/setParseAction.
@@ -39,9 +29,10 @@ def set_parse_action(parser: Any, action: Callable) -> Any:
     Returns:
         The parser object with the parse action set (for chaining)
     """
-    if _USE_NEW_PYPARSING_API:
+    try:
         return parser.set_parse_action(action)
-    return parser.setParseAction(action)
+    except AttributeError:
+        return parser.setParseAction(action)
 
 
 def set_results_name(parser: Any, name: str) -> Any:
@@ -54,9 +45,10 @@ def set_results_name(parser: Any, name: str) -> Any:
     Returns:
         The parser object with the results name set (for chaining)
     """
-    if _USE_NEW_PYPARSING_API:
+    try:
         return parser.set_results_name(name)
-    return parser.setResultsName(name)
+    except AttributeError:
+        return parser.setResultsName(name)
 
 
 def parse_string(parser: Any, string: str, parse_all: bool = False) -> Any:
@@ -70,6 +62,7 @@ def parse_string(parser: Any, string: str, parse_all: bool = False) -> Any:
     Returns:
         The parse results
     """
-    if _USE_NEW_PYPARSING_API:
+    try:
         return parser.parse_string(string, parse_all=parse_all)
-    return parser.parseString(string, parseAll=parse_all)
+    except AttributeError:
+        return parser.parseString(string, parseAll=parse_all)

--- a/great_expectations/compatibility/pyparsing.py
+++ b/great_expectations/compatibility/pyparsing.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+import pyparsing
+
+# Import classes and functions that may have different names in different versions
 try:
     from pyparsing import DelimitedList
 except ImportError:
     # Backward compatibility for older pyparsing versions (e.g., 3.0.9 used by Airflow 2.5.0)
     from pyparsing import (
-        delimitedList as DelimitedList,  # noqa: F401  # import used externally via compatibility import
+        delimitedList as DelimitedList,
     )
 
 try:
@@ -15,8 +18,54 @@ try:
 except ImportError:
     # Backward compatibility for older pyparsing versions (e.g., 3.0.9 used by Airflow 2.5.0)
     from pyparsing import (
-        dictOf as dict_of,  # noqa: F401  # import used externally via compatibility import
+        dictOf as dict_of,
     )
+
+# Re-export commonly used pyparsing classes and functions
+from pyparsing import (
+    CaselessKeyword,
+    CaselessLiteral,
+    Combine,
+    Forward,
+    Group,
+    Literal,
+    ParseException,
+    ParseResults,
+    QuotedString,
+    Regex,
+    Suppress,
+    Word,
+    alphanums,
+    alphas,
+    alphas8bit,
+    hexnums,
+)
+
+# Re-export pyparsing module itself for cases where the full module is needed
+__all__ = [
+    "CaselessKeyword",
+    "CaselessLiteral",
+    "Combine",
+    "DelimitedList",
+    "Forward",
+    "Group",
+    "Literal",
+    "ParseException",
+    "ParseResults",
+    "QuotedString",
+    "Regex",
+    "Suppress",
+    "Word",
+    "alphanums",
+    "alphas",
+    "alphas8bit",
+    "dict_of",
+    "hexnums",
+    "parse_string",
+    "pyparsing",
+    "set_parse_action",
+    "set_results_name",
+]
 
 
 def set_parse_action(parser: Any, action: Callable) -> Any:

--- a/great_expectations/compatibility/pyparsing.py
+++ b/great_expectations/compatibility/pyparsing.py
@@ -2,19 +2,31 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-try:
-    from pyparsing import DelimitedList, dict_of
+import pyparsing
 
-    _USE_NEW_PYPARSING_API = True
+try:
+    from pyparsing import DelimitedList
 except ImportError:
     # Backward compatibility for older pyparsing versions (e.g., 3.0.9 used by Airflow 2.5.0)
-    from pyparsing import delimitedList as DelimitedList
-    from pyparsing import dictOf as dict_of
+    from pyparsing import (
+        delimitedList as DelimitedList,  # noqa: F401  # import used externally via compatibility import
+    )
 
+try:
+    from pyparsing import dict_of
+except ImportError:
+    # Backward compatibility for older pyparsing versions (e.g., 3.0.9 used by Airflow 2.5.0)
+    from pyparsing import (
+        dictOf as dict_of,  # noqa: F401  # import used externally via compatibility import
+    )
+
+# Determine which API is available at import time
+try:
+    _test_parser = pyparsing.Literal("test")
+    _test_parser.set_parse_action(lambda: None)
+    _USE_NEW_PYPARSING_API = True
+except AttributeError:
     _USE_NEW_PYPARSING_API = False
-
-# Re-export for convenience
-__all__ = ["DelimitedList", "dict_of", "parse_string", "set_parse_action", "set_results_name"]
 
 
 def set_parse_action(parser: Any, action: Callable) -> Any:

--- a/great_expectations/compatibility/pyparsing.py
+++ b/great_expectations/compatibility/pyparsing.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+try:
+    from pyparsing import DelimitedList, dict_of
+
+    _USE_NEW_PYPARSING_API = True
+except ImportError:
+    # Backward compatibility for older pyparsing versions (e.g., 3.0.9 used by Airflow 2.5.0)
+    from pyparsing import delimitedList as DelimitedList
+    from pyparsing import dictOf as dict_of
+
+    _USE_NEW_PYPARSING_API = False
+
+# Re-export for convenience
+__all__ = ["DelimitedList", "dict_of", "parse_string", "set_parse_action", "set_results_name"]
+
+
+def set_parse_action(parser: Any, action: Callable) -> Any:
+    """Compatibility wrapper for set_parse_action/setParseAction.
+
+    Args:
+        parser: The pyparsing parser object
+        action: The parse action function to apply
+
+    Returns:
+        The parser object with the parse action set (for chaining)
+    """
+    if _USE_NEW_PYPARSING_API:
+        return parser.set_parse_action(action)
+    return parser.setParseAction(action)
+
+
+def set_results_name(parser: Any, name: str) -> Any:
+    """Compatibility wrapper for set_results_name/setResultsName.
+
+    Args:
+        parser: The pyparsing parser object
+        name: The name to assign to the parsed results
+
+    Returns:
+        The parser object with the results name set (for chaining)
+    """
+    if _USE_NEW_PYPARSING_API:
+        return parser.set_results_name(name)
+    return parser.setResultsName(name)
+
+
+def parse_string(parser: Any, string: str, parse_all: bool = True) -> Any:
+    """Compatibility wrapper for parse_string/parseString.
+
+    Args:
+        parser: The pyparsing parser object
+        string: The string to parse
+        parse_all: Whether to require parsing the entire string
+
+    Returns:
+        The parse results
+    """
+    if _USE_NEW_PYPARSING_API:
+        return parser.parse_string(string, parse_all=parse_all)
+    return parser.parseString(string, parseAll=parse_all)

--- a/great_expectations/compatibility/pyparsing.py
+++ b/great_expectations/compatibility/pyparsing.py
@@ -59,7 +59,7 @@ def set_results_name(parser: Any, name: str) -> Any:
     return parser.setResultsName(name)
 
 
-def parse_string(parser: Any, string: str, parse_all: bool = True) -> Any:
+def parse_string(parser: Any, string: str, parse_all: bool = False) -> Any:
     """Compatibility wrapper for parse_string/parseString.
 
     Args:

--- a/great_expectations/core/suite_parameters.py
+++ b/great_expectations/core/suite_parameters.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 import dateutil
 from pyparsing import (
     CaselessKeyword,
-    DelimitedList,
     Forward,
     Group,
     Literal,
@@ -23,9 +22,14 @@ from pyparsing import (
     Word,
     alphanums,
     alphas,
-    dict_of,
 )
 
+from great_expectations.compatibility.pyparsing import (
+    DelimitedList,
+    dict_of,
+    parse_string,
+    set_parse_action,
+)
 from great_expectations.exceptions import SuiteParameterError
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
 
@@ -150,36 +154,39 @@ class SuiteParameterParser:
             key = Word(f"{alphas}_") + Suppress("=")
             # value = (fnumber | Word(alphanums))
             value = expr
-            keyval = dict_of(key.set_parse_action(self.push_first), value)
+            keyval = dict_of(set_parse_action(key, self.push_first), value)
             kwarglist = DelimitedList(keyval)
 
             # add parse action that replaces the function identifier with a (name, number of args, has_fn_kwargs) tuple  # noqa: E501 # FIXME CoP
             # 20211009 - JPC - Note that it's important that we consider kwarglist
             # first as part of disabling backtracking for the function's arguments
-            fn_call = (variable + lpar + rpar).set_parse_action(
-                lambda t: t.insert(0, (t.pop(0), 0, False))
+            fn_call = set_parse_action(
+                variable + lpar + rpar, lambda t: t.insert(0, (t.pop(0), 0, False))
             ) | (
-                (variable + lpar - Group(expr_list) + rpar).set_parse_action(
-                    lambda t: t.insert(0, (t.pop(0), len(t[0]), False))
+                set_parse_action(
+                    variable + lpar - Group(expr_list) + rpar,
+                    lambda t: t.insert(0, (t.pop(0), len(t[0]), False)),
                 )
-                ^ (variable + lpar - Group(kwarglist) + rpar).set_parse_action(
-                    lambda t: t.insert(0, (t.pop(0), len(t[0]), True))
+                ^ set_parse_action(
+                    variable + lpar - Group(kwarglist) + rpar,
+                    lambda t: t.insert(0, (t.pop(0), len(t[0]), True)),
                 )
             )
-            atom = (
+            atom = set_parse_action(
                 addop[...]
                 + (
-                    (fn_call | pi | e | fnumber | variable).set_parse_action(self.push_first)
+                    set_parse_action(fn_call | pi | e | fnumber | variable, self.push_first)
                     | Group(lpar + expr + rpar)
-                )
-            ).set_parse_action(self.push_unary_minus)
+                ),
+                self.push_unary_minus,
+            )
 
             # by defining exponentiation as "atom [ ^ factor ]..." instead of "atom [ ^ atom ]...", we get right-to-left  # noqa: E501 # FIXME CoP
             # exponents, instead of left-to-right that is, 2^3^2 = 2^(3^2), not (2^3)^2.
             factor = Forward()
-            factor <<= atom + (expop + factor).set_parse_action(self.push_first)[...]
-            term = factor + (multop + factor).set_parse_action(self.push_first)[...]
-            expr <<= term + (addop + term).set_parse_action(self.push_first)[...]
+            factor <<= atom + set_parse_action(expop + factor, self.push_first)[...]
+            term = factor + set_parse_action(multop + factor, self.push_first)[...]
+            expr <<= term + set_parse_action(addop + term, self.push_first)[...]
             self._parser = expr
         return self._parser
 
@@ -355,7 +362,7 @@ def _get_parse_results(
     # Calling get_parser clears the stack
     parser = EXPR.get_parser()
     try:
-        parse_results = parser.parse_string(parameter_expression, parse_all=True)
+        parse_results = parse_string(parser, parameter_expression, parse_all=True)
     except ParseException as err:
         parse_results = [
             "Parse Failure",

--- a/great_expectations/core/suite_parameters.py
+++ b/great_expectations/core/suite_parameters.py
@@ -23,7 +23,7 @@ from pyparsing import (
     Word,
     alphanums,
     alphas,
-    dictOf,
+    dict_of,
 )
 
 from great_expectations.exceptions import SuiteParameterError
@@ -150,7 +150,7 @@ class SuiteParameterParser:
             key = Word(f"{alphas}_") + Suppress("=")
             # value = (fnumber | Word(alphanums))
             value = expr
-            keyval = dictOf(key.set_parse_action(self.push_first), value)
+            keyval = dict_of(key.set_parse_action(self.push_first), value)
             kwarglist = DelimitedList(keyval)
 
             # add parse action that replaces the function identifier with a (name, number of args, has_fn_kwargs) tuple  # noqa: E501 # FIXME CoP

--- a/great_expectations/core/suite_parameters.py
+++ b/great_expectations/core/suite_parameters.py
@@ -10,8 +10,10 @@ from collections import namedtuple
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import dateutil
-from pyparsing import (
+
+from great_expectations.compatibility.pyparsing import (
     CaselessKeyword,
+    DelimitedList,
     Forward,
     Group,
     Literal,
@@ -22,10 +24,6 @@ from pyparsing import (
     Word,
     alphanums,
     alphas,
-)
-
-from great_expectations.compatibility.pyparsing import (
-    DelimitedList,
     dict_of,
     parse_string,
     set_parse_action,

--- a/great_expectations/core/suite_parameters.py
+++ b/great_expectations/core/suite_parameters.py
@@ -150,36 +150,36 @@ class SuiteParameterParser:
             key = Word(f"{alphas}_") + Suppress("=")
             # value = (fnumber | Word(alphanums))
             value = expr
-            keyval = dictOf(key.setParseAction(self.push_first), value)
+            keyval = dictOf(key.set_parse_action(self.push_first), value)
             kwarglist = delimitedList(keyval)
 
             # add parse action that replaces the function identifier with a (name, number of args, has_fn_kwargs) tuple  # noqa: E501 # FIXME CoP
             # 20211009 - JPC - Note that it's important that we consider kwarglist
             # first as part of disabling backtracking for the function's arguments
-            fn_call = (variable + lpar + rpar).setParseAction(
+            fn_call = (variable + lpar + rpar).set_parse_action(
                 lambda t: t.insert(0, (t.pop(0), 0, False))
             ) | (
-                (variable + lpar - Group(expr_list) + rpar).setParseAction(
+                (variable + lpar - Group(expr_list) + rpar).set_parse_action(
                     lambda t: t.insert(0, (t.pop(0), len(t[0]), False))
                 )
-                ^ (variable + lpar - Group(kwarglist) + rpar).setParseAction(
+                ^ (variable + lpar - Group(kwarglist) + rpar).set_parse_action(
                     lambda t: t.insert(0, (t.pop(0), len(t[0]), True))
                 )
             )
             atom = (
                 addop[...]
                 + (
-                    (fn_call | pi | e | fnumber | variable).setParseAction(self.push_first)
+                    (fn_call | pi | e | fnumber | variable).set_parse_action(self.push_first)
                     | Group(lpar + expr + rpar)
                 )
-            ).setParseAction(self.push_unary_minus)
+            ).set_parse_action(self.push_unary_minus)
 
             # by defining exponentiation as "atom [ ^ factor ]..." instead of "atom [ ^ atom ]...", we get right-to-left  # noqa: E501 # FIXME CoP
             # exponents, instead of left-to-right that is, 2^3^2 = 2^(3^2), not (2^3)^2.
             factor = Forward()
-            factor <<= atom + (expop + factor).setParseAction(self.push_first)[...]
-            term = factor + (multop + factor).setParseAction(self.push_first)[...]
-            expr <<= term + (addop + term).setParseAction(self.push_first)[...]
+            factor <<= atom + (expop + factor).set_parse_action(self.push_first)[...]
+            term = factor + (multop + factor).set_parse_action(self.push_first)[...]
+            expr <<= term + (addop + term).set_parse_action(self.push_first)[...]
             self._parser = expr
         return self._parser
 

--- a/great_expectations/core/suite_parameters.py
+++ b/great_expectations/core/suite_parameters.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 import dateutil
 from pyparsing import (
     CaselessKeyword,
+    DelimitedList,
     Forward,
     Group,
     Literal,
@@ -22,7 +23,6 @@ from pyparsing import (
     Word,
     alphanums,
     alphas,
-    delimitedList,
     dictOf,
 )
 
@@ -142,7 +142,7 @@ class SuiteParameterParser:
             expop = Literal("^")
 
             expr = Forward()
-            expr_list = delimitedList(Group(expr))
+            expr_list = DelimitedList(Group(expr))
 
             # We will allow functions either to accept *only* keyword
             # expressions or *only* non-keyword expressions
@@ -151,7 +151,7 @@ class SuiteParameterParser:
             # value = (fnumber | Word(alphanums))
             value = expr
             keyval = dictOf(key.set_parse_action(self.push_first), value)
-            kwarglist = delimitedList(keyval)
+            kwarglist = DelimitedList(keyval)
 
             # add parse action that replaces the function identifier with a (name, number of args, has_fn_kwargs) tuple  # noqa: E501 # FIXME CoP
             # 20211009 - JPC - Note that it's important that we consider kwarglist
@@ -355,7 +355,7 @@ def _get_parse_results(
     # Calling get_parser clears the stack
     parser = EXPR.get_parser()
     try:
-        parse_results = parser.parseString(parameter_expression, parseAll=True)
+        parse_results = parser.parse_string(parameter_expression, parse_all=True)
     except ParseException as err:
         parse_results = [
             "Parse Failure",

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -99,7 +99,7 @@ def nested_update(
 
 def in_jupyter_notebook():
     try:
-        from IPython import get_ipython  # type: ignore[import-not-found] # FIXME CoP
+        from IPython import get_ipython
 
         shell = get_ipython().__class__.__name__
         if shell == "ZMQInteractiveShell":

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -6,9 +6,11 @@ import uuid
 from abc import ABCMeta, abstractmethod
 from typing import Any, List, Optional, Union
 
-import pyparsing as pp
-
-from great_expectations.compatibility.pyparsing import parse_string
+from great_expectations.compatibility.pyparsing import (
+    Word,
+    hexnums,
+    parse_string,
+)
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 
 logger = logging.getLogger(__name__)
@@ -83,9 +85,7 @@ class StoreBackend(metaclass=ABCMeta):
         try:
             try:
                 ge_store_backend_id_file_contents = self.get(key=self.STORE_BACKEND_ID_KEY)
-                store_backend_id_file_parser = self.STORE_BACKEND_ID_PREFIX + pp.Word(
-                    f"{pp.hexnums}-"
-                )
+                store_backend_id_file_parser = self.STORE_BACKEND_ID_PREFIX + Word(f"{hexnums}-")
                 parsed_store_backend_id = parse_string(
                     store_backend_id_file_parser, ge_store_backend_id_file_contents
                 )

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -85,7 +85,7 @@ class StoreBackend(metaclass=ABCMeta):
                 store_backend_id_file_parser = self.STORE_BACKEND_ID_PREFIX + pp.Word(
                     f"{pp.hexnums}-"
                 )
-                parsed_store_backend_id = store_backend_id_file_parser.parseString(
+                parsed_store_backend_id = store_backend_id_file_parser.parse_string(
                     ge_store_backend_id_file_contents
                 )
                 return uuid.UUID(parsed_store_backend_id[1])

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -8,6 +8,7 @@ from typing import Any, List, Optional, Union
 
 import pyparsing as pp
 
+from great_expectations.compatibility.pyparsing import parse_string
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 
 logger = logging.getLogger(__name__)
@@ -85,8 +86,6 @@ class StoreBackend(metaclass=ABCMeta):
                 store_backend_id_file_parser = self.STORE_BACKEND_ID_PREFIX + pp.Word(
                     f"{pp.hexnums}-"
                 )
-                from great_expectations.compatibility.pyparsing import parse_string
-
                 parsed_store_backend_id = parse_string(
                     store_backend_id_file_parser, ge_store_backend_id_file_contents
                 )

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -85,8 +85,10 @@ class StoreBackend(metaclass=ABCMeta):
                 store_backend_id_file_parser = self.STORE_BACKEND_ID_PREFIX + pp.Word(
                     f"{pp.hexnums}-"
                 )
-                parsed_store_backend_id = store_backend_id_file_parser.parse_string(
-                    ge_store_backend_id_file_contents
+                from great_expectations.compatibility.pyparsing import parse_string
+
+                parsed_store_backend_id = parse_string(
+                    store_backend_id_file_parser, ge_store_backend_id_file_contents
                 )
                 return uuid.UUID(parsed_store_backend_id[1])
             except InvalidKeyError:

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -12,6 +12,10 @@ from urllib.parse import urlparse
 import pyparsing as pp
 
 from great_expectations.alias_types import PathStr  # noqa: TC001 # FIXME CoP
+from great_expectations.compatibility.pyparsing import (
+    parse_string,
+    set_results_name,
+)
 from great_expectations.exceptions import StoreConfigurationError
 from great_expectations.types import safe_deep_copy
 from great_expectations.util import load_class, verify_dynamic_loading_support
@@ -136,14 +140,14 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
     Returns:
         string of variable name e.g. SOME_VAR or None if not parsable. If there are multiple substitution variables this currently returns the first e.g. $SOME_$TRING -> $SOME_
     """  # noqa: E501 # FIXME CoP
-    substitution_variable_name = pp.Word(pp.alphanums + "_").set_results_name(
-        "substitution_variable_name"
+    substitution_variable_name = set_results_name(
+        pp.Word(pp.alphanums + "_"), "substitution_variable_name"
     )
     curly_brace_parser = "${" + substitution_variable_name + "}"
     non_curly_brace_parser = "$" + substitution_variable_name
     both_parser = curly_brace_parser | non_curly_brace_parser
     try:
-        parsed_substitution_variable = both_parser.parse_string(substitution_variable)
+        parsed_substitution_variable = parse_string(both_parser, substitution_variable)
         return parsed_substitution_variable.substitution_variable_name
     except pp.ParseException:
         return None

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -143,7 +143,7 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
     non_curly_brace_parser = "$" + substitution_variable_name
     both_parser = curly_brace_parser | non_curly_brace_parser
     try:
-        parsed_substitution_variable = both_parser.parseString(substitution_variable)
+        parsed_substitution_variable = both_parser.parse_string(substitution_variable)
         return parsed_substitution_variable.substitution_variable_name
     except pp.ParseException:
         return None

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -147,7 +147,9 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
     non_curly_brace_parser = "$" + substitution_variable_name
     both_parser = curly_brace_parser | non_curly_brace_parser
     try:
-        parsed_substitution_variable = parse_string(both_parser, substitution_variable)
+        parsed_substitution_variable = parse_string(
+            both_parser, substitution_variable, parse_all=False
+        )
         return parsed_substitution_variable.substitution_variable_name
     except pp.ParseException:
         return None

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -136,7 +136,7 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
     Returns:
         string of variable name e.g. SOME_VAR or None if not parsable. If there are multiple substitution variables this currently returns the first e.g. $SOME_$TRING -> $SOME_
     """  # noqa: E501 # FIXME CoP
-    substitution_variable_name = pp.Word(pp.alphanums + "_").setResultsName(
+    substitution_variable_name = pp.Word(pp.alphanums + "_").set_results_name(
         "substitution_variable_name"
     )
     curly_brace_parser = "${" + substitution_variable_name + "}"

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -147,9 +147,7 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
     non_curly_brace_parser = "$" + substitution_variable_name
     both_parser = curly_brace_parser | non_curly_brace_parser
     try:
-        parsed_substitution_variable = parse_string(
-            both_parser, substitution_variable, parse_all=False
-        )
+        parsed_substitution_variable = parse_string(both_parser, substitution_variable)
         return parsed_substitution_variable.substitution_variable_name
     except pp.ParseException:
         return None

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -9,10 +9,11 @@ import warnings
 from typing import Any, Optional
 from urllib.parse import urlparse
 
-import pyparsing as pp
-
 from great_expectations.alias_types import PathStr  # noqa: TC001 # FIXME CoP
 from great_expectations.compatibility.pyparsing import (
+    ParseException,
+    Word,
+    alphanums,
     parse_string,
     set_results_name,
 )
@@ -141,7 +142,7 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
         string of variable name e.g. SOME_VAR or None if not parsable. If there are multiple substitution variables this currently returns the first e.g. $SOME_$TRING -> $SOME_
     """  # noqa: E501 # FIXME CoP
     substitution_variable_name = set_results_name(
-        pp.Word(pp.alphanums + "_"), "substitution_variable_name"
+        Word(alphanums + "_"), "substitution_variable_name"
     )
     curly_brace_parser = "${" + substitution_variable_name + "}"
     non_curly_brace_parser = "$" + substitution_variable_name
@@ -149,7 +150,7 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
     try:
         parsed_substitution_variable = parse_string(both_parser, substitution_variable)
         return parsed_substitution_variable.substitution_variable_name
-    except pp.ParseException:
+    except ParseException:
         return None
 
 

--- a/great_expectations/expectations/legacy_row_conditions.py
+++ b/great_expectations/expectations/legacy_row_conditions.py
@@ -35,29 +35,29 @@ def _set_notnull(s, l, t) -> None:  # noqa: E741 # ambiguous name `l`
 
 
 WHITESPACE_CHARS = " \t"
-column_name = Combine(Literal("col(") + QuotedString('"').setResultsName("column") + Literal(")"))
+column_name = Combine(Literal("col(") + QuotedString('"').set_results_name("column") + Literal(")"))
 gt = Literal(">")
 lt = Literal("<")
 ge = Literal(">=")
 le = Literal("<=")
 eq = Literal("==")
 ne = Literal("!=")
-ops = (gt ^ lt ^ ge ^ le ^ eq ^ ne).setResultsName("op")
-fnumber = Regex(r"[+-]?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?").setResultsName("fnumber")
+ops = (gt ^ lt ^ ge ^ le ^ eq ^ ne).set_results_name("op")
+fnumber = Regex(r"[+-]?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?").set_results_name("fnumber")
 punctuation_without_apostrophe = punctuation.replace('"', "").replace("'", "")
 condition_value_chars = alphanums + alphas8bit + punctuation_without_apostrophe + WHITESPACE_CHARS
-condition_value = Suppress('"') + Word(f"{condition_value_chars}._").setResultsName(
+condition_value = Suppress('"') + Word(f"{condition_value_chars}._").set_results_name(
     "condition_value"
-) + Suppress('"') ^ Suppress("'") + Word(f"{condition_value_chars}._").setResultsName(
+) + Suppress('"') ^ Suppress("'") + Word(f"{condition_value_chars}._").set_results_name(
     "condition_value"
 ) + Suppress("'")
 date = (
-    Literal("date").setResultsName("date")
+    Literal("date").set_results_name("date")
     + Suppress(Literal("("))
     + condition_value
     + Suppress(Literal(")"))
 )
-not_null = CaselessLiteral(".notnull()").setResultsName("notnull")
+not_null = CaselessLiteral(".notnull()").set_results_name("notnull")
 condition = (column_name + not_null).setParseAction(_set_notnull) ^ (
     column_name + ops + (fnumber ^ condition_value ^ date)
 )

--- a/great_expectations/expectations/legacy_row_conditions.py
+++ b/great_expectations/expectations/legacy_row_conditions.py
@@ -115,7 +115,7 @@ class RowCondition(SerializableDictDot):
 
 def parse_great_expectations_condition(row_condition: str):
     try:
-        return condition.parseString(row_condition)
+        return condition.parse_string(row_condition)
     except ParseException:
         raise ConditionParserError(f"unable to parse condition: {row_condition}")  # noqa: TRY003 # FIXME CoP
 

--- a/great_expectations/expectations/legacy_row_conditions.py
+++ b/great_expectations/expectations/legacy_row_conditions.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from string import punctuation
 from typing import TYPE_CHECKING
 
-from pyparsing import (
+import great_expectations.exceptions as gx_exceptions
+from great_expectations.compatibility.pyparsing import (
     CaselessLiteral,
     Combine,
     Literal,
@@ -17,10 +18,6 @@ from pyparsing import (
     Word,
     alphanums,
     alphas8bit,
-)
-
-import great_expectations.exceptions as gx_exceptions
-from great_expectations.compatibility.pyparsing import (
     parse_string,
     set_parse_action,
     set_results_name,

--- a/great_expectations/expectations/legacy_row_conditions.py
+++ b/great_expectations/expectations/legacy_row_conditions.py
@@ -58,7 +58,7 @@ date = (
     + Suppress(Literal(")"))
 )
 not_null = CaselessLiteral(".notnull()").set_results_name("notnull")
-condition = (column_name + not_null).setParseAction(_set_notnull) ^ (
+condition = (column_name + not_null).set_parse_action(_set_notnull) ^ (
     column_name + ops + (fnumber ^ condition_value ^ date)
 )
 

--- a/great_expectations/expectations/legacy_row_conditions.py
+++ b/great_expectations/expectations/legacy_row_conditions.py
@@ -20,6 +20,11 @@ from pyparsing import (
 )
 
 import great_expectations.exceptions as gx_exceptions
+from great_expectations.compatibility.pyparsing import (
+    parse_string,
+    set_parse_action,
+    set_results_name,
+)
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
@@ -35,30 +40,32 @@ def _set_notnull(s, l, t) -> None:  # noqa: E741 # ambiguous name `l`
 
 
 WHITESPACE_CHARS = " \t"
-column_name = Combine(Literal("col(") + QuotedString('"').set_results_name("column") + Literal(")"))
+column_name = Combine(
+    Literal("col(") + set_results_name(QuotedString('"'), "column") + Literal(")")
+)
 gt = Literal(">")
 lt = Literal("<")
 ge = Literal(">=")
 le = Literal("<=")
 eq = Literal("==")
 ne = Literal("!=")
-ops = (gt ^ lt ^ ge ^ le ^ eq ^ ne).set_results_name("op")
-fnumber = Regex(r"[+-]?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?").set_results_name("fnumber")
+ops = set_results_name(gt ^ lt ^ ge ^ le ^ eq ^ ne, "op")
+fnumber = set_results_name(Regex(r"[+-]?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?"), "fnumber")
 punctuation_without_apostrophe = punctuation.replace('"', "").replace("'", "")
 condition_value_chars = alphanums + alphas8bit + punctuation_without_apostrophe + WHITESPACE_CHARS
-condition_value = Suppress('"') + Word(f"{condition_value_chars}._").set_results_name(
-    "condition_value"
-) + Suppress('"') ^ Suppress("'") + Word(f"{condition_value_chars}._").set_results_name(
-    "condition_value"
+condition_value = Suppress('"') + set_results_name(
+    Word(f"{condition_value_chars}._"), "condition_value"
+) + Suppress('"') ^ Suppress("'") + set_results_name(
+    Word(f"{condition_value_chars}._"), "condition_value"
 ) + Suppress("'")
 date = (
-    Literal("date").set_results_name("date")
+    set_results_name(Literal("date"), "date")
     + Suppress(Literal("("))
     + condition_value
     + Suppress(Literal(")"))
 )
-not_null = CaselessLiteral(".notnull()").set_results_name("notnull")
-condition = (column_name + not_null).set_parse_action(_set_notnull) ^ (
+not_null = set_results_name(CaselessLiteral(".notnull()"), "notnull")
+condition = set_parse_action(column_name + not_null, _set_notnull) ^ (
     column_name + ops + (fnumber ^ condition_value ^ date)
 )
 
@@ -115,7 +122,7 @@ class RowCondition(SerializableDictDot):
 
 def parse_great_expectations_condition(row_condition: str):
     try:
-        return condition.parse_string(row_condition)
+        return parse_string(condition, row_condition)
     except ParseException:
         raise ConditionParserError(f"unable to parse condition: {row_condition}")  # noqa: TRY003 # FIXME CoP
 

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -62,7 +62,7 @@ def _pandas_map_condition_unexpected_count(
     **kwargs,
 ) -> int:
     """Returns unexpected count for MapExpectations"""
-    return np.count_nonzero(metrics["unexpected_condition"][0])
+    return int(np.count_nonzero(metrics["unexpected_condition"][0]))
 
 
 def _pandas_map_condition_index(

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -6,7 +6,7 @@ import copy
 import decimal
 import locale
 import re
-from typing import Any, Sequence
+from typing import Any, Sequence, TypeVar
 
 import pandas as pd
 
@@ -438,7 +438,9 @@ def _convert_unexpected_indices_to_df(
         return pd.DataFrame()
 
     # 1. groupby on domain columns, and turn id/pk into list
-    def _agg_func(y: pd.Series[Any]) -> list[Any]:
+    T = TypeVar("T")
+
+    def _agg_func(y: pd.Series[T]) -> list[T]:
         return list(y)
 
     all_unexpected_indices: pd.DataFrame = unexpected_index_df.groupby(domain_column_name_list).agg(

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -438,9 +438,11 @@ def _convert_unexpected_indices_to_df(
         return pd.DataFrame()
 
     # 1. groupby on domain columns, and turn id/pk into list
-    T = TypeVar("T")
+    # TypeVar constrained to pandas-compatible types (str, int, float, bool, etc.)
+    # Using object as bound since pandas Series can hold various types
+    T = TypeVar("T", bound=object)
 
-    def _agg_func(y: pd.Series[T]) -> list[T]:
+    def _agg_func(y: pd.Series[T]) -> list[T]:  # type: ignore[type-var]  # not yet supported by pandas-stubs
         return list(y)
 
     all_unexpected_indices: pd.DataFrame = unexpected_index_df.groupby(domain_column_name_list).agg(

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -438,8 +438,11 @@ def _convert_unexpected_indices_to_df(
         return pd.DataFrame()
 
     # 1. groupby on domain columns, and turn id/pk into list
+    def _agg_func(y: pd.Series[Any]) -> list[Any]:
+        return list(y)
+
     all_unexpected_indices: pd.DataFrame = unexpected_index_df.groupby(domain_column_name_list).agg(
-        lambda y: list(y)
+        _agg_func
     )
 
     # 2. add count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ module = [
     "databricks.*",
     "google.*",
     "great_expectations.compatibility.pydantic.*",
+    "IPython.*",
     "mistune.*",
     "moto.*",
     "pact.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -416,6 +416,7 @@ If you are working in a configuration file you may use the inline comment \
 "google".msg = "Please do not import google directly, import from great_expectations.compatibility.google instead."
 "azure".msg = "Please do not import azure directly, import from great_expectations.compatibility.azure instead."
 "trino".msg = "Please do not import trino directly, import from great_expectations.compatibility.trino instead."
+"pyparsing".msg = "Please do not import pyparsing directly, import from great_expectations.compatibility.pyparsing instead."
 "pyarrow".msg = "Please do not import pyarrow directly, import from great_expectations.compatibility.pyarrow instead."
 "typing_extensions.override".msg = "Do not import typing_extensions.override directly, import `override` from great_expectations.compatibility.typing_extensions instead."
 # TODO: remove pydantic once our min version is pydantic v2

--- a/requirements-types.txt
+++ b/requirements-types.txt
@@ -1,3 +1,12 @@
+# This file installs all dependencies needed for type checking with mypy.
+# It serves two purposes:
+# 1. Installs the actual packages (pyspark, azure, etc.) that mypy needs to type-check imports
+# 2. Installs type stubs upfront for deterministic behavior (rather than relying solely on
+#    mypy's --install-types flag, which installs stubs dynamically and can vary between runs)
+# This ensures local type checking matches CI exactly: developers can run
+# `pip install -r requirements-types.txt` followed by `invoke types --ci --pretty`
+# and get the same results as CI.
+
 --requirement reqs/requirements-dev-sqlalchemy2.txt
 --requirement requirements.txt
 --requirement reqs/requirements-dev-lite.txt
@@ -10,22 +19,40 @@ pandas-stubs
 # force sqlalchemy 2 because it exports types
 sqlalchemy>2.0
 # typing stubs
+types-aws-xray-sdk
 types-beautifulsoup4
+types-cachetools
+types-cffi
 types-colorama
 types-decorator
+types-docker
+types-geopandas
+types-greenlet
+types-grpcio
+types-grpcio-status
 types-html5lib
 types-jsonschema
+types-oauthlib
 types-openpyxl
+types-pexpect
 types-protobuf
 types-psutil
 types-psycopg2
+types-pyasn1
 types-pycurl
 types-Pygments
+types-PyMySQL
+types-PySocks
 types-python-dateutil
+types-python-jose
 types-PyYAML
 types-requests
+types-setuptools
+types-shapely
 types-six
 types-tabulate
 types-tqdm
 types-typed-ast
 types-tzlocal
+types-xlrd
+types-xmltodict

--- a/requirements-types.txt
+++ b/requirements-types.txt
@@ -1,10 +1,7 @@
-# This file installs all dependencies needed for type checking with mypy.
-# It serves two purposes:
-# 1. Installs the actual packages (pyspark, azure, etc.) that mypy needs to type-check imports
-# 2. Installs type stubs upfront for deterministic behavior (rather than relying solely on
-#    mypy's --install-types flag, which installs stubs dynamically and can vary between runs)
-# This ensures local type checking matches CI exactly: developers can run
-# `pip install -r requirements-types.txt` followed by `invoke types --ci --pretty`
+# This file installs the actual packages needed for type checking with mypy.
+# Type stubs are installed automatically by mypy's --install-types flag during type checking.
+# This ensures local type checking matches CI: developers can run
+# `invoke deps -r types` followed by `invoke types --ci --pretty`
 # and get the same results as CI.
 
 --requirement reqs/requirements-dev-sqlalchemy2.txt
@@ -18,41 +15,3 @@
 pandas-stubs
 # force sqlalchemy 2 because it exports types
 sqlalchemy>2.0
-# typing stubs
-types-aws-xray-sdk
-types-beautifulsoup4
-types-cachetools
-types-cffi
-types-colorama
-types-decorator
-types-docker
-types-geopandas
-types-greenlet
-types-grpcio
-types-grpcio-status
-types-html5lib
-types-jsonschema
-types-oauthlib
-types-openpyxl
-types-pexpect
-types-protobuf
-types-psutil
-types-psycopg2
-types-pyasn1
-types-pycurl
-types-Pygments
-types-PyMySQL
-types-PySocks
-types-python-dateutil
-types-python-jose
-types-PyYAML
-types-requests
-types-setuptools
-types-shapely
-types-six
-types-tabulate
-types-tqdm
-types-typed-ast
-types-tzlocal
-types-xlrd
-types-xmltodict

--- a/requirements-types.txt
+++ b/requirements-types.txt
@@ -1,8 +1,6 @@
 # This file installs the actual packages needed for type checking with mypy.
 # Type stubs are installed automatically by mypy's --install-types flag during type checking.
-# This ensures local type checking matches CI: developers can run
-# `invoke deps -r types` followed by `invoke types --ci --pretty`
-# and get the same results as CI.
+# For usage instructions, run: invoke types --help
 
 --requirement reqs/requirements-dev-sqlalchemy2.txt
 --requirement requirements.txt

--- a/tasks.py
+++ b/tasks.py
@@ -254,7 +254,13 @@ def type_check(  # noqa: C901, PLR0912
     ci: bool = False,
     python_version: str = "",
 ):
-    """Run mypy static type-checking on select packages."""
+    """Run mypy static type-checking on select packages.
+
+    1. Install type-checking dependencies: `invoke deps -r types --install-types`
+    2. Run type checking: `invoke types --ci --pretty`
+
+    See requirements-types.txt for details on type-checking dependencies.
+    """
     mypy_cache = pathlib.Path(".mypy_cache")
 
     if ci:
@@ -1002,6 +1008,8 @@ def deps(  # noqa: C901 - too complex
     the 'requirements-dev-cloud.txt' dependencies.
 
     $ invoke deps -m external_sqldialect -r cloud
+
+    For type-checking dependencies, use: `invoke deps -r types`
     """  # noqa: E501
     cmds = ["pip", "install"]
     if editable_install:

--- a/tasks.py
+++ b/tasks.py
@@ -971,7 +971,8 @@ def _get_marker_dependencies(markers: str | Sequence[str]) -> list[TestDependenc
     iterable=["markers", "requirements_dev"],
     help={
         "markers": "Optional marker to install dependencies for. Can be specified multiple times.",
-        "requirements_dev": "Short name of `requirements-dev-*.txt` file to install, e.g. test, spark, cloud, etc. Can be specified multiple times.",  # noqa: E501
+        "requirements_dev": "Short name of `requirements-dev-*.txt` file to install, "
+        "e.g. test, spark, cloud, types, etc. Can be specified multiple times.",
         "constraints": "Optional flag to install dependencies with constraints, default True",
         "gx_install": "Install the local version of Great Expectations.",
         "editable_install": "Install an editable local version of Great Expectations.",
@@ -1017,7 +1018,11 @@ def deps(  # noqa: C901 - too complex
         req_files.extend(test_deps.requirement_files)
 
     for name in requirements_dev:
-        req_path: pathlib.Path = REQS_DIR / f"requirements-dev-{name}.txt"
+        # Special case: "types" refers to requirements-types.txt in the root
+        if name == "types":
+            req_path = GX_ROOT_DIR / "requirements-types.txt"
+        else:
+            req_path = REQS_DIR / f"requirements-dev-{name}.txt"
         assert req_path.exists(), f"Requirement file {req_path} does not exist"
         req_files.append(str(req_path))
 

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -6,11 +6,11 @@ from typing import Optional
 from unittest import mock
 
 import boto3
-import pyparsing as pp
 import pytest
 from moto import mock_s3
 from pytest_mock import MockerFixture
 
+from great_expectations.compatibility.pyparsing import Word, hexnums
 from great_expectations.core.data_context_key import DataContextVariableKey
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.run_identifier import RunIdentifier
@@ -102,7 +102,7 @@ def check_store_backend_store_backend_id_functionality(
 
     # Check file stores for the file in the correct format
     store_backend_id_from_file = store_backend.get(key=(".ge_store_backend_id",))
-    store_backend_id_file_parser = "store_backend_id = " + pp.Word(pp.hexnums + "-")
+    store_backend_id_file_parser = "store_backend_id = " + Word(hexnums + "-")
     parsed_store_backend_id = store_backend_id_file_parser.parse_string(store_backend_id_from_file)
     assert test_utils.validate_uuid4(parsed_store_backend_id[1])
 

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -103,7 +103,7 @@ def check_store_backend_store_backend_id_functionality(
     # Check file stores for the file in the correct format
     store_backend_id_from_file = store_backend.get(key=(".ge_store_backend_id",))
     store_backend_id_file_parser = "store_backend_id = " + pp.Word(pp.hexnums + "-")
-    parsed_store_backend_id = store_backend_id_file_parser.parseString(store_backend_id_from_file)
+    parsed_store_backend_id = store_backend_id_file_parser.parse_string(store_backend_id_from_file)
     assert test_utils.validate_uuid4(parsed_store_backend_id[1])
 
 

--- a/tests/data_context/test_data_context_in_code_config.py
+++ b/tests/data_context/test_data_context_in_code_config.py
@@ -2,10 +2,10 @@ import uuid
 from typing import Dict, Optional, Set
 
 import boto3
-import pyparsing as pp
 import pytest
 from moto import mock_s3
 
+from great_expectations.compatibility.pyparsing import Word, hexnums
 from great_expectations.data_context import get_context
 from great_expectations.data_context.store import StoreBackend, TupleS3StoreBackend
 from great_expectations.data_context.types.base import DataContextConfig
@@ -92,7 +92,7 @@ def get_store_backend_id_from_s3(bucket: str, prefix: str, key: str) -> uuid.UUI
     s3_response_object = boto3.client("s3").get_object(Bucket=bucket, Key=f"{prefix}/{key}")
     ge_store_backend_id_file_contents = s3_response_object["Body"].read().decode("utf-8")
 
-    store_backend_id_file_parser = StoreBackend.STORE_BACKEND_ID_PREFIX + pp.Word(pp.hexnums + "-")
+    store_backend_id_file_parser = StoreBackend.STORE_BACKEND_ID_PREFIX + Word(hexnums + "-")
     parsed_store_backend_id = store_backend_id_file_parser.parse_string(
         ge_store_backend_id_file_contents
     )

--- a/tests/data_context/test_data_context_in_code_config.py
+++ b/tests/data_context/test_data_context_in_code_config.py
@@ -93,7 +93,7 @@ def get_store_backend_id_from_s3(bucket: str, prefix: str, key: str) -> uuid.UUI
     ge_store_backend_id_file_contents = s3_response_object["Body"].read().decode("utf-8")
 
     store_backend_id_file_parser = StoreBackend.STORE_BACKEND_ID_PREFIX + pp.Word(pp.hexnums + "-")
-    parsed_store_backend_id = store_backend_id_file_parser.parseString(
+    parsed_store_backend_id = store_backend_id_file_parser.parse_string(
         ge_store_backend_id_file_contents
     )
     return uuid.UUID(parsed_store_backend_id[1])


### PR DESCRIPTION
## What

- Fixed `pyparsing` code emitting `DeprecationWarning`s by adding `pyparsing.py` to compatibility layer
- Fixed numerous type errors.
- Documented type-checking workflow in `tasks.py` docstrings so `invoke deps -r types` then `invoke types --ci --pretty` matches CI.
- Updated `requirements-types.txt` comment to reference `invoke types --help` for discoverable documentation instead of inline commands.


## Why

Some new type errors showed up in `develop` CI due to additional typing information being added in dependencies. The local dev experience was confusing - showing me lots of `import-not-found` errors. Installing the type stubs from `requirements-types.txt` did not resolve the issue. That's because when we run the type checker via `invoke type-check --ci --pretty` we add the `--install-types` flag which has the effect of installing missing type stubs. The `requirements-types.txt` file is only used when running the type checker (not during the build).