### PR TITLE
[MAINTENANCE] Normalize SQL Server column type metrics

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -472,6 +472,7 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             GXSqlDialect.DATABRICKS,
             GXSqlDialect.POSTGRESQL,
             GXSqlDialect.SNOWFLAKE,
+            GXSqlDialect.SQL_SERVER,
             GXSqlDialect.TRINO,
         ]:
             if isinstance(actual_column_type, str):

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -438,6 +438,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             GXSqlDialect.DATABRICKS,
             GXSqlDialect.POSTGRESQL,
             GXSqlDialect.SNOWFLAKE,
+            GXSqlDialect.SQL_SERVER,
             GXSqlDialect.TRINO,
         ]:
             # For these dialects, actual_column_type should be a string or CaseInsensitiveString

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -492,13 +492,21 @@ def _build_column_metadata_result(
         GXSqlDialect.DATABRICKS,
         GXSqlDialect.POSTGRESQL,
         GXSqlDialect.SNOWFLAKE,
+        GXSqlDialect.SQL_SERVER,
         GXSqlDialect.TRINO,
     }
     if dialect_name in case_insensitive_dialects:
         for col in result:
             if col.get("type"):
-                compiled_type = col["type"].compile(dialect=execution_engine.dialect)
-                col["type"] = CaseInsensitiveString(str(compiled_type))
+                # column_reflection_fallback() returns plain strings
+                # if inspector.get_columns() ever fails.
+                if isinstance(col["type"], str):
+                    type_str = col["type"]
+                elif dialect_name == GXSqlDialect.SQL_SERVER:
+                    type_str = type(col["type"]).__name__
+                else:
+                    type_str = str(col["type"].compile(dialect=execution_engine.dialect))
+                col["type"] = CaseInsensitiveString(type_str)
         return [CaseInsensitiveNameDict(col) for col in result]
 
     return result

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -25,6 +25,7 @@ from great_expectations.exceptions import MetricResolutionError
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 from great_expectations.expectations.metrics.util import (
     CaseInsensitiveString,
+    _build_column_metadata_result,
     column_reflection_fallback,
     get_dbms_compatible_metric_domain_kwargs,
     get_dialect_like_pattern_expression,
@@ -1119,55 +1120,37 @@ def test_column_reflection_fallback_redshift_schema_qualified(
 
 
 class TestBuildColumnMetadataResultSQLServer:
-    """Tests for _build_column_metadata_result with SQL Server dialect."""
-
     @staticmethod
-    def _make_mock_engine(mocker: MockerFixture, dialect_name: str = "mssql"):
+    def _make_mock_engine(mocker: MockerFixture):
         mock_engine = mocker.MagicMock(spec=SqlAlchemyExecutionEngine)
         mock_dialect = mocker.MagicMock(spec=Dialect)
-        mock_dialect.name = dialect_name
+        mock_dialect.name = "mssql"
         mock_engine.dialect = mock_dialect
         return mock_engine
 
     @pytest.mark.unit
-    def test_uses_class_name_avoiding_collate(self, mocker: MockerFixture):
-        from great_expectations.expectations.metrics.util import _build_column_metadata_result
-
-        mock_type = mocker.MagicMock(spec=sa.types.VARCHAR)
-        mock_type.__class__ = type("VARCHAR", (), {})
-
-        columns = [{"name": "col1", "type": mock_type}]
+    @pytest.mark.parametrize(
+        "col_type,expected_str",
+        [
+            pytest.param("VARCHAR", "VARCHAR", id="string_from_fallback"),
+            pytest.param("NVARCHAR", "NVARCHAR", id="string_nvarchar_from_fallback"),
+            pytest.param("INTEGER", "INTEGER", id="string_integer_from_fallback"),
+            pytest.param(sa.types.VARCHAR(), "VARCHAR", id="type_engine_varchar"),
+            pytest.param(
+                sa.types.VARCHAR(collation="SQL_Latin1_General_CP1_CI_AS"),
+                "VARCHAR",
+                id="type_engine_varchar_with_collation",
+            ),
+            pytest.param(sa.types.NVARCHAR(), "NVARCHAR", id="type_engine_nvarchar"),
+            pytest.param(sa.types.INTEGER(), "INTEGER", id="type_engine_integer"),
+        ],
+    )
+    def test_type_normalized_to_case_insensitive_string(
+        self, mocker: MockerFixture, col_type, expected_str: str
+    ):
         engine = self._make_mock_engine(mocker)
-
-        result = _build_column_metadata_result(columns, set(), engine)
-
-        assert str(result[0]["type"]) == "VARCHAR"
-        mock_type.compile.assert_not_called()
-
-    @pytest.mark.unit
-    def test_handles_string_type_from_fallback(self, mocker: MockerFixture):
-        from great_expectations.expectations.metrics.util import _build_column_metadata_result
-
-        columns = [{"name": "col1", "type": "VARCHAR"}]
-        engine = self._make_mock_engine(mocker)
-
-        result = _build_column_metadata_result(columns, set(), engine)
+        result = _build_column_metadata_result([{"name": "col1", "type": col_type}], set(), engine)
 
         assert isinstance(result[0]["type"], CaseInsensitiveString)
-        assert str(result[0]["type"]) == "VARCHAR"
-
-    @pytest.mark.unit
-    def test_case_insensitive_comparison(self, mocker: MockerFixture):
-        from great_expectations.expectations.metrics.util import _build_column_metadata_result
-
-        mock_type = mocker.MagicMock()
-        mock_type.__class__ = type("INTEGER", (), {})
-
-        columns = [{"name": "col1", "type": mock_type}]
-        engine = self._make_mock_engine(mocker)
-
-        result = _build_column_metadata_result(columns, set(), engine)
-
-        assert result[0]["type"] == "integer"
-        assert result[0]["type"] == "INTEGER"
-        assert result[0]["type"] == "Integer"
+        assert str(result[0]["type"]) == expected_str
+        assert result[0]["type"] == expected_str.lower()

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -1116,3 +1116,58 @@ def test_column_reflection_fallback_redshift_schema_qualified(
         f"Expected '{expected_table_ref}' in sa.text() calls, but got: {text_calls}"
     )
     assert isinstance(result, list)
+
+
+class TestBuildColumnMetadataResultSQLServer:
+    """Tests for _build_column_metadata_result with SQL Server dialect."""
+
+    @staticmethod
+    def _make_mock_engine(mocker: MockerFixture, dialect_name: str = "mssql"):
+        mock_engine = mocker.MagicMock(spec=SqlAlchemyExecutionEngine)
+        mock_dialect = mocker.MagicMock(spec=Dialect)
+        mock_dialect.name = dialect_name
+        mock_engine.dialect = mock_dialect
+        return mock_engine
+
+    @pytest.mark.unit
+    def test_uses_class_name_avoiding_collate(self, mocker: MockerFixture):
+        from great_expectations.expectations.metrics.util import _build_column_metadata_result
+
+        mock_type = mocker.MagicMock(spec=sa.types.VARCHAR)
+        mock_type.__class__ = type("VARCHAR", (), {})
+
+        columns = [{"name": "col1", "type": mock_type}]
+        engine = self._make_mock_engine(mocker)
+
+        result = _build_column_metadata_result(columns, set(), engine)
+
+        assert str(result[0]["type"]) == "VARCHAR"
+        mock_type.compile.assert_not_called()
+
+    @pytest.mark.unit
+    def test_handles_string_type_from_fallback(self, mocker: MockerFixture):
+        from great_expectations.expectations.metrics.util import _build_column_metadata_result
+
+        columns = [{"name": "col1", "type": "VARCHAR"}]
+        engine = self._make_mock_engine(mocker)
+
+        result = _build_column_metadata_result(columns, set(), engine)
+
+        assert isinstance(result[0]["type"], CaseInsensitiveString)
+        assert str(result[0]["type"]) == "VARCHAR"
+
+    @pytest.mark.unit
+    def test_case_insensitive_comparison(self, mocker: MockerFixture):
+        from great_expectations.expectations.metrics.util import _build_column_metadata_result
+
+        mock_type = mocker.MagicMock()
+        mock_type.__class__ = type("INTEGER", (), {})
+
+        columns = [{"name": "col1", "type": mock_type}]
+        engine = self._make_mock_engine(mocker)
+
+        result = _build_column_metadata_result(columns, set(), engine)
+
+        assert result[0]["type"] == "integer"
+        assert result[0]["type"] == "INTEGER"
+        assert result[0]["type"] == "Integer"

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_of_type.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_of_type.py
@@ -152,20 +152,21 @@ def test_failure(batch_for_datasource: Batch) -> None:
         DatabricksDatasourceTestConfig(),
         PostgreSQLDatasourceTestConfig(),
         SnowflakeDatasourceTestConfig(),
+        SQLServerDatasourceTestConfig(),
     ],
     data=DATA,
 )
 def test_case_insensitive_dialects(batch_for_datasource: Batch) -> None:
     dialect_name = batch_for_datasource.data.execution_engine.engine.dialect.name.lower()
 
-    expected_dialects = ["snowflake", "databricks", "postgresql"]
+    expected_dialects = ["snowflake", "databricks", "postgresql", "mssql"]
     assert dialect_name in expected_dialects, f"Unexpected dialect: {dialect_name}"
 
     if dialect_name == "snowflake":
         base_type = "DECIMAL(38, 0)"
     elif dialect_name == "databricks":
         base_type = "INT"
-    elif dialect_name == "postgresql":
+    elif dialect_name in {"postgresql", "mssql"}:
         base_type = "INTEGER"
     else:
         raise AssertionError(f"Unexpected dialect: {dialect_name}")


### PR DESCRIPTION
## Summary

Fixes a mismatch between the column types produced by the experimental metric repository and those reported by `ExpectColumnValuesToBeOfType` / `ExpectColumnValuesToBeInTypeList` for SQL Server.

- Added `GXSqlDialect.SQL_SERVER` to the `case_insensitive_dialects` set in `_build_column_metadata_result()`, so SQL Server column types are normalized to `CaseInsensitiveString` values
- For SQL Server, type strings are derived from the SQLAlchemy type class name (e.g. `VARCHAR`, `INTEGER`) rather than compiled DDL, which avoids including `COLLATE` clauses in the type string
- Added a defensive guard for the fallback path where `column_reflection_fallback()` returns types as plain strings instead of `TypeEngine` objects
- Added `GXSqlDialect.SQL_SERVER` to the string-comparison dialect lists in `_validate_sqlalchemy()` for both `ExpectColumnValuesToBeOfType` and `ExpectColumnValuesToBeInTypeList`
- Added SQL Server to the `test_case_insensitive_dialects` integration test
- Added parametrized unit tests covering SQL Server type normalization for both `TypeEngine` objects (including ones with collation) and plain string types from the fallback path