### PR TITLE
[BUGFIX] Update isinstance check for ColumnElement in SqlAlchemyExecutionEngine

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -39,6 +39,7 @@ from great_expectations._docs_decorators import new_method_or_class
 from great_expectations.compatibility import snowflake, sqlalchemy
 from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.sqlalchemy import (
+    ColumnElement,
     DatabaseError,
     PendingRollbackError,
     Subquery,
@@ -1557,7 +1558,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         # since we can't make the class generic on sqlalchemy
         # since it's not installed in all environments."""
         output = super().condition_to_filter_clause(condition)
-        if not isinstance(output, sa.ColumnElement):
+        if not isinstance(output, ColumnElement):
             raise InvalidFilterClause(output)
         return output
 

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -1603,4 +1603,4 @@ class TestConditionToFilterClauseSqlAlchemy:
         # Verify the result is a valid ColumnElement (this would fail before the fix)
         assert isinstance(result, ColumnElement)
         compiled = str(result.compile(compile_kwargs={"literal_binds": True}))
-        assert "my_condition_column IN (1, 2)" == compiled
+        assert compiled == "my_condition_column IN (1, 2)"

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations.compatibility.sqlalchemy import Connection
+from great_expectations.compatibility.sqlalchemy import ColumnElement, Connection
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
@@ -1587,12 +1587,7 @@ class TestConditionToFilterClauseSqlAlchemy:
 
     @pytest.mark.sqlite
     def test_condition_to_filter_clause_returns_column_element(self, sa) -> None:
-        """
-        In SQLAlchemy 1.x, ColumnElement is not exported at the top-level namespace,
-        so using `sa.ColumnElement` in isinstance() checks fails. This test ensures
-        condition_to_filter_clause works correctly with both SQLAlchemy 1.x and 2.x.
-        """
-        from great_expectations.compatibility.sqlalchemy import ColumnElement
+        """Test that condition_to_filter_clause correctly handles ColumnElement conditions."""
 
         engine = SqlAlchemyExecutionEngine(connection_string="sqlite://")
 

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -1584,3 +1584,23 @@ class TestConditionToFilterClauseSqlAlchemy:
         assert len(result) == 4
         ids = sorted([row[2] for row in result])
         assert ids == [2, 3, 4, 5]
+
+    @pytest.mark.sqlite
+    def test_condition_to_filter_clause_returns_column_element(self, sa) -> None:
+        """
+        In SQLAlchemy 1.x, ColumnElement is not exported at the top-level namespace,
+        so using `sa.ColumnElement` in isinstance() checks fails. This test ensures
+        condition_to_filter_clause works correctly with both SQLAlchemy 1.x and 2.x.
+        """
+        from great_expectations.compatibility.sqlalchemy import ColumnElement
+
+        engine = SqlAlchemyExecutionEngine(connection_string="sqlite://")
+
+        # Test the exact scenario from the bug report: Column(...).is_in([...])
+        condition = Column("my_condition_column").is_in([1, 2])
+        result = engine.condition_to_filter_clause(condition)
+
+        # Verify the result is a valid ColumnElement (this would fail before the fix)
+        assert isinstance(result, ColumnElement)
+        compiled = str(result.compile(compile_kwargs={"literal_binds": True}))
+        assert "my_condition_column IN (1, 2)" == compiled


### PR DESCRIPTION
## Fix: Row Condition Feature Fails on SQLAlchemy 1.x Data Sources

**Fixes:** https://github.com/great-expectations/great_expectations/issues/11565

### Problem

When using the `row_condition` feature with SQLAlchemy 1.x data sources, validation fails with:

```
AttributeError: module 'sqlalchemy' has no attribute 'ColumnElement'
```

This occurs because `ColumnElement` is not exported at the top-level `sqlalchemy` namespace in SQLAlchemy 1.x (it was added in SQLAlchemy 2.x). The code was using `sa.ColumnElement` in an `isinstance()` check, which fails for SQLAlchemy 1.x users.

### Solution

Import `ColumnElement` from the compatibility module (`great_expectations.compatibility.sqlalchemy`) which correctly imports it from `sqlalchemy.sql.elements.ColumnElement`, ensuring compatibility with both SQLAlchemy 1.x and 2.x.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
