### PR TITLE
[MAINTENANCE] Upper bound pandas to be below 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ numpy>=1.22.4; python_version >= "3.10"
 numpy>=1.26.0; python_version >= "3.12"
 numpy>=2.1.0; python_version >= "3.13"
 packaging
-pandas>=1.3.0; python_version >= "3.10"
-pandas>=2.2.3; python_version >= "3.13"
-pandas; python_version >= "3.12"
+pandas>=1.3.0,<3.0.0; python_version >= "3.10"
+pandas>=2.2.3,<3.0.0; python_version >= "3.13"
+pandas>=1.3.0,<3.0.0; python_version >= "3.12"
 # patch version updates `typing_extensions` to the needed version
 pydantic>=1.10.7
 pyparsing>=2.4,!=3.2.4

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 33
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 35
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -205,6 +205,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-lite.txt", "pact-python", (("<", "3"), (">=", "2.0.1"))),
+        ("requirements-dev.txt", "pandas", (("<", "3.0.0"), (">=", "1.3.0"))),
         ("requirements-dev-pagerduty.txt", "pypd", (("==", "1.1.0"),)),
         (
             "requirements-dev-spark.txt",
@@ -252,4 +253,5 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
+        ("requirements.txt", "pandas", (("<", "3.0.0"), (">=", "1.3.0"))),
     }


### PR DESCRIPTION


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
