### PR TITLE
[BUGFIX] fix CustomSQL & MultiSource row-level result population

### DIFF
--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -372,7 +372,12 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         details = cls._get_details_from_results(result)
         if details is None:
             # Details are only available with COMPLETE result_format
-            return []
+            # For BASIC/SUMMARY, use unexpected_percent; for BOOLEAN_ONLY, use a fallback
+            return cls._create_fallback_observed_value(
+                configuration=configuration,
+                result=result,
+                runtime_configuration=runtime_configuration,
+            )
 
         missing_rows: list[dict[str, Any]] = details["missing_rows"]
         unexpected_rows: list[dict[str, Any]] = details["unexpected_rows"]
@@ -382,6 +387,8 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         unexpected_rows_table = cls._create_observed_values_table(unexpected_rows)
 
         if len(missing_rows) == 0 and len(unexpected_rows) == 0:
+            # For COMPLETE format with no differences, return empty list
+            # (detailed observed value is not needed when everything matches)
             return []
         elif (
             len(missing_rows) == 1
@@ -598,6 +605,56 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
             # Details are only available with COMPLETE result_format
             return None
         return details
+
+    @classmethod
+    def _create_fallback_observed_value(
+        cls,
+        configuration: Optional[ExpectationConfiguration] = None,
+        result: Optional[ExpectationValidationResult] = None,
+        runtime_configuration: Optional[dict] = None,
+    ) -> RenderedAtomicContent:
+        """Create a fallback observed value for non-COMPLETE result formats.
+
+        For BASIC/SUMMARY formats, displays the unexpected_percent.
+        For BOOLEAN_ONLY or when no data is available, displays '--'.
+        """
+        renderer_configuration: RendererConfiguration = RendererConfiguration(
+            configuration=configuration,
+            result=result,
+            runtime_configuration=runtime_configuration,
+        )
+
+        # Try to get unexpected_percent from result (available in BASIC/SUMMARY formats)
+        unexpected_percent: Optional[float] = None
+        if result and result.result:
+            unexpected_percent = result.result.get("unexpected_percent")
+
+        if unexpected_percent is not None:
+            renderer_configuration.add_param(
+                name="unexpected_percent",
+                param_type=RendererValueType.NUMBER,
+                value=unexpected_percent,
+            )
+            template_str = "$unexpected_percent% unexpected"
+        else:
+            # BOOLEAN_ONLY format or no data available
+            renderer_configuration.add_param(
+                name="observed_value",
+                param_type=RendererValueType.STRING,
+                value="--",
+            )
+            template_str = "$observed_value"
+
+        return RenderedAtomicContent(
+            name=AtomicDiagnosticRendererType.OBSERVED_VALUE,
+            value=RenderedAtomicValue(
+                template=template_str,
+                params=renderer_configuration.params.dict(),
+                meta_notes=renderer_configuration.meta_notes,
+                schema={"type": "com.superconductive.rendered.string"},
+            ),
+            value_type="StringValueType",
+        )
 
     @classmethod
     def _create_table_rendered_atomic_content(

--- a/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
+++ b/great_expectations/expectations/core/expect_query_results_to_match_comparison.py
@@ -257,9 +257,14 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         runtime_configuration: dict | None = None,
         execution_engine: ExecutionEngine | None = None,
     ) -> Union[ExpectationValidationResult, dict]:
-        result_format: str | dict[str, Any] = self._get_result_format(
+        result_format_config: str | dict[str, Any] = self._get_result_format(
             runtime_configuration=runtime_configuration
         )
+        # result_format can be a string or a dict with a "result_format" key
+        if isinstance(result_format_config, dict):
+            result_format = result_format_config.get("result_format", ResultFormat.SUMMARY)
+        else:
+            result_format = result_format_config
 
         missing_rows: list[dict[str, Any]]
         unexpected_rows: list[dict[str, Any]]
@@ -314,7 +319,7 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
 
         if result_format == ResultFormat.BOOLEAN_ONLY:
             return {"success": success}
-        else:
+        elif result_format == ResultFormat.COMPLETE:
             return {
                 "success": success,
                 "result": {
@@ -324,6 +329,15 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
                         "missing_rows": missing_rows,
                         "unexpected_rows": unexpected_rows,
                     },
+                },
+            }
+        else:
+            # BASIC or SUMMARY - don't include details with row data
+            return {
+                "success": success,
+                "result": {
+                    "unexpected_count": unexpected_count,
+                    "unexpected_percent": unexpected_percent,
                 },
             }
 
@@ -356,6 +370,9 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
     ) -> list[RenderedAtomicContent] | RenderedAtomicContent:
         details = cls._get_details_from_results(result)
+        if details is None:
+            # Details are only available with COMPLETE result_format
+            return []
 
         missing_rows: list[dict[str, Any]] = details["missing_rows"]
         unexpected_rows: list[dict[str, Any]] = details["unexpected_rows"]
@@ -409,6 +426,7 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
     ) -> list[RenderedAtomicContent]:
         result_details = cls._get_details_from_results(result)
+        assert result_details is not None  # Caller guarantees details exist
 
         renderer_configuration_base: RendererConfiguration = RendererConfiguration(
             configuration=configuration,
@@ -465,6 +483,7 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
     ) -> RenderedAtomicContent:
         result_details = cls._get_details_from_results(result)
+        assert result_details is not None  # Caller guarantees details exist
         comparison_values = (
             [
                 row[comparison_col_name]
@@ -571,10 +590,13 @@ class ExpectQueryResultsToMatchComparison(BatchExpectation):
     @classmethod
     def _get_details_from_results(
         cls, result: Optional[ExpectationValidationResult]
-    ) -> dict[str, Any]:
-        assert result and result.result, "Must have result"
+    ) -> Optional[dict[str, Any]]:
+        if not result or not result.result:
+            return None
         details = result.result.get("details")
-        assert isinstance(details, dict), "Details must exist and be a dict"
+        if not isinstance(details, dict):
+            # Details are only available with COMPLETE result_format
+            return None
         return details
 
     @classmethod

--- a/great_expectations/expectations/core/unexpected_rows_expectation.py
+++ b/great_expectations/expectations/core/unexpected_rows_expectation.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type, Un
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.result_format import ResultFormat
 from great_expectations.core.suite_parameters import (
     SuiteParameterDict,  # FIXME CoP
 )
@@ -267,12 +268,34 @@ class UnexpectedRowsExpectation(BatchExpectation):
         runtime_configuration: dict | None = None,
         execution_engine: ExecutionEngine | None = None,
     ) -> Union[ExpectationValidationResult, dict]:
+        result_format_config: str | dict[str, Any] = self._get_result_format(
+            runtime_configuration=runtime_configuration
+        )
+        # result_format can be a string or a dict with a "result_format" key
+        if isinstance(result_format_config, dict):
+            result_format = result_format_config.get("result_format", ResultFormat.SUMMARY)
+        else:
+            result_format = result_format_config
+
         metric_value = metrics["unexpected_rows_query.table"]
         unexpected_row_count = metrics["unexpected_rows_query.row_count"]
-        return {
-            "success": unexpected_row_count == 0,
-            "result": {
-                "observed_value": unexpected_row_count,
-                "details": {"unexpected_rows": metric_value},
-            },
-        }
+        success = unexpected_row_count == 0
+
+        if result_format == ResultFormat.BOOLEAN_ONLY:
+            return {"success": success}
+        elif result_format == ResultFormat.COMPLETE:
+            return {
+                "success": success,
+                "result": {
+                    "observed_value": unexpected_row_count,
+                    "details": {"unexpected_rows": metric_value},
+                },
+            }
+        else:
+            # BASIC or SUMMARY - don't include details with row data
+            return {
+                "success": success,
+                "result": {
+                    "observed_value": unexpected_row_count,
+                },
+            }

--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pytest
 
@@ -98,7 +98,7 @@ def test_unexpected_rows_expectation_validate(
     batch = sqlite_batch
 
     expectation = UnexpectedRowsExpectation(unexpected_rows_query=query)
-    result = batch.validate(expectation)
+    result = batch.validate(expectation, result_format="COMPLETE")
 
     assert result.success is expected_success
 
@@ -107,6 +107,43 @@ def test_unexpected_rows_expectation_validate(
 
     unexpected_count_rows_returned = len(res["details"]["unexpected_rows"])
     assert unexpected_count_rows_returned == expected_count_unexpected_rows_returned
+
+
+@pytest.mark.sqlite
+@pytest.mark.parametrize(
+    "result_format,expected_keys",
+    [
+        pytest.param("BOOLEAN_ONLY", {"success"}, id="boolean_only"),
+        pytest.param("BASIC", {"success", "result"}, id="basic"),
+        pytest.param("SUMMARY", {"success", "result"}, id="summary"),
+        pytest.param("COMPLETE", {"success", "result"}, id="complete"),
+    ],
+)
+def test_result_format_controls_details_visibility(
+    sqlite_batch: Batch,
+    result_format: Literal["BOOLEAN_ONLY", "BASIC", "SUMMARY", "COMPLETE"],
+    expected_keys: set[str],
+) -> None:
+    """Test that unexpected_rows are only visible with COMPLETE result format."""
+    batch = sqlite_batch
+    query = "SELECT * FROM {batch} WHERE passenger_count > 6"
+
+    expectation = UnexpectedRowsExpectation(unexpected_rows_query=query)
+    result = batch.validate(expectation, result_format=result_format)
+
+    # Verify top-level keys
+    assert set(result.to_json_dict().keys()) >= expected_keys
+
+    if result_format == "BOOLEAN_ONLY":
+        assert result.result is None
+    elif result_format == "COMPLETE":
+        assert "details" in result.result
+        assert "unexpected_rows" in result.result["details"]
+        assert "observed_value" in result.result
+    else:
+        # BASIC and SUMMARY should not have details
+        assert "details" not in result.result
+        assert "observed_value" in result.result
 
 
 @pytest.mark.unit

--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -135,7 +135,7 @@ def test_result_format_controls_details_visibility(
     assert set(result.to_json_dict().keys()) >= expected_keys
 
     if result_format == "BOOLEAN_ONLY":
-        assert result.result is None
+        assert result.result == {}
     elif result_format == "COMPLETE":
         assert "details" in result.result
         assert "unexpected_rows" in result.result["details"]

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 import pytest
@@ -347,7 +347,8 @@ def test_expect_query_results_to_match_comparison_missing_and_unexpected_values(
             base_query=base_query,
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT source FROM {multi_source_batch.comparison_table_name}",
-        )
+        ),
+        result_format="COMPLETE",
     )
 
     assert result.result["details"] == {
@@ -408,7 +409,8 @@ def test_column_ordering(
             comparison_query=comparison_query.replace(
                 "{source_table}", multi_source_batch.comparison_table_name
             ),
-        )
+        ),
+        result_format="COMPLETE",
     )
 
     assert result.result["details"] == {
@@ -507,7 +509,8 @@ def test_rendering_with_missing_and_unexpected(multi_source_batch: MultiSourceBa
             base_query="SELECT a, b, c, d FROM {batch} ORDER BY e",
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT e, f, g, h  FROM {source_table} ORDER BY g",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 
@@ -587,7 +590,8 @@ def test_rendering_with_one_column(multi_source_batch: MultiSourceBatch):
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT foo FROM {source_table}",
             base_query="SELECT bar FROM {batch}",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 
@@ -656,7 +660,8 @@ def test_rendering_with_one_value(multi_source_batch: MultiSourceBatch):
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT foo FROM {source_table}",
             base_query="SELECT bar FROM {batch}",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 
@@ -705,7 +710,8 @@ def test_rendering_only_missing_rows_single_column(multi_source_batch: MultiSour
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT foo FROM {source_table}",
             base_query="SELECT bar FROM {batch}",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 
@@ -760,7 +766,8 @@ def test_rendering_only_unexpected_rows_single_column(multi_source_batch: MultiS
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT foo FROM {source_table}",
             base_query="SELECT bar FROM {batch}",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 
@@ -878,7 +885,8 @@ def test_rendering_table_with_multiple_uuid():
                 comparison_data_source_name=data_source_name,
                 comparison_query=f"SELECT name, id FROM {source_table}",
                 base_query="SELECT name, id FROM {batch}",
-            )
+            ),
+            result_format="COMPLETE",
         )
         result.render()
 
@@ -963,7 +971,8 @@ def test_rendering_table_with_null_values(multi_source_batch: MultiSourceBatch):
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT col1, col2, col3 FROM {source_table}",
             base_query="SELECT col1, col2, col3 FROM {batch}",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 
@@ -1023,7 +1032,8 @@ def test_rendering_table_with_mixed_null_values(multi_source_batch: MultiSourceB
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT name, age FROM {source_table}",
             base_query="SELECT name, age FROM {batch}",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 
@@ -1124,6 +1134,51 @@ def test_rendering_table_with_mixed_null_values(multi_source_batch: MultiSourceB
             value_type="TableType",
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    "result_format,expected_keys",
+    [
+        pytest.param("BOOLEAN_ONLY", {"success"}, id="boolean_only"),
+        pytest.param("BASIC", {"success", "result"}, id="basic"),
+        pytest.param("SUMMARY", {"success", "result"}, id="summary"),
+        pytest.param("COMPLETE", {"success", "result"}, id="complete"),
+    ],
+)
+@multi_source_batch_setup(
+    multi_source_test_configs=SQLITE_ONLY,
+    base_data=MISSING_AND_UNEXPECTED_DF,
+    comparison_data=MISSING_AND_UNEXPECTED_DF,
+)
+def test_result_format_controls_details_visibility(
+    multi_source_batch: MultiSourceBatch,
+    result_format: Literal["BOOLEAN_ONLY", "BASIC", "SUMMARY", "COMPLETE"],
+    expected_keys: set[str],
+) -> None:
+    """Test that missing_rows and unexpected_rows are only visible with COMPLETE result format."""
+    result = multi_source_batch.base_batch.validate(
+        gxe.ExpectQueryResultsToMatchComparison(
+            base_query="SELECT missing_and_unexpected FROM {batch}",
+            comparison_data_source_name=multi_source_batch.comparison_data_source_name,
+            comparison_query=f"SELECT source FROM {multi_source_batch.comparison_table_name}",
+        ),
+        result_format=result_format,
+    )
+
+    # Verify top-level keys
+    assert set(result.to_json_dict().keys()) >= expected_keys
+
+    if result_format == "BOOLEAN_ONLY":
+        assert result.result is None
+    elif result_format == "COMPLETE":
+        assert "details" in result.result
+        assert "missing_rows" in result.result["details"]
+        assert "unexpected_rows" in result.result["details"]
+    else:
+        # BASIC and SUMMARY should not have details
+        assert "details" not in result.result
+        assert "unexpected_count" in result.result
+        assert "unexpected_percent" in result.result
 
 
 @multi_source_batch_setup(

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -487,7 +487,8 @@ def test_rendering_no_differences(multi_source_batch: MultiSourceBatch):
             base_query="SELECT e, a, d, g, b, e FROM {batch} ORDER BY e",
             comparison_data_source_name=multi_source_batch.comparison_data_source_name,
             comparison_query=f"SELECT g, d, g, c, e, a  FROM {source_table} ORDER BY g",
-        )
+        ),
+        result_format="COMPLETE",
     )
     result.render()
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -1169,7 +1169,7 @@ def test_result_format_controls_details_visibility(
     assert set(result.to_json_dict().keys()) >= expected_keys
 
     if result_format == "BOOLEAN_ONLY":
-        assert result.result is None
+        assert result.result == {}
     elif result_format == "COMPLETE":
         assert "details" in result.result
         assert "missing_rows" in result.result["details"]

--- a/tests/integration/data_sources_and_expectations/expectations/test_unexpected_rows_expectation.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_unexpected_rows_expectation.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Sequence
+from typing import Literal, Sequence
 from uuid import uuid4
 
 import pandas as pd
@@ -331,7 +331,8 @@ def test_success_result_format(batch_for_datasource: Batch) -> None:
     result = batch_for_datasource.validate(
         gxe.UnexpectedRowsExpectation(
             unexpected_rows_query="SELECT * FROM {batch} WHERE entity_id = 123"
-        )
+        ),
+        result_format="COMPLETE",
     )
 
     assert result.success
@@ -351,7 +352,8 @@ def test_fail_result_format(batch_for_datasource: Batch) -> None:
     result = batch_for_datasource.validate(
         gxe.UnexpectedRowsExpectation(
             unexpected_rows_query="SELECT * FROM {batch} WHERE entity_id = 2"
-        )
+        ),
+        result_format="COMPLETE",
     )
 
     assert not result.success
@@ -369,6 +371,47 @@ def test_fail_result_format(batch_for_datasource: Batch) -> None:
             ],
         },
     }
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[PostgreSQLDatasourceTestConfig(), RedshiftDatasourceTestConfig()],
+    data=TABLE_1,
+)
+@pytest.mark.parametrize(
+    "result_format,expected_keys",
+    [
+        pytest.param("BOOLEAN_ONLY", {"success"}, id="boolean_only"),
+        pytest.param("BASIC", {"success", "result"}, id="basic"),
+        pytest.param("SUMMARY", {"success", "result"}, id="summary"),
+        pytest.param("COMPLETE", {"success", "result"}, id="complete"),
+    ],
+)
+def test_result_format_controls_details_visibility(
+    batch_for_datasource: Batch,
+    result_format: Literal["BOOLEAN_ONLY", "BASIC", "SUMMARY", "COMPLETE"],
+    expected_keys: set[str],
+) -> None:
+    """Test that unexpected_rows are only visible with COMPLETE result format."""
+    result = batch_for_datasource.validate(
+        gxe.UnexpectedRowsExpectation(
+            unexpected_rows_query="SELECT * FROM {batch} WHERE entity_id = 2"
+        ),
+        result_format=result_format,
+    )
+
+    # Verify top-level keys
+    assert set(result.to_json_dict().keys()) >= expected_keys
+
+    if result_format == "BOOLEAN_ONLY":
+        assert result.result is None
+    elif result_format == "COMPLETE":
+        assert "details" in result.result
+        assert "unexpected_rows" in result.result["details"]
+        assert "observed_value" in result.result
+    else:
+        # BASIC and SUMMARY should not have details
+        assert "details" not in result.result
+        assert "observed_value" in result.result
 
 
 @parameterize_batch_for_data_sources(

--- a/tests/integration/data_sources_and_expectations/expectations/test_unexpected_rows_expectation.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_unexpected_rows_expectation.py
@@ -403,7 +403,7 @@ def test_result_format_controls_details_visibility(
     assert set(result.to_json_dict().keys()) >= expected_keys
 
     if result_format == "BOOLEAN_ONLY":
-        assert result.result is None
+        assert result.result == {}
     elif result_format == "COMPLETE":
         assert "details" in result.result
         assert "unexpected_rows" in result.result["details"]


### PR DESCRIPTION
### Problem
We were unintentionally populating the Validation Results of CustomSQL and MultiSource Expectations with row-level data at result_format levels below COMPLETE, which falls outside the specified boundaries of the BOOLEAN_ONLY, BASIC, SUMMARY, and COMPLETE hierarchy.

This PR adjusts the data population to match the following:

### CustomSQL Expectations
- BOOLEAN_ONLY
  - success
- BASIC | SUMMARY
  - success
  - observed value
- COMPLETE
  - success
  - observed value
  - unexpected rows
  
### MultiSource Expectations
- BOOLEAN_ONLY
  - success
- BASIC | SUMMARY
  - success
  - unexpected count
  - unexpected percent
- COMPLETE
  - success
  - unexpected count
  - unexpected percent
  - missing rows
  - unexpected rows

This also fixes an issue where MultiSource Expectations would fail to render with empty `result`s.

---

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
