### PR TITLE
Fix incorrect exception_info structure when raised_exception is True

### DIFF
--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -788,9 +788,14 @@ class Validator:
             # Report all MetricResolutionError occurrences impacting expectation and append it to rejected list.  # noqa: E501 # FIXME CoP
             if len(metric_exception_info) > 0:
                 configuration = expectation_validation_graph.configuration
+                # Flatten the metric_exception_info dict to get a single ExceptionInfo
+                # instead of a dict keyed by metric identifiers, so that exception_info
+                # has the expected flat structure: {raised_exception, exception_traceback,
+                # exception_message}. See https://github.com/great-expectations/great_expectations/issues/10849
+                first_exception_info = next(iter(metric_exception_info.values()))
                 result = ExpectationValidationResult(
                     success=False,
-                    exception_info=metric_exception_info,
+                    exception_info=first_exception_info,
                     expectation_config=configuration,
                 )
                 evrs.append(result)


### PR DESCRIPTION
## Summary

Fixes #10849

When a metric resolution error occurs during validation (e.g. referencing a non-existent column), the `exception_info` dict on the result gets structured as:

```python
{"('column_values.nonnull.condition', '242ce...', ())": {"raised_exception": True, "exception_traceback": "...", "exception_message": "..."}}
```

instead of the expected flat structure:

```python
{"raised_exception": True, "exception_traceback": "...", "exception_message": "..."}
```

This happens because `_resolve_suite_level_graph_and_process_metric_evaluation_errors` in `validator.py` passes the raw `metric_exception_info` dict (keyed by metric ID strings) directly as the `exception_info` argument to `ExpectationValidationResult`. Every other exception handling path in the validator correctly passes a single `ExceptionInfo` object.

The fix extracts the `ExceptionInfo` from the first failing metric and passes it directly, making the structure consistent across all code paths. This matches how the renderers in `expectation.py` already handle this case — they iterate the dict and break after the first entry.

## Changes

- `great_expectations/validator/validator.py`: Extract the first `ExceptionInfo` value from `metric_exception_info` before passing it to `ExpectationValidationResult`, instead of passing the entire dict keyed by metric identifiers.

## Test plan

- Validate that `result.exception_info["raised_exception"]` returns `True` directly (no nested key)
- Validate that `result.exception_info["exception_message"]` and `result.exception_info["exception_traceback"]` are accessible at the top level
- Confirm existing renderers in `expectation.py` still work (they check `"raised_exception" in result.exception_info` first, which now succeeds on the first branch)
- Existing tests pass since `get_exception_info()` itself is unchanged