### PR TITLE
[DOCS] define asterisks in core result format docs

### DIFF
--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/choose_a_result_format/_result_verbosity_reference_table.md
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/choose_a_result_format/_result_verbosity_reference_table.md
@@ -1,4 +1,4 @@
-The following table lists the fields that can be found in the `result` dictionary of a Validation Result and the `result_format` levels that return that field.
+The following table lists the fields that can be found in the `result` dictionary of a Validation Result and the `result_format` levels that return that field. An * indicates the field is not returned by default but can be enabled through an additional setting. Meanwhile, ** indicates that the field is returned by default but can be disabled.
 
 | Fields within `result`                |BOOLEAN_ONLY    |BASIC           |SUMMARY         |COMPLETE        |
 ----------------------------------------|----------------|----------------|----------------|-----------------


### PR DESCRIPTION
copies definitions from cloud page to resolve https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1770158548489729 



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
