### PR TITLE
[BUGFIX] Enhance JSON serialization for row conditions and improve validation logic

### DIFF
--- a/great_expectations/validator/util.py
+++ b/great_expectations/validator/util.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from great_expectations.compatibility import pydantic
 from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.types import SerializableDictDot, SerializableDotDict
 
@@ -35,6 +36,11 @@ def recursively_convert_to_json_serializable(
 def _recursively_convert_to_json_serializable(  # noqa: C901, PLR0911, PLR0912 # FIXME CoP
     test_obj: Any,
 ) -> Any:
+    # Handle Pydantic BaseModel objects (e.g., Condition objects for row_condition)
+    if isinstance(test_obj, pydantic.BaseModel):
+        dump_method = getattr(test_obj, "model_dump", None) or getattr(test_obj, "dict")
+        return dump_method()
+
     # If it's one of our types, we pass
     if isinstance(test_obj, (SerializableDictDot, SerializableDotDict)):
         return test_obj
@@ -139,9 +145,17 @@ def ensure_row_condition_is_correct(row_condition_string) -> None:
 
     Parameters
     ----------
-    row_condition_string : str
-        the pandas query string
+    row_condition_string : str or Condition
+        the pandas query string or a Condition object
     """
+    # Condition objects (pydantic BaseModel) are handled separately and don't need validation
+    if isinstance(row_condition_string, pydantic.BaseModel):
+        return
+
+    # Only validate string row conditions
+    if not isinstance(row_condition_string, str):
+        return
+
     if "'" in row_condition_string:
         raise InvalidExpectationConfigurationError(  # noqa: TRY003 # FIXME CoP
             f"{row_condition_string} cannot be serialized to json. "

--- a/great_expectations/validator/util.py
+++ b/great_expectations/validator/util.py
@@ -38,7 +38,7 @@ def _recursively_convert_to_json_serializable(  # noqa: C901, PLR0911, PLR0912 #
 ) -> Any:
     # Handle Pydantic BaseModel objects (e.g., Condition objects for row_condition)
     if isinstance(test_obj, pydantic.BaseModel):
-        dump_method = getattr(test_obj, "model_dump", None) or getattr(test_obj, "dict")
+        dump_method = getattr(test_obj, "model_dump", None) or test_obj.dict
         return dump_method()
 
     # If it's one of our types, we pass

--- a/tests/validator/test_util.py
+++ b/tests/validator/test_util.py
@@ -8,6 +8,7 @@ import pytest
 from numpy.lib.npyio import DataSource
 
 from great_expectations import validator
+from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.expectations.row_conditions import (
     AndCondition,
     Column,
@@ -15,7 +16,6 @@ from great_expectations.expectations.row_conditions import (
     NullityCondition,
     OrCondition,
 )
-from great_expectations.exceptions import InvalidExpectationConfigurationError
 
 
 @pytest.mark.big

--- a/tests/validator/test_util.py
+++ b/tests/validator/test_util.py
@@ -8,6 +8,13 @@ import pytest
 from numpy.lib.npyio import DataSource
 
 from great_expectations import validator
+from great_expectations.expectations.row_conditions import (
+    AndCondition,
+    Column,
+    ComparisonCondition,
+    NullityCondition,
+    OrCondition,
+)
 
 
 @pytest.mark.big
@@ -76,3 +83,167 @@ def test_recursively_convert_to_json_serializable(tmp_path):
     with pytest.raises(TypeError):
         y = {"p": DataSource(tmp_path)}
         validator.util.recursively_convert_to_json_serializable(y)
+
+
+@pytest.mark.unit
+def test_recursively_convert_to_json_serializable_with_nullity_condition():
+    """Test that NullityCondition objects can be serialized (regression test for row_condition bug)."""
+    condition = Column("COLUMN1").is_not_null()
+    assert isinstance(condition, NullityCondition)
+
+    result = validator.util.recursively_convert_to_json_serializable(
+        {"row_condition": condition}
+    )
+
+    assert result == {
+        "row_condition": {
+            "type": "nullity",
+            "column": {"name": "COLUMN1"},
+            "is_null": False,
+        }
+    }
+
+
+@pytest.mark.unit
+def test_recursively_convert_to_json_serializable_with_is_null_condition():
+    """Test that NullityCondition with is_null=True can be serialized."""
+    condition = Column("col").is_null()
+    assert isinstance(condition, NullityCondition)
+
+    result = validator.util.recursively_convert_to_json_serializable(
+        {"row_condition": condition}
+    )
+
+    assert result == {
+        "row_condition": {
+            "type": "nullity",
+            "column": {"name": "col"},
+            "is_null": True,
+        }
+    }
+
+
+@pytest.mark.unit
+def test_recursively_convert_to_json_serializable_with_comparison_condition():
+    """Test that ComparisonCondition objects can be serialized."""
+    condition = Column("tenure") > 2
+    assert isinstance(condition, ComparisonCondition)
+
+    result = validator.util.recursively_convert_to_json_serializable(
+        {"row_condition": condition}
+    )
+
+    assert result == {
+        "row_condition": {
+            "type": "comparison",
+            "column": {"name": "tenure"},
+            "operator": ">",
+            "parameter": 2,
+        }
+    }
+
+
+@pytest.mark.unit
+def test_recursively_convert_to_json_serializable_with_and_condition():
+    """Test that AndCondition objects can be serialized."""
+    condition = (Column("tenure") > 2) & (Column("salary") <= 50000)
+    assert isinstance(condition, AndCondition)
+
+    result = validator.util.recursively_convert_to_json_serializable(
+        {"row_condition": condition}
+    )
+
+    assert result == {
+        "row_condition": {
+            "type": "and",
+            "conditions": [
+                {
+                    "type": "comparison",
+                    "column": {"name": "tenure"},
+                    "operator": ">",
+                    "parameter": 2,
+                },
+                {
+                    "type": "comparison",
+                    "column": {"name": "salary"},
+                    "operator": "<=",
+                    "parameter": 50000,
+                },
+            ],
+        }
+    }
+
+
+@pytest.mark.unit
+def test_recursively_convert_to_json_serializable_with_or_condition():
+    """Test that OrCondition objects can be serialized."""
+    condition = (Column("name") == "alice") | (Column("name") == "bob")
+    assert isinstance(condition, OrCondition)
+
+    result = validator.util.recursively_convert_to_json_serializable(
+        {"row_condition": condition}
+    )
+
+    assert result == {
+        "row_condition": {
+            "type": "or",
+            "conditions": [
+                {
+                    "type": "comparison",
+                    "column": {"name": "name"},
+                    "operator": "==",
+                    "parameter": "alice",
+                },
+                {
+                    "type": "comparison",
+                    "column": {"name": "name"},
+                    "operator": "==",
+                    "parameter": "bob",
+                },
+            ],
+        }
+    }
+
+
+@pytest.mark.unit
+def test_recursively_convert_to_json_serializable_with_complex_condition():
+    """Test serialization of complex condition: (A & B) | C."""
+    statement_1 = Column("tenure") > 2
+    statement_2 = Column("salary") <= 50000
+    statement_3 = Column("department") == "Sales"
+
+    block_1 = statement_1 & statement_2
+    row_condition = block_1 | statement_3
+
+    result = validator.util.recursively_convert_to_json_serializable(
+        {"row_condition": row_condition}
+    )
+
+    assert result["row_condition"]["type"] == "or"
+    assert len(result["row_condition"]["conditions"]) == 2
+
+
+@pytest.mark.unit
+def test_ensure_row_condition_is_correct_with_condition_object():
+    """Test that ensure_row_condition_is_correct does not raise for Condition objects."""
+    condition = Column("COLUMN1").is_not_null()
+
+    # Should not raise
+    validator.util.ensure_row_condition_is_correct(condition)
+
+
+@pytest.mark.unit
+def test_ensure_row_condition_is_correct_with_string():
+    """Test that ensure_row_condition_is_correct still validates strings."""
+    from great_expectations.exceptions import InvalidExpectationConfigurationError
+
+    # Valid string should not raise
+    validator.util.ensure_row_condition_is_correct('col("x") > 5')
+
+    # String with single quotes should raise
+    with pytest.raises(InvalidExpectationConfigurationError):
+        validator.util.ensure_row_condition_is_correct("col('x') > 5")
+
+    # String with newline should raise
+    with pytest.raises(InvalidExpectationConfigurationError):
+        validator.util.ensure_row_condition_is_correct("col(\"x\")\n> 5")

--- a/tests/validator/test_util.py
+++ b/tests/validator/test_util.py
@@ -87,13 +87,11 @@ def test_recursively_convert_to_json_serializable(tmp_path):
 
 @pytest.mark.unit
 def test_recursively_convert_to_json_serializable_with_nullity_condition():
-    """Test that NullityCondition objects can be serialized (regression test for row_condition bug)."""
+    """Test that NullityCondition objects can be serialized."""
     condition = Column("COLUMN1").is_not_null()
     assert isinstance(condition, NullityCondition)
 
-    result = validator.util.recursively_convert_to_json_serializable(
-        {"row_condition": condition}
-    )
+    result = validator.util.recursively_convert_to_json_serializable({"row_condition": condition})
 
     assert result == {
         "row_condition": {
@@ -110,9 +108,7 @@ def test_recursively_convert_to_json_serializable_with_is_null_condition():
     condition = Column("col").is_null()
     assert isinstance(condition, NullityCondition)
 
-    result = validator.util.recursively_convert_to_json_serializable(
-        {"row_condition": condition}
-    )
+    result = validator.util.recursively_convert_to_json_serializable({"row_condition": condition})
 
     assert result == {
         "row_condition": {
@@ -129,9 +125,7 @@ def test_recursively_convert_to_json_serializable_with_comparison_condition():
     condition = Column("tenure") > 2
     assert isinstance(condition, ComparisonCondition)
 
-    result = validator.util.recursively_convert_to_json_serializable(
-        {"row_condition": condition}
-    )
+    result = validator.util.recursively_convert_to_json_serializable({"row_condition": condition})
 
     assert result == {
         "row_condition": {
@@ -149,9 +143,7 @@ def test_recursively_convert_to_json_serializable_with_and_condition():
     condition = (Column("tenure") > 2) & (Column("salary") <= 50000)
     assert isinstance(condition, AndCondition)
 
-    result = validator.util.recursively_convert_to_json_serializable(
-        {"row_condition": condition}
-    )
+    result = validator.util.recursively_convert_to_json_serializable({"row_condition": condition})
 
     assert result == {
         "row_condition": {
@@ -180,9 +172,7 @@ def test_recursively_convert_to_json_serializable_with_or_condition():
     condition = (Column("name") == "alice") | (Column("name") == "bob")
     assert isinstance(condition, OrCondition)
 
-    result = validator.util.recursively_convert_to_json_serializable(
-        {"row_condition": condition}
-    )
+    result = validator.util.recursively_convert_to_json_serializable({"row_condition": condition})
 
     assert result == {
         "row_condition": {
@@ -246,4 +236,4 @@ def test_ensure_row_condition_is_correct_with_string():
 
     # String with newline should raise
     with pytest.raises(InvalidExpectationConfigurationError):
-        validator.util.ensure_row_condition_is_correct("col(\"x\")\n> 5")
+        validator.util.ensure_row_condition_is_correct('col("x")\n> 5')

--- a/tests/validator/test_util.py
+++ b/tests/validator/test_util.py
@@ -15,6 +15,7 @@ from great_expectations.expectations.row_conditions import (
     NullityCondition,
     OrCondition,
 )
+from great_expectations.exceptions import InvalidExpectationConfigurationError
 
 
 @pytest.mark.big
@@ -225,7 +226,6 @@ def test_ensure_row_condition_is_correct_with_condition_object():
 @pytest.mark.unit
 def test_ensure_row_condition_is_correct_with_string():
     """Test that ensure_row_condition_is_correct still validates strings."""
-    from great_expectations.exceptions import InvalidExpectationConfigurationError
 
     # Valid string should not raise
     validator.util.ensure_row_condition_is_correct('col("x") > 5')


### PR DESCRIPTION
**Description:**
Fixes the TypeError when passing Condition objects (e.g., Column("col").is_not_null()) to the row_condition parameter in expectations via the Validator API.
Issue: https://github.com/great-expectations/great_expectations/issues/11597

**Changes:**
- Added Pydantic BaseModel handling in _recursively_convert_to_json_serializable() in great_expectations/validator/util.py
- Updated ensure_row_condition_is_correct() to handle Condition objects (not just strings)
- Added unit tests for Condition object serialization

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
