### PR TITLE
[MAINTENANCE] Include SUMMARY in result_format query support

### DIFF
--- a/docs/docusaurus/docs/snippets/result_format.py
+++ b/docs/docusaurus/docs/snippets/result_format.py
@@ -110,6 +110,7 @@ assert validation_result.result == {
         {"value": "C", "count": 3},
         {"value": "D", "count": 2},
     ],
+    "unexpected_index_query": "df.filter(items=[3, 4, 5, 6, 7], axis=0)",
 }
 # </snippet>
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -3095,6 +3095,9 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915 # FIXME CoP
                 )
 
     if result_format["result_format"] == ResultFormat.SUMMARY:
+        _add_unexpected_index_query_to_result(
+            return_obj, result_format, unexpected_index_query, unexpected_index_column_names
+        )
         return return_obj
 
     if unexpected_list is not None and not exclude_unexpected_values:

--- a/tests/expectations/test_format_map_output.py
+++ b/tests/expectations/test_format_map_output.py
@@ -453,6 +453,136 @@ class TestBasicWithReturnUnexpectedIndexQuery:
         assert "unexpected_index_query" not in result["result"]
 
 
+class TestSummaryWithReturnUnexpectedIndexQuery:
+    """Tests for SUMMARY format with return_unexpected_index_query."""
+
+    def test_summary_with_return_unexpected_index_query_includes_query(self):
+        """SUMMARY with return_unexpected_index_query=True should include the query."""
+        result = _format_map_output(
+            result_format={
+                "result_format": "SUMMARY",
+                "return_unexpected_index_query": True,
+                "partial_unexpected_count": 20,
+                "include_unexpected_rows": False,
+            },
+            success=False,
+            element_count=5,
+            nonnull_count=5,
+            unexpected_count=2,
+            unexpected_list=["d", "e"],
+            unexpected_index_list=[1, 2],
+            unexpected_index_query="SELECT * FROM table WHERE condition",
+        )
+
+        assert result["success"] is False
+        assert "result" in result
+        assert result["result"]["unexpected_index_query"] == "SELECT * FROM table WHERE condition"
+        # SUMMARY should also have standard fields
+        assert result["result"]["element_count"] == 5
+        assert result["result"]["unexpected_count"] == 2
+        # SUMMARY should have partial_unexpected_counts
+        assert "partial_unexpected_counts" in result["result"]
+
+    def test_summary_with_return_unexpected_index_query_includes_column_names(self):
+        """SUMMARY with return_unexpected_index_query=True should include column names."""
+        result = _format_map_output(
+            result_format={
+                "result_format": "SUMMARY",
+                "return_unexpected_index_query": True,
+                "partial_unexpected_count": 20,
+                "include_unexpected_rows": False,
+            },
+            success=False,
+            element_count=5,
+            nonnull_count=5,
+            unexpected_count=2,
+            unexpected_list=["d", "e"],
+            unexpected_index_list=[1, 2],
+            unexpected_index_query="SELECT pk_1, pk_2 FROM table WHERE condition",
+            unexpected_index_column_names=["pk_1", "pk_2"],
+        )
+
+        assert result["success"] is False
+        assert "result" in result
+        assert (
+            result["result"]["unexpected_index_query"]
+            == "SELECT pk_1, pk_2 FROM table WHERE condition"
+        )
+        assert result["result"]["unexpected_index_column_names"] == ["pk_1", "pk_2"]
+
+    def test_summary_without_return_unexpected_index_query_excludes_query(self):
+        """SUMMARY without return_unexpected_index_query should NOT include the query.
+
+        This test verifies backwards compatibility.
+        """
+        result = _format_map_output(
+            result_format={
+                "result_format": "SUMMARY",
+                "partial_unexpected_count": 20,
+                "include_unexpected_rows": False,
+            },
+            success=False,
+            element_count=5,
+            nonnull_count=5,
+            unexpected_count=2,
+            unexpected_list=["d", "e"],
+            unexpected_index_list=[1, 2],
+            unexpected_index_query="SELECT * FROM table WHERE condition",
+        )
+
+        assert result["success"] is False
+        assert "result" in result
+        assert "unexpected_index_query" not in result["result"]
+        # But should still have standard SUMMARY fields
+        assert result["result"]["element_count"] == 5
+        assert result["result"]["unexpected_count"] == 2
+
+    def test_summary_with_return_unexpected_index_query_false_excludes_query(self):
+        """SUMMARY with return_unexpected_index_query=False should NOT include the query."""
+        result = _format_map_output(
+            result_format={
+                "result_format": "SUMMARY",
+                "return_unexpected_index_query": False,
+                "partial_unexpected_count": 20,
+                "include_unexpected_rows": False,
+            },
+            success=False,
+            element_count=5,
+            nonnull_count=5,
+            unexpected_count=2,
+            unexpected_list=["d", "e"],
+            unexpected_index_list=[1, 2],
+            unexpected_index_query="SELECT * FROM table WHERE condition",
+        )
+
+        assert "unexpected_index_query" not in result["result"]
+
+    def test_summary_with_return_unexpected_index_query_but_no_query(self):
+        """SUMMARY with return_unexpected_index_query=True but no query.
+
+        Should not add unexpected_index_query to the result.
+        """
+        result = _format_map_output(
+            result_format={
+                "result_format": "SUMMARY",
+                "return_unexpected_index_query": True,
+                "partial_unexpected_count": 20,
+                "include_unexpected_rows": False,
+            },
+            success=True,
+            element_count=5,
+            nonnull_count=5,
+            unexpected_count=0,
+            unexpected_list=[],
+            unexpected_index_list=[],
+            unexpected_index_query=None,
+        )
+
+        assert result["success"] is True
+        assert "result" in result
+        assert "unexpected_index_query" not in result["result"]
+
+
 # Tests for the helper function _add_unexpected_index_query_to_result
 class TestAddUnexpectedIndexQueryToResult:
     """Tests for the _add_unexpected_index_query_to_result helper function."""


### PR DESCRIPTION
With the recent ResultFormat changes that enable `unexpected_index_column_names` and `return_unexpected_index_query` for BASIC, we missed adding support for `return_unexpected_index_query` to SUMMARY. This covers that, thus ensuring that BASIC doesn't arbitrarily have more privileges than SUMMARY.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
