### PR TITLE
[MAINTENANCE] Ignore `DeprecationWarning` emitted by deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,6 +451,9 @@ filterwarnings = [
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "ignore: pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore: pkg_resources is deprecated as an API:UserWarning",
+    # the distutils module is deprecated in Python 3.10+ and removed in Python 3.12
+    # versioneer.py still uses it via setuptools
+    "ignore:The distutils.sysconfig module is deprecated:DeprecationWarning",
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation
     "ignore:Setting result format to COMPLETE for a SqlAlchemyDataset:UserWarning",

--- a/tasks.py
+++ b/tasks.py
@@ -983,6 +983,7 @@ def _get_marker_dependencies(markers: str | Sequence[str]) -> list[TestDependenc
         "gx_install": "Install the local version of Great Expectations.",
         "editable_install": "Install an editable local version of Great Expectations.",
         "force_reinstall": "Force re-installation of dependencies.",
+        "pty": _PTY_HELP_DESC,
     },
 )
 def deps(  # noqa: C901 - too complex
@@ -993,6 +994,7 @@ def deps(  # noqa: C901 - too complex
     gx_install: bool = False,
     editable_install: bool = False,
     force_reinstall: bool = False,
+    pty: bool = True,
 ):
     """
     Install dependencies for development and testing.
@@ -1043,7 +1045,7 @@ def deps(  # noqa: C901 - too complex
     if constraints:
         cmds.append("-c constraints-dev.txt")
 
-    ctx.run(" ".join(cmds), echo=True, pty=True)
+    ctx.run(" ".join(cmds), echo=True, pty=pty)
 
 
 @invoke.task(iterable=["service_names", "up_services", "verbose"])


### PR DESCRIPTION
Python deprecated `distutils` in 3.10, removed it in 3.12; `setuptools` is gradually migrating away from it.

We are likely not seeing this in CI due to installed versions, but it is causing tests to fail locally on python 3.11.