### PR TITLE
[MAINTENANCE] Only run python 3.13 marker tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,10 +686,13 @@ jobs:
           # TODO: would like to adopt `actionlint` pre-commit hook
           # but false positive here and inability to do an inline ignore
           # prevents this https://github.com/rhysd/actionlint/issues/237
+          - python-version: ${{ github.event_name == 'pull_request_target' && '3.10' }}
           - python-version: ${{ github.event_name == 'pull_request_target' && '3.11' }}
           - python-version: ${{ github.event_name == 'pull_request_target' && '3.12' }}
+          - python-version: ${{ github.event_name == 'merge_group' && '3.10' }}
           - python-version: ${{ github.event_name == 'merge_group' && '3.11' }}
           - python-version: ${{ github.event_name == 'merge_group' && '3.12' }}
+          - python-version: ${{ github.event_name == 'workflow_dispatch' && '3.10' }}
           - python-version: ${{ github.event_name == 'workflow_dispatch' && '3.11' }}
           - python-version: ${{ github.event_name == 'workflow_dispatch' && '3.12' }}
             # clickhouse needs dependency update
@@ -782,7 +785,7 @@ jobs:
         markers:
           # - redshift
           - gx-redshift
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.13"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Motivation

For externally-hosted datasources, e.g. snowflake and databricks, the number of entities we create impacts the runtime. We've taken previous measures to automate cleanup of these periodically. This is an additional step to improve performance.

Running tests against multiple python versions helps catch a few categories of bugs:
* differences in python standard library across versions
* differences in versions of dependencies we pull in

But the main point of our marker tests is to verify differences between datasources (not the libraries that connect to them), and running multiple versions of python against the same datasource (e.g. instance of snowflake) is not uncovering these types of errors.

So we'll try to cut the number of tests running on every PR, and leave the full version matrix to run for releases, as it does today.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
