### PR TITLE
[BUGFIX] Remove table domain key from ExpectColumnToExist

### DIFF
--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -172,9 +172,7 @@ class ExpectColumnToExist(BatchExpectation):
         "column",
         "column_index",
     )
-    domain_keys = (
-        "batch_id",
-    )
+    domain_keys = ("batch_id",)
     args_keys = ("column", "column_index")
 
     class Config:

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -174,7 +174,6 @@ class ExpectColumnToExist(BatchExpectation):
     )
     domain_keys = (
         "batch_id",
-        "table",
     )
     args_keys = ("column", "column_index")
 


### PR DESCRIPTION
The `table` domain key is vestigial and not supported with GX 1.0.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
