### PR TITLE
[BUGFIX] Roll back connection after failed retry in _execute_query_with_recovery to prevent SQL Server teardown hang

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1479,7 +1479,18 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             # Connection has an invalid transaction from a previous failed operation
             # Roll back and retry with the same connection
             connection.rollback()
-            return connection.execute(query)  # type: ignore[arg-type] # Selectable union type too broad
+            try:
+                return connection.execute(query)  # type: ignore[arg-type] # Selectable union type too broad
+            except Exception:
+                # Retry also failed - roll back again so the connection is left clean.
+                # Without this, the deactivated transaction causes pyodbc to issue a
+                # blocking ROLLBACK when the persistent SQL Server connection is closed
+                # during teardown, which causes intermittent test hangs.
+                try:
+                    connection.rollback()
+                except Exception:
+                    pass
+                raise
 
     @new_method_or_class(version="0.16.14")
     def execute_query(


### PR DESCRIPTION
When a metric computation fails on a SQL Server persistent connection, `_execute_query_with_recovery` handles the `PendingRollbackError` by rolling back and retrying. If the retry itself also fails (e.g. `pyodbc.ProgrammingError` from a type mismatch like computing `ColumnMean` on a varchar column), the connection is left in a deactivated/pending-rollback state. When teardown later calls `execution_engine.close()`, pyodbc must issue an implicit ROLLBACK to SQL Server before closing the ODBC connection, which occasionally blocks indefinitely and causes intermittent test hangs.

The fix wraps the retry in its own try/except. On failure, an explicit `connection.rollback()` is issued before re-raising, leaving the connection clean so `close()` has nothing to roll back and returns immediately.

SQL Server temp tables are connection-scoped, not transaction-scoped, so rolling back the failed transaction has no effect on any temp tables created before metric execution.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated