### PR TITLE
[BUGFIX] Change default match_type to "success" to prevent overwritng expectations with same type/column but different kwargs (#11582)

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -487,7 +487,7 @@ class ExpectationSuite(SerializableDictDot):
     def _add_expectation(
         self,
         expectation_configuration: ExpectationConfiguration,
-        match_type: str = "domain",
+        match_type: str = "success",
         overwrite_existing: bool = True,
     ) -> ExpectationConfiguration:
         """
@@ -496,7 +496,9 @@ class ExpectationSuite(SerializableDictDot):
         Args:
             expectation_configuration: The ExpectationConfiguration to add or update
             match_type: The criteria used to determine whether the Suite already has an ExpectationConfiguration
-                and so whether we should add or replace.
+                and so whether we should add or replace. Changed from "domain" to "success" to prevent
+                expectations with the same type/column but different kwargs (e.g., different regex patterns)
+                from overwriting each other.
             overwrite_existing: If the expectation already exists, this will overwrite if True and raise an error if
                 False.
 
@@ -547,7 +549,7 @@ class ExpectationSuite(SerializableDictDot):
     def add_expectation_configurations(
         self,
         expectation_configurations: List[ExpectationConfiguration],
-        match_type: str = "domain",
+        match_type: str = "success",
         overwrite_existing: bool = True,
     ) -> List[ExpectationConfiguration]:
         """Upsert a list of ExpectationConfigurations into this ExpectationSuite.
@@ -556,6 +558,8 @@ class ExpectationSuite(SerializableDictDot):
             expectation_configurations: The List of candidate new/modifed "ExpectationConfiguration" objects for Suite.
             match_type: The criteria used to determine whether the Suite already has an "ExpectationConfiguration"
                 object, matching the specified criteria, and thus whether we should add or replace (i.e., "upsert").
+                Changed from "domain" to "success" to prevent expectations with same type/column but different
+                kwargs (e.g., different regex patterns) from overwriting each other.
             overwrite_existing: If "ExpectationConfiguration" already exists, this will cause it to be overwritten if
                 True and raise an error if False.
 
@@ -581,7 +585,7 @@ class ExpectationSuite(SerializableDictDot):
     def add_expectation_configuration(
         self,
         expectation_configuration: ExpectationConfiguration,
-        match_type: str = "domain",
+        match_type: str = "success",
         overwrite_existing: bool = True,
     ) -> ExpectationConfiguration:
         """Upsert specified ExpectationConfiguration into this ExpectationSuite.
@@ -589,7 +593,8 @@ class ExpectationSuite(SerializableDictDot):
         Args:
             expectation_configuration: The ExpectationConfiguration to add or update.
             match_type: The criteria used to determine whether the Suite already has an ExpectationConfiguration
-                and so whether we should add or replace.
+                and so whether we should add or replace. Changed from "domain" to "success" to prevent
+                expectations with same type/column but different kwargs from overwriting each other.
             overwrite_existing: If the expectation already exists, this will overwrite if True and raise an error if
                 False.
 

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -1555,3 +1555,47 @@ def test_expectation_suite_severity_in_configuration():
     # Test that to_domain_obj preserves severity
     domain_obj = config.to_domain_obj()
     assert domain_obj.severity == FailureSeverity.WARNING
+
+
+def test_multiple_expectations_same_type_column_different_kwargs_not_deduplicated() -> None:
+    """
+    Test that multiple expectations of the same type on the same column but with different
+    kwargs (e.g., different regex patterns) are NOT deduplicated.
+
+    This was a bug where match_type="domain" (the old default) caused expectations
+    with the same (type, column) but different kwargs to overwrite each other.
+
+    After the fix (match_type="success" by default), all expectations should be
+    preserved individually.
+    """
+    suite = ExpectationSuite(name="test_suite")
+
+    # Add multiple regex expectations on the same column with DIFFERENT regex patterns
+    suite.add_expectation_configuration(
+        ExpectationConfiguration(
+            type="expect_column_values_to_not_match_regex",
+            kwargs={"column": "First Name", "regex": r"^\s*[Mm][Rr]\."},
+        )
+    )
+    suite.add_expectation_configuration(
+        ExpectationConfiguration(
+            type="expect_column_values_to_not_match_regex",
+            kwargs={"column": "First Name", "regex": r"['\"]"},
+        )
+    )
+    suite.add_expectation_configuration(
+        ExpectationConfiguration(
+            type="expect_column_values_to_not_match_regex",
+            kwargs={"column": "First Name", "regex": r"(?i)\bJr\.\s*$"},
+        )
+    )
+
+    # Should have 3 expectations, not 1 (the bug would leave only the last one)
+    assert len(suite.expectations) == 3, f"Expected 3 expectations, got {len(suite.expectations)}"
+
+    # Verify all regex patterns are preserved
+    regex_patterns = {exp.configuration.kwargs["regex"] for exp in suite.expectations}
+    expected_patterns = {r"^\s*[Mm][Rr]\.", r"['\"]", r"(?i)\bJr\.\s*$"}
+    assert regex_patterns == expected_patterns, (
+        f"Expected regex patterns {expected_patterns}, got {regex_patterns}"
+    )


### PR DESCRIPTION
## Fix: ExpectationSuite deduplicates expectations with same type/column but different kwargs

**Closes #11584**

### Problem

When adding multiple expectations of the same type on the same column but with different kwargs (e.g., different regex patterns), the `ExpectationSuite` was incorrectly deduplicating them—leaving only the last expectation.

For example, adding these three expectations to the same suite:

```python
validator.expect_column_values_to_not_match_regex(column='name', regex=r'^\s*Mr\.')
validator.expect_column_values_to_not_match_regex(column='name', regex=r'[\'"]')
validator.expect_column_values_to_not_match_regex(column='name', regex=r'Jr\.\s*$')
```

Would result in only **1 expectation** instead of **3**.

### Root Cause

The default `match_type="domain"` in `_add_expectation()`, `add_expectation_configuration()`, and `add_expectation_configurations()` was matching expectations based only on `(type, column)`, ignoring other kwargs like `regex`, `value_set`, etc.

### Solution

Changed the default `match_type` from `"domain"` to `"success"`, which compares the full expectation configuration including all kwargs. This ensures expectations with different parameters are preserved individually.

### Changes

- **`great_expectations/core/expectation_suite.py`**: Changed default `match_type` from `"domain"` to `"success"` in three methods
- **`tests/core/test_expectation_suite.py`**: Added regression test `test_multiple_expectations_same_type_column_different_kwargs_not_deduplicated`

### Breaking Change Notice

⚠️ This changes the default behavior of expectation deduplication. Users who previously relied on the `match_type="domain"` behavior (intentionally or unintentionally) may now see more expectations in their suites. The old behavior can still be achieved by explicitly passing `match_type="domain"`.



- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues/11584)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
