### PR TITLE
[BUGFIX] Fix missing elements from result due to resul format replacing on validator

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1404,6 +1404,21 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         success_kwargs.update(domain_kwargs)
         return success_kwargs
 
+    @staticmethod
+    def _merge_result_formats(
+        expectation_result_format: dict,
+        runtime_result_format: Union[str, dict],
+    ) -> dict:
+        """
+        Merge a runtime result_format with the expectation's result_format.
+        """
+        if isinstance(runtime_result_format, str):
+            merged = parse_result_format(runtime_result_format)
+        else:
+            merged = runtime_result_format
+        merged.update(expectation_result_format)
+        return merged
+
     def _get_runtime_kwargs(
         self,
         runtime_configuration: Optional[dict] = None,
@@ -1411,6 +1426,15 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         configuration = deepcopy(self.configuration)
 
         if runtime_configuration:
+            if "result_format" in runtime_configuration:
+                expectation_rf = configuration.kwargs.get("result_format")
+                if isinstance(expectation_rf, dict):
+                    runtime_configuration = dict(runtime_configuration)
+                    runtime_configuration["result_format"] = self._merge_result_formats(
+                        expectation_result_format=expectation_rf,
+                        runtime_result_format=runtime_configuration["result_format"],
+                    )
+
             configuration.kwargs.update(runtime_configuration)
 
         success_kwargs = self._get_success_kwargs()
@@ -1438,10 +1462,16 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         ] = self.configuration.kwargs.get("result_format", default_result_format or {})
         result_format: Union[Dict[str, Union[str, int, bool, List[str], None]], str]
         if runtime_configuration:
-            result_format = runtime_configuration.get(
-                "result_format",
-                configuration_result_format,
-            )
+            runtime_rf = runtime_configuration.get("result_format")
+            if runtime_rf is not None and isinstance(configuration_result_format, dict):
+                result_format = self._merge_result_formats(
+                    expectation_result_format=configuration_result_format,
+                    runtime_result_format=runtime_rf,
+                )
+            elif runtime_rf is not None:
+                result_format = runtime_rf
+            else:
+                result_format = configuration_result_format
         else:
             result_format = configuration_result_format
         return result_format

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -841,3 +841,155 @@ class TestLegacyRowConditionTransformation:
 
         # Should have two warnings: one for condition_parser, one for string row_condition
         assert len(warning_list) == 2
+
+
+class TestMergeResultFormats:
+    """Tests for Expectation._merge_result_formats.
+
+    When an expectation specifies a dict result_format (e.g. with
+    unexpected_index_column_names), that dict must not be silently
+    replaced when a runtime default like "SUMMARY" is supplied.
+    """
+
+    def test_string_runtime_preserves_expectation_keys(self):
+        """A plain string runtime format should not drop expectation-level keys."""
+        expectation_rf = {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["broker_code"],
+        }
+        result = Expectation._merge_result_formats(
+            expectation_result_format=expectation_rf,
+            runtime_result_format="SUMMARY",
+        )
+        assert result["result_format"] == "COMPLETE"
+        assert result["unexpected_index_column_names"] == ["broker_code"]
+        # Runtime defaults like partial_unexpected_count should still be present
+        assert "partial_unexpected_count" in result
+
+    def test_dict_runtime_merges_with_expectation(self):
+        """A dict runtime format should merge, with expectation keys winning."""
+        expectation_rf = {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["id"],
+        }
+        runtime_rf = {
+            "result_format": "BASIC",
+            "partial_unexpected_count": 10,
+        }
+        result = Expectation._merge_result_formats(
+            expectation_result_format=expectation_rf,
+            runtime_result_format=runtime_rf,
+        )
+        assert result["result_format"] == "COMPLETE"
+        assert result["unexpected_index_column_names"] == ["id"]
+        assert result["partial_unexpected_count"] == 10
+
+    def test_string_runtime_without_expectation_extras(self):
+        """When the expectation dict has no extras, the format level still comes from it."""
+        expectation_rf = {"result_format": "BASIC"}
+        result = Expectation._merge_result_formats(
+            expectation_result_format=expectation_rf,
+            runtime_result_format="SUMMARY",
+        )
+        assert result["result_format"] == "BASIC"
+
+    def test_runtime_fills_defaults_expectation_does_not_set(self):
+        """Runtime-provided defaults fill in keys not set by the expectation."""
+        expectation_rf = {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk"],
+        }
+        result = Expectation._merge_result_formats(
+            expectation_result_format=expectation_rf,
+            runtime_result_format="SUMMARY",
+        )
+        assert result["include_unexpected_rows"] is False
+        assert result["partial_unexpected_count"] == 20
+
+
+class TestGetRuntimeKwargsResultFormatMerge:
+    """Tests that _get_runtime_kwargs properly merges result_format."""
+
+    def test_dict_result_format_preserved_with_string_runtime(self):
+        """Per-expectation dict result_format must survive a string runtime override."""
+        expectation = gxe.ExpectColumnValuesToNotBeNull(
+            column="broker_name",
+            result_format={
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["broker_code"],
+            },
+        )
+        runtime_configuration = {"result_format": "SUMMARY"}
+        result = expectation._get_runtime_kwargs(
+            runtime_configuration=runtime_configuration,
+        )
+        rf = result["result_format"]
+        assert rf["result_format"] == "COMPLETE"
+        assert rf["unexpected_index_column_names"] == ["broker_code"]
+
+    def test_string_result_format_not_affected(self):
+        """When the expectation uses a plain string, runtime override works as before."""
+        expectation = gxe.ExpectColumnValuesToNotBeNull(column="col")
+        runtime_configuration = {"result_format": "BASIC"}
+        result = expectation._get_runtime_kwargs(
+            runtime_configuration=runtime_configuration,
+        )
+        rf = result["result_format"]
+        assert rf["result_format"] == "BASIC"
+        assert "unexpected_index_column_names" not in rf
+
+    def test_no_runtime_configuration_uses_expectation_format(self):
+        """Without runtime config, the expectation's own result_format is used."""
+        expectation = gxe.ExpectColumnValuesToNotBeNull(
+            column="col",
+            result_format={
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["id"],
+            },
+        )
+        result = expectation._get_runtime_kwargs(runtime_configuration=None)
+        rf = result["result_format"]
+        assert rf["result_format"] == "COMPLETE"
+        assert rf["unexpected_index_column_names"] == ["id"]
+
+
+class TestGetResultFormatMerge:
+    """Tests that _get_result_format properly merges result_format."""
+
+    def test_dict_config_preserved_with_string_runtime(self):
+        """Per-expectation dict result_format must survive a string runtime override."""
+        expectation = gxe.ExpectColumnValuesToNotBeNull(
+            column="broker_name",
+            result_format={
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["broker_code"],
+            },
+        )
+        result = expectation._get_result_format(
+            runtime_configuration={"result_format": "SUMMARY"},
+        )
+        assert isinstance(result, dict)
+        assert result["result_format"] == "COMPLETE"
+        assert result["unexpected_index_column_names"] == ["broker_code"]
+
+    def test_string_config_replaced_by_runtime(self):
+        """When the expectation has no dict result_format, runtime takes effect."""
+        expectation = gxe.ExpectColumnValuesToNotBeNull(column="col")
+        result = expectation._get_result_format(
+            runtime_configuration={"result_format": "BASIC"},
+        )
+        assert result == "BASIC"
+
+    def test_no_runtime_returns_expectation_config(self):
+        """Without runtime config, the expectation's own result_format is returned."""
+        expectation = gxe.ExpectColumnValuesToNotBeNull(
+            column="col",
+            result_format={
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["id"],
+            },
+        )
+        result = expectation._get_result_format(runtime_configuration=None)
+        assert isinstance(result, dict)
+        assert result["result_format"] == "COMPLETE"
+        assert result["unexpected_index_column_names"] == ["id"]


### PR DESCRIPTION
**Problem:**
When using the Spark Execution Engine in Great Expectations 1.x, the validation result is missing unexpected_index_list, partial_unexpected_index_list, unexpected_list, and unexpected_index_query  even when unexpected_index_column_names is properly configured in the expectation's result_format.

**Root cause**
The V1 Validator (used by ValidationDefinition.run() and Checkpoint.run()) always injects result_format: "SUMMARY" into the runtime_configuration dict even when the user never explicitly set one.

**Fix**
Introduced Expectation._merge_result_formats(), a static helper that merges the runtime result_format with the expectation's dict result_format instead of replacing it.

**Fixes:** [11647](https://github.com/great-expectations/great_expectations/issues/11647)


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
