### PR TITLE
[DOCS] Fix link to expect_table_row_count_to_equal_other_table in documentation

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_table_checksum_to_equal_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_table_checksum_to_equal_other_table.py
@@ -273,7 +273,7 @@ class ExpectTableChecksumToEqualOtherTable(BatchExpectation):
         Exact fields vary depending on the values passed to result_format, catch_exceptions, and meta.
 
     See Also:
-        [expect_table_row_count_to_equal_other_table](https://greatexpectations.io/expectations/xpect_table_row_count_to_equal_other_table)
+        [expect_table_row_count_to_equal_other_table](https://greatexpectations.io/expectations/expect_table_row_count_to_equal_other_table)
     """
 
     # These examples will be shown in the public gallery, and also executed as unit tests for your Expectation


### PR DESCRIPTION
…umentation




- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
