### PR TITLE
[MINORBUMP] Format `unexpected_rows` as dicts in map expectation validation results

### DIFF
--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -24,10 +24,8 @@ from great_expectations.expectations.metrics.util import (
     get_sqlalchemy_source_table_and_schema,
     sqlalchemy_select_to_sql_string,
 )
-from great_expectations.util import (  # noqa: TID251 # FIXME CoP
+from great_expectations.util import (  # FIXME CoP
     convert_to_json_serializable,
-)
-from great_expectations.util import (
     generate_temporary_table_name,
     get_sqlalchemy_selectable,
 )

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import numpy as np
 
@@ -9,7 +17,9 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.pyspark import pyspark
-from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
+from great_expectations.compatibility.sqlalchemy import (
+    sqlalchemy as sa,
+)
 from great_expectations.core.metric_function_types import (
     SummarizationMetricNameSuffixes,
 )
@@ -24,8 +34,8 @@ from great_expectations.expectations.metrics.util import (
     get_sqlalchemy_source_table_and_schema,
     sqlalchemy_select_to_sql_string,
 )
-from great_expectations.util import (  # FIXME CoP
-    convert_to_json_serializable,
+from great_expectations.util import (
+    convert_to_json_serializable,  # noqa: TID251 # FIXME CoP
     generate_temporary_table_name,
     get_sqlalchemy_selectable,
 )

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -1,15 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 
@@ -17,9 +9,7 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.pyspark import pyspark
-from great_expectations.compatibility.sqlalchemy import (
-    sqlalchemy as sa,
-)
+from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.core.metric_function_types import (
     SummarizationMetricNameSuffixes,
 )
@@ -34,8 +24,10 @@ from great_expectations.expectations.metrics.util import (
     get_sqlalchemy_source_table_and_schema,
     sqlalchemy_select_to_sql_string,
 )
+from great_expectations.util import (  # noqa: TID251 # FIXME CoP
+    convert_to_json_serializable,
+)
 from great_expectations.util import (
-    convert_to_json_serializable,  # noqa: TID251 # FIXME CoP
     generate_temporary_table_name,
     get_sqlalchemy_selectable,
 )
@@ -399,14 +391,10 @@ def _sqlalchemy_map_condition_rows(
         limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
         query = query.limit(limit)
     try:
-        rows_result = execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
-
-        serialize = result_format.get("map_expectation_unexpected_rows_as_dict", False)
-
-        if serialize:
-            return [row._asdict() for row in rows_result]
-
-        return rows_result
+        return [
+            val._asdict()
+            for val in execution_engine.execute_query(query).fetchmany(MAX_RESULT_RECORDS)
+        ]
     except sqlalchemy.OperationalError as oe:
         exception_message: str = f"An SQL execution Exception occurred: {oe!s}."
         raise gx_exceptions.InvalidMetricAccessorDomainKwargsKeyError(message=exception_message)
@@ -640,7 +628,7 @@ def _spark_map_condition_rows(
     metric_value_kwargs: dict,
     metrics: Dict[str, Any],
     **kwargs,
-) -> Union[list[dict], Any]:
+) -> list[dict]:
     unexpected_condition, compute_domain_kwargs, accessor_domain_kwargs = metrics[
         "unexpected_condition"
     ]
@@ -665,12 +653,7 @@ def _spark_map_condition_rows(
         limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
         rows = filtered.limit(limit).collect()
 
-    serialize = result_format.get("map_expectation_unexpected_rows_as_dict", False)
-
-    if serialize:
-        return [row.asDict() for row in rows]
-
-    return rows
+    return [row.asDict() for row in rows]
 
 
 def _spark_map_condition_index(  # noqa: C901 #  too complex

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -2148,7 +2148,7 @@ def test_map_column_values_increasing_spark(spark_session):
     metrics.update(results)
 
     assert metrics[unexpected_rows_metric.id] == [
-        (3,),
+        {"a": 3},
     ]
 
 
@@ -3520,9 +3520,9 @@ def test_map_column_pairs_equal_metric_spark(spark_session):  # noqa: PLR0915 # 
     metrics.update(results)
 
     assert metrics[unexpected_rows_metric.id] == [
-        (0, 5, 5, 7),
-        (1, 4, 4, 8),
-        (2, 6, 6, 0),
+        {"a": 0, "b": 5, "c": 5, "d": 7},
+        {"a": 1, "b": 4, "c": 4, "d": 8},
+        {"a": 2, "b": 6, "c": 6, "d": 0},
     ]
 
     unexpected_values_metric = MetricConfiguration(
@@ -6653,9 +6653,9 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
     metrics.update(results)
 
     assert metrics[unexpected_rows_metric.id] == [
-        (1.0, 1.0, 2.0),
-        (4.0, 4.0, 4.0),
-        (None, None, 9.0),
+        {"a": 1.0, "b": 1.0, "c": 2.0},
+        {"a": 4.0, "b": 4.0, "c": 4.0},
+        {"a": None, "b": None, "c": 9.0},
     ]
 
     unexpected_values_metric = MetricConfiguration(

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -2315,7 +2315,7 @@ def test_map_column_values_decreasing_spark(spark_session):
     results = engine.resolve_metrics(metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics)
     metrics.update(results)
 
-    assert metrics[unexpected_rows_metric.id] == [(6,)]
+    assert metrics[unexpected_rows_metric.id] == [{"a": 6}]
 
 
 @pytest.mark.big
@@ -2488,7 +2488,7 @@ def test_map_unique_column_exists_sa(sa):
     }
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,), metrics=metrics)
     metrics.update(results)
-    assert results[desired_metric.id] == [(3, "baz"), (3, "qux")]
+    assert results[desired_metric.id] == [{"a": 3, "b": "baz"}, {"a": 3, "b": "qux"}]
 
 
 @pytest.mark.sqlite
@@ -2649,7 +2649,7 @@ def test_map_unique_column_exists_spark(spark_session):
     }
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,), metrics=metrics)
     metrics.update(results)
-    assert results[desired_metric.id] == [(3, "bar"), (3, "baz")]
+    assert results[desired_metric.id] == [{"a": 3, "b": "bar"}, {"a": 3, "b": "baz"}]
 
 
 @pytest.mark.spark
@@ -3310,9 +3310,9 @@ def test_map_column_pairs_equal_metric_sa(sa):  # noqa: PLR0915 # FIXME CoP
     metrics.update(results)
 
     assert metrics[unexpected_rows_metric.id] == [
-        (0, 5, 5, 7),
-        (1, 4, 4, 8),
-        (2, 6, 6, 0),
+        {"a": 0, "b": 5, "c": 5, "d": 7},
+        {"a": 1, "b": 4, "c": 4, "d": 8},
+        {"a": 2, "b": 6, "c": 6, "d": 0},
     ]
 
     unexpected_values_metric = MetricConfiguration(
@@ -5273,7 +5273,7 @@ def test_map_multicolumn_sum_equal_sa(sa):  # noqa: PLR0915 # FIXME CoP
     results = engine.resolve_metrics(metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics)
     metrics.update(results)
 
-    assert metrics[unexpected_rows_metric.id] == [(2, 3, 1, 9)]
+    assert metrics[unexpected_rows_metric.id] == [{"a": 2, "b": 3, "c": 1, "d": 9}]
     assert len(metrics[unexpected_rows_metric.id][0]) == 4
 
     unexpected_values_metric = MetricConfiguration(
@@ -5468,7 +5468,7 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915 # FIXM
     results = engine.resolve_metrics(metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics)
     metrics.update(results)
 
-    assert metrics[unexpected_rows_metric.id] == [(2, 3, 1, 9)]
+    assert metrics[unexpected_rows_metric.id] == [{"a": 2, "b": 3, "c": 1, "d": 9}]
     assert len(metrics[unexpected_rows_metric.id][0]) == 4
 
     unexpected_values_metric = MetricConfiguration(
@@ -5892,7 +5892,10 @@ def test_map_compound_columns_unique_sa(sa):  # noqa: PLR0915 # FIXME CoP
     results = engine.resolve_metrics(metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics)
     metrics.update(results)
 
-    assert metrics[unexpected_rows_metric.id] == [(1, 2, 2), (1, 3, 2)]
+    assert metrics[unexpected_rows_metric.id] == [
+        {"a": 1, "b": 2, "c": 2},
+        {"a": 1, "b": 3, "c": 2},
+    ]
 
     unexpected_values_metric = MetricConfiguration(
         metric_name=unexpected_values_metric_name,
@@ -6083,7 +6086,10 @@ def test_map_compound_columns_unique_spark(spark_session):  # noqa: PLR0915 # FI
     results = engine.resolve_metrics(metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics)
     metrics.update(results)
 
-    assert metrics[unexpected_rows_metric.id] == [(1, 2, 2), (1, 3, 2)]
+    assert metrics[unexpected_rows_metric.id] == [
+        {"a": 1, "b": 2, "c": 2},
+        {"a": 1, "b": 3, "c": 2},
+    ]
 
     unexpected_values_metric = MetricConfiguration(
         metric_name=unexpected_values_metric_name,
@@ -6435,9 +6441,9 @@ def test_map_select_column_values_unique_within_record_sa(sa):  # noqa: PLR0915 
     metrics.update(results)
 
     assert metrics[unexpected_rows_metric.id] == [
-        (1.0, 1.0, 2.0),
-        (4.0, 4.0, 4.0),
-        (None, None, 9.0),
+        {"a": 1.0, "b": 1.0, "c": 2.0},
+        {"a": 4.0, "b": 4.0, "c": 4.0},
+        {"a": None, "b": None, "c": 9.0},
     ]
 
     unexpected_values_metric = MetricConfiguration(
@@ -6522,7 +6528,10 @@ def test_map_select_column_values_unique_within_record_sa(sa):  # noqa: PLR0915 
     results = engine.resolve_metrics(metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics)
     metrics.update(results)
 
-    assert metrics[unexpected_rows_metric.id] == [(1.0, 1.0, 2.0), (4.0, 4.0, 4.0)]
+    assert metrics[unexpected_rows_metric.id] == [
+        {"a": 1.0, "b": 1.0, "c": 2.0},
+        {"a": 4.0, "b": 4.0, "c": 4.0},
+    ]
 
     unexpected_values_metric = MetricConfiguration(
         metric_name=unexpected_values_metric_name,
@@ -6739,7 +6748,10 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
     results = engine.resolve_metrics(metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics)
     metrics.update(results)
 
-    assert metrics[unexpected_rows_metric.id] == [(1.0, 1.0, 2.0), (4.0, 4.0, 4.0)]
+    assert metrics[unexpected_rows_metric.id] == [
+        {"a": 1.0, "b": 1.0, "c": 2.0},
+        {"a": 4.0, "b": 4.0, "c": 4.0},
+    ]
 
     unexpected_values_metric = MetricConfiguration(
         metric_name=unexpected_values_metric_name,

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_equal.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_equal.py
@@ -13,7 +13,9 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
     NON_SQL_DATA_SOURCES,
     SQL_DATA_SOURCES,
 )
-from tests.integration.test_utils.data_source_config import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config import (
+    PostgreSQLDatasourceTestConfig,
+)
 
 EQUAL_STRINGS_A = "equal_strings_a"
 EQUAL_STRINGS_B = "equal_strings_b"
@@ -282,47 +284,10 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     # Should contain 1 row where column_A != column_B
     assert len(unexpected_rows_data) == 1
 
-    # For SQL data sources, the row is returned as a tuple
-    # The unexpected row should contain "baz" and "wat" (different values)
-    unexpected_row = unexpected_rows_data[0]
-    assert len(unexpected_row) >= 3  # Should have at least the columns we're testing
-
-    # Check that the row contains the expected values somewhere
-    unexpected_row_str = str(unexpected_row)
-    assert "baz" in unexpected_row_str
-    assert "wat" in unexpected_row_str
-
-
-@parameterize_batch_for_data_sources(
-    data_source_configs=[PostgreSQLDatasourceTestConfig()], data=DATA
-)
-def test_map_expectation_unexpected_rows_as_dict_flag_sql(batch_for_datasource: Batch) -> None:
-    expectation = gxe.ExpectColumnPairValuesToBeEqual(
-        column_A=EQUAL_STRINGS_A, column_B=UNEQUAL_STRINGS
-    )
-    result = batch_for_datasource.validate(
-        expectation,
-        result_format={
-            "result_format": "BASIC",
-            "include_unexpected_rows": True,
-            "map_expectation_unexpected_rows_as_dict": True,
-        },
-    )
-
-    assert not result.success
-    result_dict = result["result"]
-
-    assert "unexpected_rows" in result_dict
-    assert result_dict["unexpected_rows"] is not None
-
-    unexpected_rows_data = result_dict["unexpected_rows"]
-    assert isinstance(unexpected_rows_data, list)
-
-    # Should contain 1 row where column_A != column_B
-    assert len(unexpected_rows_data) == 1
-
+    # Verify that the unexpected row is a dictionary
     unexpected_row = unexpected_rows_data[0]
     assert isinstance(unexpected_row, dict)
 
+    # Verify that the unexpected row contains the expected columns and values
     assert unexpected_row[EQUAL_STRINGS_A] == "baz"
     assert unexpected_row[UNEQUAL_STRINGS] == "wat"

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_set.py
@@ -13,7 +13,9 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
     NON_SQL_DATA_SOURCES,
     SQL_DATA_SOURCES,
 )
-from tests.integration.test_utils.data_source_config import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config import (
+    PostgreSQLDatasourceTestConfig,
+)
 
 NUMBERS_COLUMN = "numbers"
 STRINGS_COLUMN = "strings"
@@ -198,40 +200,7 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     # Should contain 1 row where NUMBERS_COLUMN has value 3 (not in set [1, 2])
     assert len(unexpected_rows_data) == 1
 
-    # Check that the unexpected value 3 and corresponding string "c" appear
-    unexpected_rows_str = str(unexpected_rows_data)
-    assert "3" in unexpected_rows_str
-    assert "c" in unexpected_rows_str
-
-
-@parameterize_batch_for_data_sources(
-    data_source_configs=[PostgreSQLDatasourceTestConfig()], data=DATA
-)
-def test_map_expectation_unexpected_rows_as_dict_flag_sql(batch_for_datasource: Batch) -> None:
-    expectation = gxe.ExpectColumnValuesToBeInSet(column=NUMBERS_COLUMN, value_set=[1, 2])
-    result = batch_for_datasource.validate(
-        expectation,
-        result_format={
-            "result_format": "BASIC",
-            "include_unexpected_rows": True,
-            "map_expectation_unexpected_rows_as_dict": True,
-        },
-    )
-
-    assert not result.success
-    result_dict = result["result"]
-
-    assert "unexpected_rows" in result_dict
-    assert result_dict["unexpected_rows"] is not None
-
-    unexpected_rows_data = result_dict["unexpected_rows"]
-    assert isinstance(unexpected_rows_data, list)
-
-    # Should contain 1 row where NUMBERS_COLUMN has value 3 (not in set [1, 2])
-    assert len(unexpected_rows_data) == 1
-
     unexpected_row = unexpected_rows_data[0]
     assert isinstance(unexpected_row, dict)
-
     assert unexpected_row[NUMBERS_COLUMN] == 3
     assert unexpected_row[STRINGS_COLUMN] == "c"

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
@@ -9,7 +9,9 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
     ALL_DATA_SOURCES,
     JUST_PANDAS_DATA_SOURCES,
 )
-from tests.integration.test_utils.data_source_config import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config import (
+    PostgreSQLDatasourceTestConfig,
+)
 
 INT_COL_A = "INT_COL_A"
 INT_COL_B = "INT_COL_B"
@@ -172,14 +174,22 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     assert len(unexpected_rows_data) == 1
 
     unexpected_row = unexpected_rows_data[0]
+
+    # Debug: Print the actual row data to understand the structure
+    print(f"\nDEBUG - unexpected_row type: {type(unexpected_row)}")
+    print(f"DEBUG - unexpected_row repr: {unexpected_row!r}")
+    print(f"DEBUG - unexpected_row keys: {list(unexpected_row.keys())}")
+    print(f"DEBUG - unexpected_row key types: {[type(k) for k in unexpected_row.keys()]}")
+    if isinstance(unexpected_row, dict):
+        print(f"DEBUG - unexpected_row keys: {list(unexpected_row.keys())}")
+        print(f"DEBUG - unexpected_row key types: {[type(k) for k in unexpected_row.keys()]}")
+        print(f"DEBUG - unexpected_row: {unexpected_row}")
+
     assert isinstance(unexpected_row, dict)
 
-    assert unexpected_rows_data == [
-        {
-            "INT_COL_A": 3,
-            "INT_COL_B": 4,
-            "INT_COL_C": 4,
-            "STRING_COL_A": "d",
-            "STRING_COL_B": "a",
-        }
-    ]
+    # Check that the unexpected row contains the expected values
+    assert unexpected_row["INT_COL_A"] == 3
+    assert unexpected_row["INT_COL_B"] == 4
+    assert unexpected_row["INT_COL_C"] == 4
+    assert unexpected_row["STRING_COL_A"] == "d"
+    assert unexpected_row["STRING_COL_B"] == "a"

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
@@ -175,21 +175,16 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
 
     unexpected_row = unexpected_rows_data[0]
 
-    # Debug: Print the actual row data to understand the structure
-    print(f"\nDEBUG - unexpected_row type: {type(unexpected_row)}")
-    print(f"DEBUG - unexpected_row repr: {unexpected_row!r}")
-    print(f"DEBUG - unexpected_row keys: {list(unexpected_row.keys())}")
-    print(f"DEBUG - unexpected_row key types: {[type(k) for k in unexpected_row.keys()]}")
-    if isinstance(unexpected_row, dict):
-        print(f"DEBUG - unexpected_row keys: {list(unexpected_row.keys())}")
-        print(f"DEBUG - unexpected_row key types: {[type(k) for k in unexpected_row.keys()]}")
-        print(f"DEBUG - unexpected_row: {unexpected_row}")
-
     assert isinstance(unexpected_row, dict)
 
-    # Check that the unexpected row contains the expected values
-    assert unexpected_row["INT_COL_A"] == 3
-    assert unexpected_row["INT_COL_B"] == 4
-    assert unexpected_row["INT_COL_C"] == 4
-    assert unexpected_row["STRING_COL_A"] == "d"
-    assert unexpected_row["STRING_COL_B"] == "a"
+    unexpected_row_normalized = {str(k).upper(): v for k, v in unexpected_row.items()}
+
+    expected = {
+        "INT_COL_A": 3,
+        "INT_COL_B": 4,
+        "INT_COL_C": 4,
+        "STRING_COL_A": "d",
+        "STRING_COL_B": "a",
+    }
+
+    assert unexpected_row_normalized == expected

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
@@ -169,6 +169,23 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     unexpected_rows_data = result_dict["unexpected_rows"]
     assert isinstance(unexpected_rows_data, list)
 
-    assert unexpected_rows_data == [
-        {INT_COL_A: 3, INT_COL_B: 4, INT_COL_C: 4, STRING_COL_A: "d", STRING_COL_B: "a"}
-    ]
+    assert len(unexpected_rows_data) == 1
+
+    unexpected_row = unexpected_rows_data[0]
+    assert isinstance(unexpected_row, dict)
+    # Check that we have exactly the expected keys (catches extra columns)
+    expected_keys = {INT_COL_A, INT_COL_B, INT_COL_C, STRING_COL_A, STRING_COL_B}
+    actual_keys = set(unexpected_row.keys())
+    extra_keys = actual_keys - expected_keys
+    missing_keys = expected_keys - actual_keys
+
+    assert actual_keys == expected_keys, (
+        f"Key mismatch. Expected: {expected_keys}, Got: {actual_keys}, "
+        f"Extra: {extra_keys}, Missing: {missing_keys}"
+    )
+
+    assert unexpected_row[INT_COL_A] == 3
+    assert unexpected_row[INT_COL_B] == 4
+    assert unexpected_row[INT_COL_C] == 4
+    assert unexpected_row[STRING_COL_A] == "d"
+    assert unexpected_row[STRING_COL_B] == "a"

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
@@ -169,4 +169,6 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     unexpected_rows_data = result_dict["unexpected_rows"]
     assert isinstance(unexpected_rows_data, list)
 
-    assert unexpected_rows_data == [(3, 4, 4, "d", "a")]
+    assert unexpected_rows_data == [
+        {INT_COL_A: 3, INT_COL_B: 4, INT_COL_C: 4, STRING_COL_A: "d", STRING_COL_B: "a"}
+    ]

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_select_column_values_to_be_unique_within_record.py
@@ -173,19 +173,13 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
 
     unexpected_row = unexpected_rows_data[0]
     assert isinstance(unexpected_row, dict)
-    # Check that we have exactly the expected keys (catches extra columns)
-    expected_keys = {INT_COL_A, INT_COL_B, INT_COL_C, STRING_COL_A, STRING_COL_B}
-    actual_keys = set(unexpected_row.keys())
-    extra_keys = actual_keys - expected_keys
-    missing_keys = expected_keys - actual_keys
 
-    assert actual_keys == expected_keys, (
-        f"Key mismatch. Expected: {expected_keys}, Got: {actual_keys}, "
-        f"Extra: {extra_keys}, Missing: {missing_keys}"
-    )
-
-    assert unexpected_row[INT_COL_A] == 3
-    assert unexpected_row[INT_COL_B] == 4
-    assert unexpected_row[INT_COL_C] == 4
-    assert unexpected_row[STRING_COL_A] == "d"
-    assert unexpected_row[STRING_COL_B] == "a"
+    assert unexpected_rows_data == [
+        {
+            "INT_COL_A": 3,
+            "INT_COL_B": 4,
+            "INT_COL_C": 4,
+            "STRING_COL_A": "d",
+            "STRING_COL_B": "a",
+        }
+    ]


### PR DESCRIPTION
 Removes the `map_expectation_unexpected_rows_as_dict` flag that was introduced in a previous PR as a workaround to ensure that unexpected rows were serialized as dictionaries rather than db-specific row objects (stringified as tuples), which made parsing non-primitive types fragile. Unexpected rows are now serialized as dicts by default for Map expectations, so the flag is no longer needed.
 
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
