### PR TITLE
[MAINTENANCE] Add `start_period` to mercury healthcheck to prevent flaky CI failures

### DIFF
--- a/assets/docker/mercury/docker-compose.yml
+++ b/assets/docker/mercury/docker-compose.yml
@@ -24,6 +24,11 @@ services:
     ports:
       - 8042:15672
       - 5672:5672
+    healthcheck:
+      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
   db-provisioner:
     image: 258143015559.dkr.ecr.us-east-1.amazonaws.com/mercury/provisioner:0.4.1
     platform: linux/amd64
@@ -74,12 +79,15 @@ services:
     healthcheck:
       test: bash -c ':> /dev/tcp/0.0.0.0/6002' || exit 1
       interval: 5s
-      timeout: 2s
+      timeout: 5s
       retries: 20
+      start_period: 90s
     depends_on:
       db-provisioner:
         condition: service_completed_successfully
       localstack:
+        condition: service_healthy
+      mq:
         condition: service_healthy
     entrypoint:
       - /bin/bash

--- a/tasks.py
+++ b/tasks.py
@@ -1234,7 +1234,7 @@ def service(
                     "up",
                     "-d",
                     "--wait",
-                    "--wait-timeout 120",
+                    "--wait-timeout 300",
                 ]
             )
             ctx.run(" ".join(cmds), echo=True, pty=pty)


### PR DESCRIPTION
### Root Cause

The `mercury-service-api-v1` entrypoint runs alembic migrations, database seeding, and a localstack init script **before** the FastAPI server starts listening on port 6002. Without a `start_period`, Docker begins counting healthcheck failures immediately — and with only 20 retries × 5s intervals (~100s), the container gets marked unhealthy before the server even starts if those startup tasks take too long.

### Changes

1. **`assets/docker/mercury/docker-compose.yml` — `mercury-service-api-v1` healthcheck**:
   - Added `start_period: 90s` — Docker ignores healthcheck failures during this window, giving the entrypoint time to run migrations/seeding/init before failures count against the retry limit.
   - Bumped `timeout` from `2s` → `5s` — a 2s timeout for a TCP check is tight under CI load.

2. **`assets/docker/mercury/docker-compose.yml` — `mq` service**:
   - Added a healthcheck (`rabbitmq-diagnostics -q ping`) so RabbitMQ readiness is verified.
   - Added `mq` as a `depends_on` with `condition: service_healthy` for `mercury-service-api-v1`, ensuring the API does not start until RabbitMQ is accepting connections.

3. **`tasks.py` — `--wait-timeout`**:
   - Increased from `120` → `300` to accommodate the new 90s `start_period` plus the retry window (90 + 20×5 = 190s), with headroom for all other services.