### PR TITLE
[FEATURE] Auto-strip ORDER BY for MSSQL COUNT(*) subqueries

### DIFF
--- a/great_expectations/expectations/metrics/query_metric_provider.py
+++ b/great_expectations/expectations/metrics/query_metric_provider.py
@@ -18,6 +18,75 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_ORDER_BY_TOKEN = "ORDER BY"
+_OFFSET_TOKEN = "OFFSET"
+
+
+def has_top_level_token(query: str, token: str) -> bool:
+    """Return True if *token* appears at parentheses depth 0 (case-insensitive).
+
+    Tokens nested inside parenthesised subqueries or window-function
+    OVER() clauses are ignored.
+    """
+    upper = query.upper()
+    upper_token = token.upper()
+    depth = 0
+    token_len = len(upper_token)
+    query_len = len(upper)
+    i = 0
+    while i < query_len:
+        char = upper[i]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif depth == 0 and upper[i : i + token_len] == upper_token:
+            return True
+        i += 1
+    return False
+
+
+def find_last_top_level_order_by(query: str) -> int:
+    """Return the character position of the last top-level ORDER BY, or -1.
+
+    ORDER BY inside parenthesised subqueries or window-function OVER()
+    clauses (depth > 0) is ignored.
+    """
+    upper = query.upper()
+    last_pos = -1
+    depth = 0
+    token_len = len(_ORDER_BY_TOKEN)
+    query_len = len(upper)
+    i = 0
+    while i < query_len:
+        char = upper[i]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif depth == 0 and upper[i : i + token_len] == _ORDER_BY_TOKEN:
+            last_pos = i
+        i += 1
+    return last_pos
+
+
+def strip_top_level_order_by(query: str) -> str:
+    """Strip the last top-level ORDER BY clause from a SQL query.
+
+    Used when wrapping user queries in COUNT(*) for MSSQL, where ORDER BY
+    in a subquery is invalid unless TOP or OFFSET is present.  Returns the
+    query unchanged if no top-level ORDER BY exists or a top-level OFFSET
+    is present (stripping would remove the pagination clause).
+    """
+    if has_top_level_token(query, _OFFSET_TOKEN):
+        return query
+
+    pos = find_last_top_level_order_by(query)
+    if pos == -1:
+        return query
+
+    return query[:pos].rstrip()
+
 
 class MissingElementError(TypeError):
     def __init__(self):

--- a/great_expectations/expectations/metrics/query_metrics/query_row_count/query_row_count.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_row_count/query_row_count.py
@@ -44,7 +44,7 @@ class QueryRowCount(QueryMetricProvider):
                 execution_engine=execution_engine,
             )
         )
-        if getattr(execution_engine, "dialect_name", None) == "mssql":
+        if execution_engine.dialect_name == "mssql":
             substituted_batch_subquery = strip_top_level_order_by(substituted_batch_subquery)
 
         count_column_name = "unexpected_row_count"

--- a/great_expectations/expectations/metrics/query_metrics/query_row_count/query_row_count.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_row_count/query_row_count.py
@@ -13,6 +13,7 @@ from great_expectations.execution_engine import (
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.expectations.metrics.query_metric_provider import (
     QueryMetricProvider,
+    strip_top_level_order_by,
 )
 
 if TYPE_CHECKING:
@@ -43,6 +44,9 @@ class QueryRowCount(QueryMetricProvider):
                 execution_engine=execution_engine,
             )
         )
+        if getattr(execution_engine, "dialect_name", None) == "mssql":
+            substituted_batch_subquery = strip_top_level_order_by(substituted_batch_subquery)
+
         count_column_name = "unexpected_row_count"
         row_count_query = (
             f"SELECT COUNT(*) as {count_column_name} FROM "

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -521,15 +521,15 @@ class TestStripTopLevelOrderBy:
 class MockMSSQLSqlAlchemyExecutionEngine(MockSqlAlchemyExecutionEngine):
     """Mock engine that reports dialect_name as 'mssql'."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
-        from tests.expectations.metrics.conftest import Dialect, MockSaEngine
+        from tests.expectations.metrics.conftest import MockSaEngine
 
-        self.engine = MockSaEngine(dialect=Dialect("mssql"))  # type: ignore[assignment]
+        self.engine = MockSaEngine(dialect=sa.dialects.mssql.dialect())  # type: ignore[assignment]
 
 
 @pytest.fixture
-def mock_mssql_execution_engine():
+def mock_mssql_execution_engine() -> MockMSSQLSqlAlchemyExecutionEngine:
     from tests.expectations.metrics.conftest import MockBatchManager
 
     engine = MockMSSQLSqlAlchemyExecutionEngine()

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, Optional
 from unittest import mock
+from unittest.mock import create_autospec
 
 import pytest
 from sqlalchemy.dialects import mysql
@@ -10,6 +11,9 @@ from great_expectations.compatibility.sqlalchemy import (
 from great_expectations.expectations.metrics.query_metric_provider import (
     QueryMetricProvider,
     QueryParameters,
+    find_last_top_level_order_by,
+    has_top_level_token,
+    strip_top_level_order_by,
 )
 from great_expectations.expectations.metrics.query_metrics import (
     QueryColumn,
@@ -259,3 +263,391 @@ def test_get_substituted_batch_subquery_uses_dialect_for_compilation(
     # Verify that the batch selectable was actually compiled
     # (should contain table and column references)
     assert "test_table" in result.lower() or "reportingdate" in result.lower()
+
+
+class TestHasTopLevelToken:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "query, token, expected",
+        [
+            pytest.param("SELECT * FROM t ORDER BY x", "ORDER BY", True, id="simple_match"),
+            pytest.param("SELECT * FROM t", "ORDER BY", False, id="no_match"),
+            pytest.param("select * from t order by x", "ORDER BY", True, id="case_insensitive"),
+            pytest.param(
+                "SELECT * FROM (SELECT * FROM t ORDER BY x) sub",
+                "ORDER BY",
+                False,
+                id="nested_not_matched",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER BY x OFFSET 5 ROWS",
+                "OFFSET",
+                True,
+                id="offset_at_top_level",
+            ),
+            pytest.param(
+                "SELECT * FROM (SELECT * FROM t ORDER BY x OFFSET 0 ROWS) sub",
+                "OFFSET",
+                False,
+                id="offset_nested_not_matched",
+            ),
+            pytest.param("", "ORDER BY", False, id="empty_string"),
+            pytest.param(
+                "SELECT *, ROW_NUMBER() OVER (ORDER BY x) FROM t",
+                "ORDER BY",
+                False,
+                id="window_function_not_matched",
+            ),
+        ],
+    )
+    def test_has_top_level_token(self, query: str, token: str, expected: bool) -> None:
+        assert has_top_level_token(query, token) is expected
+
+
+class TestFindLastTopLevelOrderBy:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "query, expected_pos",
+        [
+            pytest.param("SELECT * FROM t ORDER BY x", 16, id="simple"),
+            pytest.param("SELECT * FROM t", -1, id="none"),
+            pytest.param("", -1, id="empty"),
+            pytest.param(
+                "SELECT * FROM (SELECT * FROM t ORDER BY x) sub ORDER BY y",
+                47,
+                id="inner_and_outer_returns_outer",
+            ),
+            pytest.param(
+                "SELECT *, ROW_NUMBER() OVER (ORDER BY x) FROM t",
+                -1,
+                id="window_function_ignored",
+            ),
+            pytest.param(
+                "SELECT * FROM t1 ORDER BY a UNION ALL SELECT * FROM t2 ORDER BY b",
+                55,
+                id="multiple_returns_last",
+            ),
+        ],
+    )
+    def test_find_last_top_level_order_by(self, query: str, expected_pos: int) -> None:
+        assert find_last_top_level_order_by(query) == expected_pos
+
+
+class TestStripTopLevelOrderBy:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "query, expected",
+        [
+            # --- basic stripping ---
+            pytest.param(
+                "SELECT * FROM t WHERE x > 1 ORDER BY x DESC",
+                "SELECT * FROM t WHERE x > 1",
+                id="where_then_order_by",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER BY x",
+                "SELECT * FROM t",
+                id="simple_order_by",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER BY x ASC, y DESC",
+                "SELECT * FROM t",
+                id="multi_column_order_by",
+            ),
+            pytest.param(
+                "SELECT * FROM t GROUP BY color HAVING SUM(x) > 3 ORDER BY color",
+                "SELECT * FROM t GROUP BY color HAVING SUM(x) > 3",
+                id="group_having_order_by",
+            ),
+            # --- no-op (no ORDER BY) ---
+            pytest.param(
+                "SELECT * FROM t WHERE x > 1",
+                "SELECT * FROM t WHERE x > 1",
+                id="no_order_by",
+            ),
+            pytest.param("SELECT * FROM t", "SELECT * FROM t", id="plain_select"),
+            pytest.param("", "", id="empty_string"),
+            # --- case insensitivity ---
+            pytest.param(
+                "select * from t order by x",
+                "select * from t",
+                id="all_lowercase",
+            ),
+            pytest.param(
+                "SELECT * FROM t Order By x",
+                "SELECT * FROM t",
+                id="mixed_case",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER  BY x",
+                "SELECT * FROM t ORDER  BY x",
+                id="extra_space_not_matched",
+            ),
+            # --- window functions preserved ---
+            pytest.param(
+                "SELECT *, ROW_NUMBER() OVER (ORDER BY x) FROM t",
+                "SELECT *, ROW_NUMBER() OVER (ORDER BY x) FROM t",
+                id="window_function_preserved",
+            ),
+            pytest.param(
+                "SELECT *, ROW_NUMBER() OVER (PARTITION BY a ORDER BY x) as rn FROM t",
+                "SELECT *, ROW_NUMBER() OVER (PARTITION BY a ORDER BY x) as rn FROM t",
+                id="window_partition_preserved",
+            ),
+            pytest.param(
+                "SELECT *, ROW_NUMBER() OVER (ORDER BY x) FROM t ORDER BY rn",
+                "SELECT *, ROW_NUMBER() OVER (ORDER BY x) FROM t",
+                id="window_preserved_outer_stripped",
+            ),
+            # --- subqueries ---
+            pytest.param(
+                "SELECT * FROM (SELECT TOP 5 * FROM t ORDER BY x) sub",
+                "SELECT * FROM (SELECT TOP 5 * FROM t ORDER BY x) sub",
+                id="inner_only_preserved",
+            ),
+            pytest.param(
+                "SELECT * FROM (SELECT TOP 5 * FROM t ORDER BY x) sub ORDER BY y",
+                "SELECT * FROM (SELECT TOP 5 * FROM t ORDER BY x) sub",
+                id="inner_preserved_outer_stripped",
+            ),
+            pytest.param(
+                "SELECT * FROM (SELECT * FROM (SELECT TOP 3 * FROM t ORDER BY x) a) b ORDER BY z",
+                "SELECT * FROM (SELECT * FROM (SELECT TOP 3 * FROM t ORDER BY x) a) b",
+                id="deeply_nested",
+            ),
+            # --- OFFSET guard (returns unchanged) ---
+            pytest.param(
+                "SELECT * FROM t ORDER BY x OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY",
+                "SELECT * FROM t ORDER BY x OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY",
+                id="offset_fetch_preserved",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER BY x OFFSET 0 ROWS",
+                "SELECT * FROM t ORDER BY x OFFSET 0 ROWS",
+                id="offset_only_preserved",
+            ),
+            pytest.param(
+                "SELECT * FROM (SELECT * FROM t ORDER BY x OFFSET 0 ROWS) sub ORDER BY y",
+                "SELECT * FROM (SELECT * FROM t ORDER BY x OFFSET 0 ROWS) sub",
+                id="nested_offset_does_not_prevent_outer_strip",
+            ),
+            # --- TOP does not prevent stripping ---
+            pytest.param(
+                "SELECT TOP 10 * FROM t ORDER BY x DESC",
+                "SELECT TOP 10 * FROM t",
+                id="top_without_offset_still_strips",
+            ),
+            pytest.param(
+                "SELECT * FROM (SELECT TOP 5 * FROM t ORDER BY x) sub ORDER BY y",
+                "SELECT * FROM (SELECT TOP 5 * FROM t ORDER BY x) sub",
+                id="nested_top_does_not_prevent_outer_strip",
+            ),
+            # --- complex patterns ---
+            pytest.param(
+                "SELECT * FROM t1 UNION ALL SELECT * FROM t2 ORDER BY x",
+                "SELECT * FROM t1 UNION ALL SELECT * FROM t2",
+                id="union_trailing_stripped",
+            ),
+            pytest.param(
+                "SELECT t1.* FROM t1 JOIN t2 ON t1.id = t2.id ORDER BY t1.x",
+                "SELECT t1.* FROM t1 JOIN t2 ON t1.id = t2.id",
+                id="join_stripped",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER BY CASE WHEN x > 1 THEN 0 ELSE 1 END",
+                "SELECT * FROM t",
+                id="case_expression_stripped",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER BY COALESCE(x, 0)",
+                "SELECT * FROM t",
+                id="function_call_stripped",
+            ),
+            # --- multi-line ---
+            pytest.param(
+                "SELECT *\nFROM t\nWHERE x > 1\nORDER BY x DESC",
+                "SELECT *\nFROM t\nWHERE x > 1",
+                id="multiline",
+            ),
+            pytest.param(
+                "SELECT *\r\nFROM t\r\nORDER BY x",
+                "SELECT *\r\nFROM t",
+                id="crlf_line_endings",
+            ),
+            # --- trailing content ---
+            pytest.param(
+                "SELECT * FROM t ORDER BY x   ",
+                "SELECT * FROM t",
+                id="trailing_whitespace",
+            ),
+            pytest.param(
+                "SELECT * FROM t ORDER BY x;",
+                "SELECT * FROM t",
+                id="trailing_semicolon",
+            ),
+            # --- edge cases ---
+            pytest.param("ORDER BY x", "", id="just_order_by"),
+            pytest.param(
+                "SELECT * FROM t1 ORDER BY a UNION ALL SELECT * FROM t2 ORDER BY b",
+                "SELECT * FROM t1 ORDER BY a UNION ALL SELECT * FROM t2",
+                id="multiple_top_level_strips_last",
+            ),
+        ],
+    )
+    def test_strip_top_level_order_by(self, query: str, expected: str) -> None:
+        assert strip_top_level_order_by(query) == expected
+
+    @pytest.mark.unit
+    def test_large_query_does_not_hang(self) -> None:
+        base = "SELECT col FROM table_name WHERE " + " AND ".join(
+            f"col_{i} > {i}" for i in range(500)
+        )
+        query = base + " ORDER BY col"
+        assert strip_top_level_order_by(query) == base
+
+    @pytest.mark.unit
+    def test_sql_comment_containing_order_by_is_known_limitation(self) -> None:
+        """Naive parser treats comments as real SQL — known limitation."""
+        query = "SELECT * FROM t -- ORDER BY x"
+        assert strip_top_level_order_by(query) != query
+
+    @pytest.mark.unit
+    def test_string_literal_containing_order_by_is_known_limitation(self) -> None:
+        """Naive parser treats string literals as real SQL — known limitation."""
+        query = "SELECT * FROM t WHERE name = 'ORDER BY'"
+        assert strip_top_level_order_by(query) != query
+
+
+class MockMSSQLSqlAlchemyExecutionEngine(MockSqlAlchemyExecutionEngine):
+    """Mock engine that reports dialect_name as 'mssql'."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        from tests.expectations.metrics.conftest import Dialect, MockSaEngine
+
+        self.engine = MockSaEngine(dialect=Dialect("mssql"))  # type: ignore[assignment]
+
+
+@pytest.fixture
+def mock_mssql_execution_engine():
+    from tests.expectations.metrics.conftest import MockBatchManager
+
+    engine = MockMSSQLSqlAlchemyExecutionEngine()
+    engine._batch_manager = MockBatchManager()
+    return engine
+
+
+class TestQueryRowCountMSSQLOrderByStripping:
+    @pytest.mark.unit
+    @mock.patch.object(sa, "text")
+    @mock.patch.object(
+        QueryMetricProvider, "_get_substituted_batch_subquery_from_query_and_batch_selectable"
+    )
+    @pytest.mark.parametrize(
+        "substituted_query, assert_order_by_present, assert_fragments",
+        [
+            pytest.param(
+                "SELECT * FROM (my_table) AS subselect WHERE x > 1 ORDER BY x DESC",
+                False,
+                ["COUNT(*)"],
+                id="plain_order_by_stripped",
+            ),
+            pytest.param(
+                "SELECT TOP 10 * FROM (my_table) AS subselect WHERE x > 1 ORDER BY x DESC",
+                False,
+                ["TOP 10"],
+                id="top_present_order_by_still_stripped",
+            ),
+            pytest.param(
+                "SELECT * FROM (my_table) AS subselect "
+                "ORDER BY x OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY",
+                True,
+                ["OFFSET"],
+                id="offset_present_order_by_preserved",
+            ),
+            pytest.param(
+                "SELECT * FROM (my_table) AS subselect WHERE x > 1",
+                False,
+                [],
+                id="no_order_by_passes_through",
+            ),
+            pytest.param(
+                "SELECT * FROM (SELECT TOP 5 * FROM my_table ORDER BY x) sub ORDER BY y",
+                False,
+                ["TOP 5", "ORDER BY x"],
+                id="nested_top_outer_order_by_stripped",
+            ),
+        ],
+    )
+    def test_mssql_query_row_count(
+        self,
+        mock_get_sub,
+        mock_text,
+        mock_mssql_execution_engine: MockMSSQLSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+        substituted_query: str,
+        assert_order_by_present: bool,
+        assert_fragments: list[str],
+    ) -> None:
+        mock_get_sub.return_value = substituted_query
+        mock_text.return_value = "*"
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchone.return_value = (42,)
+
+        with mock.patch.object(
+            mock_mssql_execution_engine, "execute_query", return_value=mock_result
+        ):
+            MyQueryRowCount._sqlalchemy(
+                cls=MyQueryRowCount,
+                execution_engine=mock_mssql_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "query_param": "my_query",
+                    "my_query": "SELECT * FROM {batch}",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+
+        actual_sql = mock_text.call_args[0][0]
+        if assert_order_by_present:
+            assert "ORDER BY" in actual_sql
+        for fragment in assert_fragments:
+            assert fragment in actual_sql
+
+    @pytest.mark.unit
+    @mock.patch.object(sa, "text")
+    @mock.patch.object(
+        QueryMetricProvider, "_get_substituted_batch_subquery_from_query_and_batch_selectable"
+    )
+    def test_non_mssql_preserves_order_by(
+        self,
+        mock_get_sub,
+        mock_text,
+        mock_sqlalchemy_execution_engine: MockSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        mock_get_sub.return_value = (
+            "SELECT * FROM (my_table) AS subselect WHERE x > 1 ORDER BY x DESC"
+        )
+        mock_text.return_value = "*"
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchone.return_value = (3,)
+
+        with mock.patch.object(
+            mock_sqlalchemy_execution_engine, "execute_query", return_value=mock_result
+        ):
+            MyQueryRowCount._sqlalchemy(
+                cls=MyQueryRowCount,
+                execution_engine=mock_sqlalchemy_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "query_param": "my_query",
+                    "my_query": "SELECT * FROM {batch} WHERE x > 1 ORDER BY x DESC",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+
+        actual_sql = mock_text.call_args[0][0]
+        assert "ORDER BY" in actual_sql

--- a/tests/integration/data_sources_and_expectations/expectations/test_unexpected_rows_expectation.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_unexpected_rows_expectation.py
@@ -74,8 +74,10 @@ PARTITIONER_AND_EXTRA_DATA_SUPPORTED_DATA_SOURCES: Sequence[DataSourceTestConfig
     # SqliteDatasourceTestConfig(),  # fix me
 ]
 
-# NOTE: MSSQL requires the TOP expression to be used in nested queries that use ORDER BY,
-#       so we have to group by this requirement.
+# NOTE: MSSQL historically required the TOP expression in nested queries that use ORDER BY,
+#       so tests were grouped by this requirement.  Since GX-2551, ORDER BY is automatically
+#       stripped for the COUNT(*) path, so MSSQL can handle ORDER BY without TOP transparently.
+#       The existing TOP/non-TOP test split is kept for backwards-compatibility coverage.
 # strings correspond to `label` property on TestConfig instances
 DATA_SOURCE_TYPES_THAT_REQUIRE_TOP_EXPRESSION = {
     MSSQLDatasourceTestConfig().label,
@@ -577,3 +579,49 @@ def test_success_with_suite_param_other_table_name_with_top_expression(
         expectation, expectation_parameters={suite_param_key: unexpected_rows_query}
     )
     assert result.success
+
+
+MSSQL_ORDER_BY_WITHOUT_TOP_SUCCESS_QUERIES = [
+    "SELECT * FROM {batch} WHERE quantity > 2 ORDER BY quantity DESC",
+    "SELECT * FROM {batch} WHERE quantity > 2 ORDER BY quantity ASC, temperature DESC",
+]
+
+MSSQL_ORDER_BY_WITHOUT_TOP_FAILURE_QUERIES = [
+    "SELECT * FROM {batch} WHERE quantity > 0 ORDER BY quantity DESC",
+]
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=DATA_SOURCES_THAT_REQUIRE_TOP_EXPRESSION,
+    data=TABLE_1,
+)
+@pytest.mark.parametrize("unexpected_rows_query", MSSQL_ORDER_BY_WITHOUT_TOP_SUCCESS_QUERIES)
+def test_mssql_order_by_without_top_works_transparently_success(
+    batch_for_datasource,
+    unexpected_rows_query,
+) -> None:
+    expectation = gxe.UnexpectedRowsExpectation(
+        description="ORDER BY without TOP should work on MSSQL",
+        unexpected_rows_query=unexpected_rows_query,
+    )
+    result = batch_for_datasource.validate(expectation)
+    assert result.success
+    assert result.exception_info.get("raised_exception") is False
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=DATA_SOURCES_THAT_REQUIRE_TOP_EXPRESSION,
+    data=TABLE_1,
+)
+@pytest.mark.parametrize("unexpected_rows_query", MSSQL_ORDER_BY_WITHOUT_TOP_FAILURE_QUERIES)
+def test_mssql_order_by_without_top_works_transparently_failure(
+    batch_for_datasource,
+    unexpected_rows_query,
+) -> None:
+    expectation = gxe.UnexpectedRowsExpectation(
+        description="ORDER BY without TOP should work on MSSQL (failing case)",
+        unexpected_rows_query=unexpected_rows_query,
+    )
+    result = batch_for_datasource.validate(expectation)
+    assert result.success is False
+    assert result.exception_info.get("raised_exception") is False


### PR DESCRIPTION
MSSQL forbids ORDER BY in subqueries unless TOP or OFFSET is present. When `QueryRowCount` wraps a user query in `SELECT COUNT(*) FROM (...)`, a top-level ORDER BY becomes invalid. Since ordering is meaningless for counting, this PR strips it automatically instead of erroring.

The stripping is parentheses-depth-aware so ORDER BY inside window functions and nested subqueries is preserved. Queries with a top-level OFFSET are left untouched because OFFSET follows ORDER BY syntactically and makes it legal in MSSQL subqueries.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!