### PR TITLE
[MAINTENANCE] Serialize `unexpected_rows` for all Map expectations when opt-in flag is provided

### DIFF
--- a/great_expectations/expectations/expectation_configuration.py
+++ b/great_expectations/expectations/expectation_configuration.py
@@ -54,7 +54,7 @@ def parse_result_format(result_format: Union[str, dict]) -> dict:
             "result_format": result_format,
             "partial_unexpected_count": 20,
             "include_unexpected_rows": False,
-            "serialize_unexpected_rows": False,
+            "map_expectation_unexpected_rows_as_dict": False,
         }
     else:
         if "include_unexpected_rows" in result_format and "result_format" not in result_format:
@@ -68,8 +68,8 @@ def parse_result_format(result_format: Union[str, dict]) -> dict:
         if "include_unexpected_rows" not in result_format:
             result_format["include_unexpected_rows"] = False
 
-        if "serialize_unexpected_rows" not in result_format:
-            result_format["serialize_unexpected_rows"] = False
+        if "map_expectation_unexpected_rows_as_dict" not in result_format:
+            result_format["map_expectation_unexpected_rows_as_dict"] = False
 
     return result_format
 

--- a/great_expectations/expectations/expectation_configuration.py
+++ b/great_expectations/expectations/expectation_configuration.py
@@ -54,6 +54,7 @@ def parse_result_format(result_format: Union[str, dict]) -> dict:
             "result_format": result_format,
             "partial_unexpected_count": 20,
             "include_unexpected_rows": False,
+            "serialize_unexpected_rows": False,
         }
     else:
         if "include_unexpected_rows" in result_format and "result_format" not in result_format:
@@ -66,6 +67,9 @@ def parse_result_format(result_format: Union[str, dict]) -> dict:
 
         if "include_unexpected_rows" not in result_format:
             result_format["include_unexpected_rows"] = False
+
+        if "serialize_unexpected_rows" not in result_format:
+            result_format["serialize_unexpected_rows"] = False
 
     return result_format
 

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -401,7 +401,7 @@ def _sqlalchemy_map_condition_rows(
     try:
         rows_result = execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
 
-        serialize = result_format.get("serialize_unexpected_rows", False)
+        serialize = result_format.get("map_expectation_unexpected_rows_as_dict", False)
 
         if serialize:
             return [row._asdict() for row in rows_result]
@@ -665,7 +665,7 @@ def _spark_map_condition_rows(
         limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
         rows = filtered.limit(limit).collect()
 
-    serialize = result_format.get("serialize_unexpected_rows", False)
+    serialize = result_format.get("map_expectation_unexpected_rows_as_dict", False)
 
     if serialize:
         return [row.asDict() for row in rows]

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -376,6 +376,7 @@ def _sqlalchemy_map_condition_rows(
     Returns all rows of the metric values which do not meet an expected Expectation condition for instances
     of ColumnMapExpectation.
     """  # noqa: E501 # FIXME CoP
+
     unexpected_condition, compute_domain_kwargs, accessor_domain_kwargs = metrics[
         "unexpected_condition"
     ]
@@ -398,7 +399,10 @@ def _sqlalchemy_map_condition_rows(
         limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
         query = query.limit(limit)
     try:
-        return execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
+        return [
+            val._asdict()
+            for val in execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
+        ]
     except sqlalchemy.OperationalError as oe:
         exception_message: str = f"An SQL execution Exception occurred: {oe!s}."
         raise gx_exceptions.InvalidMetricAccessorDomainKwargsKeyError(message=exception_message)
@@ -632,7 +636,7 @@ def _spark_map_condition_rows(
     metric_value_kwargs: dict,
     metrics: Dict[str, Any],
     **kwargs,
-) -> list[pyspark.Row]:
+) -> list[dict]:
     unexpected_condition, compute_domain_kwargs, accessor_domain_kwargs = metrics[
         "unexpected_condition"
     ]
@@ -652,10 +656,12 @@ def _spark_map_condition_rows(
     result_format = metric_value_kwargs["result_format"]
 
     if result_format["result_format"] == "COMPLETE":
-        return filtered.limit(MAX_RESULT_RECORDS).collect()
+        rows = filtered.limit(MAX_RESULT_RECORDS).collect()
+    else:
+        limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
+        rows = filtered.limit(limit).collect()
 
-    limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
-    return filtered.limit(limit).collect()
+    return [row.asDict() for row in rows]
 
 
 def _spark_map_condition_index(  # noqa: C901 #  too complex

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -640,7 +640,7 @@ def _spark_map_condition_rows(
     metric_value_kwargs: dict,
     metrics: Dict[str, Any],
     **kwargs,
-) -> list[dict]:
+) -> Union[list[dict], Any]:
     unexpected_condition, compute_domain_kwargs, accessor_domain_kwargs = metrics[
         "unexpected_condition"
     ]

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -401,9 +401,7 @@ def _sqlalchemy_map_condition_rows(
     try:
         rows_result = execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
 
-        serialize = metric_value_kwargs.get("result_format", {}).get(
-            "serialize_unexpected_rows", False
-        )
+        serialize = result_format.get("serialize_unexpected_rows", False)
 
         if serialize:
             return [row._asdict() for row in rows_result]

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -399,10 +399,16 @@ def _sqlalchemy_map_condition_rows(
         limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
         query = query.limit(limit)
     try:
-        return [
-            val._asdict()
-            for val in execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
-        ]
+        rows_result = execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
+
+        serialize = metric_value_kwargs.get("result_format", {}).get(
+            "serialize_unexpected_rows", False
+        )
+
+        if serialize:
+            return [row._asdict() for row in rows_result]
+
+        return rows_result
     except sqlalchemy.OperationalError as oe:
         exception_message: str = f"An SQL execution Exception occurred: {oe!s}."
         raise gx_exceptions.InvalidMetricAccessorDomainKwargsKeyError(message=exception_message)
@@ -661,7 +667,12 @@ def _spark_map_condition_rows(
         limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
         rows = filtered.limit(limit).collect()
 
-    return [row.asDict() for row in rows]
+    serialize = result_format.get("serialize_unexpected_rows", False)
+
+    if serialize:
+        return [row.asDict() for row in rows]
+
+    return rows
 
 
 def _spark_map_condition_index(  # noqa: C901 #  too complex

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_equal.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_equal.py
@@ -296,7 +296,7 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
 @parameterize_batch_for_data_sources(
     data_source_configs=[PostgreSQLDatasourceTestConfig()], data=DATA
 )
-def test_serialize_unexpected_rows_flag_sql(batch_for_datasource: Batch) -> None:
+def test_map_expectation_unexpected_rows_as_dict_flag_sql(batch_for_datasource: Batch) -> None:
     expectation = gxe.ExpectColumnPairValuesToBeEqual(
         column_A=EQUAL_STRINGS_A, column_B=UNEQUAL_STRINGS
     )
@@ -305,7 +305,7 @@ def test_serialize_unexpected_rows_flag_sql(batch_for_datasource: Batch) -> None
         result_format={
             "result_format": "BASIC",
             "include_unexpected_rows": True,
-            "serialize_unexpected_rows": True,
+            "map_expectation_unexpected_rows_as_dict": True,
         },
     )
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_equal.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_equal.py
@@ -291,3 +291,38 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     unexpected_row_str = str(unexpected_row)
     assert "baz" in unexpected_row_str
     assert "wat" in unexpected_row_str
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[PostgreSQLDatasourceTestConfig()], data=DATA
+)
+def test_serialize_unexpected_rows_flag_sql(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnPairValuesToBeEqual(
+        column_A=EQUAL_STRINGS_A, column_B=UNEQUAL_STRINGS
+    )
+    result = batch_for_datasource.validate(
+        expectation,
+        result_format={
+            "result_format": "BASIC",
+            "include_unexpected_rows": True,
+            "serialize_unexpected_rows": True,
+        },
+    )
+
+    assert not result.success
+    result_dict = result["result"]
+
+    assert "unexpected_rows" in result_dict
+    assert result_dict["unexpected_rows"] is not None
+
+    unexpected_rows_data = result_dict["unexpected_rows"]
+    assert isinstance(unexpected_rows_data, list)
+
+    # Should contain 1 row where column_A != column_B
+    assert len(unexpected_rows_data) == 1
+
+    unexpected_row = unexpected_rows_data[0]
+    assert isinstance(unexpected_row, dict)
+
+    assert unexpected_row[EQUAL_STRINGS_A] == "baz"
+    assert unexpected_row[UNEQUAL_STRINGS] == "wat"

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_set.py
@@ -207,14 +207,14 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
 @parameterize_batch_for_data_sources(
     data_source_configs=[PostgreSQLDatasourceTestConfig()], data=DATA
 )
-def test_serialize_unexpected_rows_flag_sql(batch_for_datasource: Batch) -> None:
+def test_map_expectation_unexpected_rows_as_dict_flag_sql(batch_for_datasource: Batch) -> None:
     expectation = gxe.ExpectColumnValuesToBeInSet(column=NUMBERS_COLUMN, value_set=[1, 2])
     result = batch_for_datasource.validate(
         expectation,
         result_format={
             "result_format": "BASIC",
             "include_unexpected_rows": True,
-            "serialize_unexpected_rows": True,
+            "map_expectation_unexpected_rows_as_dict": True,
         },
     )
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_set.py
@@ -202,3 +202,36 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     unexpected_rows_str = str(unexpected_rows_data)
     assert "3" in unexpected_rows_str
     assert "c" in unexpected_rows_str
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[PostgreSQLDatasourceTestConfig()], data=DATA
+)
+def test_serialize_unexpected_rows_flag_sql(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnValuesToBeInSet(column=NUMBERS_COLUMN, value_set=[1, 2])
+    result = batch_for_datasource.validate(
+        expectation,
+        result_format={
+            "result_format": "BASIC",
+            "include_unexpected_rows": True,
+            "serialize_unexpected_rows": True,
+        },
+    )
+
+    assert not result.success
+    result_dict = result["result"]
+
+    assert "unexpected_rows" in result_dict
+    assert result_dict["unexpected_rows"] is not None
+
+    unexpected_rows_data = result_dict["unexpected_rows"]
+    assert isinstance(unexpected_rows_data, list)
+
+    # Should contain 1 row where NUMBERS_COLUMN has value 3 (not in set [1, 2])
+    assert len(unexpected_rows_data) == 1
+
+    unexpected_row = unexpected_rows_data[0]
+    assert isinstance(unexpected_row, dict)
+
+    assert unexpected_row[NUMBERS_COLUMN] == 3
+    assert unexpected_row[STRINGS_COLUMN] == "c"


### PR DESCRIPTION
Previously, Map type expectations returned raw tuple rows, which broke downstream parsing when `unexpected_rows` were included in validation results. This change introduces a new opt-in flag `map_expectation_unexpected_rows_as_dict` to Chekpoint config to ensure all map expectations `unexpected_rows` are serialized as dictionaries for sqlachemy and spark (pandas already return serializable dataframes).
The default format output is unchanged (strigified tuple of row values)

Default format: `(1.0, 1.0, 2.0)`
Serialized format (with `map_expectation_unexpected_rows_as_dict=True`):  `{"col_a": 1.0, "col_b": 1.0, "col_c": 2.0}`


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
