### PR TITLE
[FEATURE] Add `FabricDatasource`

### DIFF
--- a/great_expectations/datasource/fluent/__init__.py
+++ b/great_expectations/datasource/fluent/__init__.py
@@ -63,6 +63,9 @@ from great_expectations.datasource.fluent.pandas_azure_blob_storage_datasource i
     PandasAzureBlobStorageDatasource,
 )
 from great_expectations.datasource.fluent.fabric import FabricPowerBIDatasource
+from great_expectations.datasource.fluent.fabric_datasource import (
+    FabricDatasource,
+)
 from great_expectations.datasource.fluent.postgres_datasource import (
     PostgresDatasource,
 )

--- a/great_expectations/datasource/fluent/fabric_datasource.py
+++ b/great_expectations/datasource/fluent/fabric_datasource.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from great_expectations.compatibility import pydantic
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.sql_server_datasource import (
     EntraIDServicePrincipalAuthConnectionDetails,
     SQLServerDatasource,
@@ -21,8 +22,9 @@ class FabricDatasource(SQLServerDatasource):
     """
 
     type: Literal["fabric"] = "fabric"  # type: ignore[assignment]
-    connection_string: EntraIDServicePrincipalAuthConnectionDetails  # type: ignore[assignment]
+    connection_string: EntraIDServicePrincipalAuthConnectionDetails
 
+    @override
     @pydantic.root_validator(pre=True)
     def _convert_root_connection_detail_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Pack top-level connection detail kwargs into ``connection_string``."""

--- a/great_expectations/datasource/fluent/fabric_datasource.py
+++ b/great_expectations/datasource/fluent/fabric_datasource.py
@@ -5,6 +5,8 @@ from typing import Any, Literal
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.sql_server_datasource import (
+    _CONNECTION_DETAIL_FIELDS,
+    _MUTUALLY_EXCLUSIVE_MSG,
     EntraIDServicePrincipalAuthConnectionDetails,
     SQLServerDatasource,
 )
@@ -38,11 +40,6 @@ class FabricDatasource(SQLServerDatasource):
     @pydantic.root_validator(pre=True)
     def _convert_root_connection_detail_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Pack top-level connection detail kwargs into ``connection_string``."""
-        from great_expectations.datasource.fluent.sql_server_datasource import (
-            _CONNECTION_DETAIL_FIELDS,
-            _MUTUALLY_EXCLUSIVE_MSG,
-        )
-
         connection_string = values.get("connection_string")
         connection_details: dict[str, Any] = {}
         for field_name in list(values.keys()):

--- a/great_expectations/datasource/fluent/fabric_datasource.py
+++ b/great_expectations/datasource/fluent/fabric_datasource.py
@@ -10,6 +10,16 @@ from great_expectations.datasource.fluent.sql_server_datasource import (
 )
 
 
+class UnsupportedAuthenticationError(ValueError):
+    """Raised when a non-Entra ID authentication method is used with FabricDatasource."""
+
+    def __init__(self, authentication: str) -> None:
+        super().__init__(
+            f"FabricDatasource only supports Entra ID Service Principal "
+            f"authentication, got {authentication!r}."
+        )
+
+
 class FabricDatasource(SQLServerDatasource):
     """Adds a Microsoft Fabric datasource to the data context.
 
@@ -41,6 +51,9 @@ class FabricDatasource(SQLServerDatasource):
                     raise ValueError(_MUTUALLY_EXCLUSIVE_MSG)
                 connection_details[field_name] = values.pop(field_name)
         if connection_details:
-            connection_details.setdefault("authentication", "Entra ID Service Principal")
+            auth = connection_details.get("authentication", "Entra ID Service Principal")
+            if auth != "Entra ID Service Principal":
+                raise UnsupportedAuthenticationError(auth)
+            connection_details["authentication"] = auth
             values["connection_string"] = connection_details
         return values

--- a/great_expectations/datasource/fluent/fabric_datasource.py
+++ b/great_expectations/datasource/fluent/fabric_datasource.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from great_expectations.compatibility import pydantic
+from great_expectations.datasource.fluent.sql_server_datasource import (
+    EntraIDServicePrincipalAuthConnectionDetails,
+    SQLServerDatasource,
+)
+
+
+class FabricDatasource(SQLServerDatasource):
+    """Adds a Microsoft Fabric datasource to the data context.
+
+    Args:
+        name: The name of this Fabric datasource.
+        connection_string: Structured connection details using Entra ID
+            Service Principal authentication.
+        assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose
+            values are TableAsset or QueryAsset objects.
+    """
+
+    type: Literal["fabric"] = "fabric"  # type: ignore[assignment]
+    connection_string: EntraIDServicePrincipalAuthConnectionDetails  # type: ignore[assignment]
+
+    @pydantic.root_validator(pre=True)
+    def _convert_root_connection_detail_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Pack top-level connection detail kwargs into ``connection_string``."""
+        from great_expectations.datasource.fluent.sql_server_datasource import (
+            _CONNECTION_DETAIL_FIELDS,
+            _MUTUALLY_EXCLUSIVE_MSG,
+        )
+
+        connection_string = values.get("connection_string")
+        connection_details: dict[str, Any] = {}
+        for field_name in list(values.keys()):
+            if field_name in _CONNECTION_DETAIL_FIELDS:
+                if connection_string is not None:
+                    raise ValueError(_MUTUALLY_EXCLUSIVE_MSG)
+                connection_details[field_name] = values.pop(field_name)
+        if connection_details:
+            connection_details.setdefault("authentication", "Entra ID Service Principal")
+            values["connection_string"] = connection_details
+        return values

--- a/great_expectations/datasource/fluent/schemas/FabricDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/FabricDatasource.json
@@ -1,0 +1,604 @@
+{
+    "title": "FabricDatasource",
+    "description": "Adds a Microsoft Fabric datasource to the data context.\n\nArgs:\n    name: The name of this Fabric datasource.\n    connection_string: Structured connection details using Entra ID\n        Service Principal authentication.\n    assets: An optional dictionary whose keys are TableAsset or QueryAsset names and whose\n        values are TableAsset or QueryAsset objects.",
+    "type": "object",
+    "properties": {
+        "type": {
+            "title": "Type",
+            "default": "fabric",
+            "enum": [
+                "fabric"
+            ],
+            "type": "string"
+        },
+        "name": {
+            "title": "Name",
+            "type": "string"
+        },
+        "id": {
+            "title": "Id",
+            "description": "Datasource id",
+            "type": "string",
+            "format": "uuid"
+        },
+        "assets": {
+            "title": "Assets",
+            "default": [],
+            "type": "array",
+            "items": {
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "table": "#/definitions/TableAsset",
+                        "query": "#/definitions/QueryAsset"
+                    }
+                },
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/TableAsset"
+                    },
+                    {
+                        "$ref": "#/definitions/QueryAsset"
+                    }
+                ]
+            }
+        },
+        "connection_string": {
+            "$ref": "#/definitions/EntraIDServicePrincipalAuthConnectionDetails"
+        },
+        "create_temp_table": {
+            "title": "Create Temp Table",
+            "default": false,
+            "type": "boolean"
+        },
+        "kwargs": {
+            "title": "Kwargs",
+            "description": "Optional dictionary of `kwargs` will be passed to the SQLAlchemy Engine as part of `create_engine(connection_string, **kwargs)`",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "writeOnly": true,
+                        "format": "password",
+                        "description": "Contains config templates to be substituted at runtime. Runtime values will never be serialized.",
+                        "pattern": ".*(?<!\\\\)\\$\\{(.*?)\\}|(?<!\\\\)\\$([_a-zA-Z][_a-zA-Z0-9]*).*",
+                        "examples": [
+                            "hello_${NAME}",
+                            "${MY_CFG_VAR}"
+                        ]
+                    },
+                    {}
+                ]
+            }
+        }
+    },
+    "required": [
+        "name",
+        "connection_string"
+    ],
+    "additionalProperties": false,
+    "definitions": {
+        "Sorter": {
+            "title": "Sorter",
+            "type": "object",
+            "properties": {
+                "key": {
+                    "title": "Key",
+                    "type": "string"
+                },
+                "reverse": {
+                    "title": "Reverse",
+                    "default": false,
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "key"
+            ]
+        },
+        "PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ]
+        },
+        "PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ]
+        },
+        "PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "type": "object",
+            "properties": {
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                },
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "divisor",
+                "column_name"
+            ]
+        },
+        "PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "type": "object",
+            "properties": {
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                },
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "mod",
+                "column_name"
+            ]
+        },
+        "ColumnPartitionerYearly": {
+            "title": "ColumnPartitionerYearly",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ]
+        },
+        "ColumnPartitionerMonthly": {
+            "title": "ColumnPartitionerMonthly",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ]
+        },
+        "ColumnPartitionerDaily": {
+            "title": "ColumnPartitionerDaily",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ]
+        },
+        "PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "type": "object",
+            "properties": {
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "datetime_parts",
+                "column_name"
+            ]
+        },
+        "PartitionerConvertedDatetime": {
+            "title": "PartitionerConvertedDatetime",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "sort_ascending": {
+                    "title": "Sort Ascending",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_converted_datetime",
+                    "enum": [
+                        "partition_on_converted_datetime"
+                    ],
+                    "type": "string"
+                },
+                "date_format_string": {
+                    "title": "Date Format String",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name",
+                "date_format_string"
+            ]
+        },
+        "BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__": {
+            "title": "BatchDefinition[Union[PartitionerColumnValue, PartitionerMultiColumnValue, PartitionerDividedInteger, PartitionerModInteger, ColumnPartitionerYearly, ColumnPartitionerMonthly, ColumnPartitionerDaily, PartitionerDatetimePart, PartitionerConvertedDatetime]]",
+            "description": "--Public API--Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnPartitionerYearly"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnPartitionerMonthly"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnPartitionerDaily"
+                        },
+                        {
+                            "$ref": "#/definitions/PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/PartitionerConvertedDatetime"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "TableAsset": {
+            "title": "TableAsset",
+            "description": "--Public API--A class representing a table from a SQL database\n\nArgs:\n    table_name: The name of the database table to be added\n    schema_name: The name of the schema containing the database table to be added.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "Type",
+                    "default": "table",
+                    "enum": [
+                        "table"
+                    ],
+                    "type": "string"
+                },
+                "id": {
+                    "title": "Id",
+                    "description": "DataAsset id",
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "order_by": {
+                    "title": "Order By",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
+                },
+                "batch_metadata": {
+                    "title": "Batch Metadata",
+                    "type": "object"
+                },
+                "batch_definitions": {
+                    "title": "Batch Definitions",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                    }
+                },
+                "table_name": {
+                    "title": "Table Name",
+                    "description": "Name of the SQL table. Will default to the value of `name` if not provided.",
+                    "default": "",
+                    "type": "string"
+                },
+                "schema_name": {
+                    "title": "Schema Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "QueryAsset": {
+            "title": "QueryAsset",
+            "description": "--Public API--An asset made from a SQL query\n\nArgs:\n    query: The query to be used to construct the underlying Data Asset",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "Type",
+                    "default": "query",
+                    "enum": [
+                        "query"
+                    ],
+                    "type": "string"
+                },
+                "id": {
+                    "title": "Id",
+                    "description": "DataAsset id",
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "order_by": {
+                    "title": "Order By",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
+                },
+                "batch_metadata": {
+                    "title": "Batch Metadata",
+                    "type": "object"
+                },
+                "batch_definitions": {
+                    "title": "Batch Definitions",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/BatchDefinition_Union_PartitionerColumnValue__PartitionerMultiColumnValue__PartitionerDividedInteger__PartitionerModInteger__ColumnPartitionerYearly__ColumnPartitionerMonthly__ColumnPartitionerDaily__PartitionerDatetimePart__PartitionerConvertedDatetime__"
+                    }
+                },
+                "query": {
+                    "title": "Query",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "query"
+            ],
+            "additionalProperties": false
+        },
+        "EntraIDServicePrincipalAuthConnectionDetails": {
+            "title": "EntraIDServicePrincipalAuthConnectionDetails",
+            "description": "Entra ID Service Principal authentication.",
+            "type": "object",
+            "properties": {
+                "host": {
+                    "title": "Host",
+                    "type": "string"
+                },
+                "port": {
+                    "title": "Port",
+                    "default": 1433,
+                    "type": "integer"
+                },
+                "database": {
+                    "title": "Database",
+                    "type": "string"
+                },
+                "schema": {
+                    "title": "Schema",
+                    "type": "string"
+                },
+                "driver": {
+                    "title": "Driver",
+                    "default": "ODBC Driver 18 for SQL Server",
+                    "type": "string"
+                },
+                "encrypt": {
+                    "title": "Encrypt",
+                    "default": "Mandatory",
+                    "enum": [
+                        "Mandatory",
+                        "Optional",
+                        "Strict"
+                    ],
+                    "type": "string"
+                },
+                "authentication": {
+                    "title": "Authentication",
+                    "default": "Entra ID Service Principal",
+                    "enum": [
+                        "Entra ID Service Principal"
+                    ],
+                    "type": "string"
+                },
+                "client_id": {
+                    "title": "Client Id",
+                    "type": "string"
+                },
+                "client_secret": {
+                    "title": "Client Secret",
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "writeOnly": true,
+                            "format": "password",
+                            "description": "Contains config templates to be substituted at runtime. Runtime values will never be serialized.",
+                            "pattern": ".*(?<!\\\\)\\$\\{(.*?)\\}|(?<!\\\\)\\$([_a-zA-Z][_a-zA-Z0-9]*).*",
+                            "examples": [
+                                "hello_${NAME}",
+                                "${MY_CFG_VAR}"
+                            ]
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "tenant_id": {
+                    "title": "Tenant Id",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "host",
+                "database",
+                "schema",
+                "client_id",
+                "client_secret",
+                "tenant_id"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/great_expectations/datasource/fluent/schemas/FabricDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/FabricDatasource.json
@@ -562,6 +562,10 @@
                     ],
                     "type": "string"
                 },
+                "tenant_id": {
+                    "title": "Tenant Id",
+                    "type": "string"
+                },
                 "client_id": {
                     "title": "Client Id",
                     "type": "string"
@@ -584,19 +588,15 @@
                             "type": "string"
                         }
                     ]
-                },
-                "tenant_id": {
-                    "title": "Tenant Id",
-                    "type": "string"
                 }
             },
             "required": [
                 "host",
                 "database",
                 "schema",
+                "tenant_id",
                 "client_id",
-                "client_secret",
-                "tenant_id"
+                "client_secret"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/datasource/fluent/schemas/SQLServerDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLServerDatasource.json
@@ -655,6 +655,10 @@
                     ],
                     "type": "string"
                 },
+                "tenant_id": {
+                    "title": "Tenant Id",
+                    "type": "string"
+                },
                 "client_id": {
                     "title": "Client Id",
                     "type": "string"
@@ -677,19 +681,15 @@
                             "type": "string"
                         }
                     ]
-                },
-                "tenant_id": {
-                    "title": "Tenant Id",
-                    "type": "string"
                 }
             },
             "required": [
                 "host",
                 "database",
                 "schema",
+                "tenant_id",
                 "client_id",
-                "client_secret",
-                "tenant_id"
+                "client_secret"
             ],
             "additionalProperties": false
         }

--- a/great_expectations/datasource/fluent/sources.pyi
+++ b/great_expectations/datasource/fluent/sources.pyi
@@ -46,6 +46,9 @@ from great_expectations.datasource.fluent import (
 )
 from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.databricks_sql_datasource import DatabricksDsn
+from great_expectations.datasource.fluent.fabric_datasource import (
+    FabricDatasource,
+)
 from great_expectations.datasource.fluent.interfaces import (
     DataAsset,
     Datasource,
@@ -62,6 +65,7 @@ from great_expectations.datasource.fluent.snowflake_datasource import (
 )
 from great_expectations.datasource.fluent.spark_datasource import SparkConfig
 from great_expectations.datasource.fluent.sql_server_datasource import (
+    EntraIDServicePrincipalAuthConnectionDetails,
     SQLServerConnectionDetails,
 )
 from great_expectations.datasource.fluent.sqlite_datasource import SqliteDsn
@@ -936,6 +940,76 @@ class DataSourceManager:
         tenant_id: str = ...,
     ) -> SQLServerDatasource: ...
     def delete_sql_server(
+        self,
+        name: str,
+    ) -> None: ...
+    @overload
+    def add_fabric(
+        self,
+        name: str,
+        *,
+        connection_string: EntraIDServicePrincipalAuthConnectionDetails = ...,
+    ) -> FabricDatasource: ...
+    @overload
+    def add_fabric(
+        self,
+        name: str,
+        *,
+        host: str = ...,
+        port: int = ...,
+        database: str = ...,
+        schema: str = ...,
+        driver: str = ...,
+        encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
+        client_id: str = ...,
+        client_secret: Union[ConfigStr, str] = ...,
+        tenant_id: str = ...,
+    ) -> FabricDatasource: ...
+    @overload
+    def update_fabric(
+        self,
+        name: str,
+        *,
+        connection_string: EntraIDServicePrincipalAuthConnectionDetails = ...,
+    ) -> FabricDatasource: ...
+    @overload
+    def update_fabric(
+        self,
+        name: str,
+        *,
+        host: str = ...,
+        port: int = ...,
+        database: str = ...,
+        schema: str = ...,
+        driver: str = ...,
+        encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
+        client_id: str = ...,
+        client_secret: Union[ConfigStr, str] = ...,
+        tenant_id: str = ...,
+    ) -> FabricDatasource: ...
+    @overload
+    def add_or_update_fabric(
+        self,
+        name: str,
+        *,
+        connection_string: EntraIDServicePrincipalAuthConnectionDetails = ...,
+    ) -> FabricDatasource: ...
+    @overload
+    def add_or_update_fabric(
+        self,
+        name: str,
+        *,
+        host: str = ...,
+        port: int = ...,
+        database: str = ...,
+        schema: str = ...,
+        driver: str = ...,
+        encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
+        client_id: str = ...,
+        client_secret: Union[ConfigStr, str] = ...,
+        tenant_id: str = ...,
+    ) -> FabricDatasource: ...
+    def delete_fabric(
         self,
         name: str,
     ) -> None: ...

--- a/great_expectations/datasource/fluent/sources.pyi
+++ b/great_expectations/datasource/fluent/sources.pyi
@@ -859,9 +859,9 @@ class DataSourceManager:
         driver: str = ...,
         encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
         authentication: Literal["Entra ID Service Principal"] = ...,
+        tenant_id: str = ...,
         client_id: str = ...,
         client_secret: Union[ConfigStr, str] = ...,
-        tenant_id: str = ...,
     ) -> SQLServerDatasource: ...
     @overload
     def update_sql_server(
@@ -897,9 +897,9 @@ class DataSourceManager:
         driver: str = ...,
         encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
         authentication: Literal["Entra ID Service Principal"] = ...,
+        tenant_id: str = ...,
         client_id: str = ...,
         client_secret: Union[ConfigStr, str] = ...,
-        tenant_id: str = ...,
     ) -> SQLServerDatasource: ...
     @overload
     def add_or_update_sql_server(
@@ -935,9 +935,9 @@ class DataSourceManager:
         driver: str = ...,
         encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
         authentication: Literal["Entra ID Service Principal"] = ...,
+        tenant_id: str = ...,
         client_id: str = ...,
         client_secret: Union[ConfigStr, str] = ...,
-        tenant_id: str = ...,
     ) -> SQLServerDatasource: ...
     def delete_sql_server(
         self,
@@ -961,9 +961,9 @@ class DataSourceManager:
         schema: str = ...,
         driver: str = ...,
         encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
+        tenant_id: str = ...,
         client_id: str = ...,
         client_secret: Union[ConfigStr, str] = ...,
-        tenant_id: str = ...,
     ) -> FabricDatasource: ...
     @overload
     def update_fabric(
@@ -983,9 +983,9 @@ class DataSourceManager:
         schema: str = ...,
         driver: str = ...,
         encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
+        tenant_id: str = ...,
         client_id: str = ...,
         client_secret: Union[ConfigStr, str] = ...,
-        tenant_id: str = ...,
     ) -> FabricDatasource: ...
     @overload
     def add_or_update_fabric(
@@ -1005,9 +1005,9 @@ class DataSourceManager:
         schema: str = ...,
         driver: str = ...,
         encrypt: Literal["Mandatory", "Optional", "Strict"] = ...,
+        tenant_id: str = ...,
         client_id: str = ...,
         client_secret: Union[ConfigStr, str] = ...,
-        tenant_id: str = ...,
     ) -> FabricDatasource: ...
     def delete_fabric(
         self,

--- a/great_expectations/datasource/fluent/sql_server_datasource.py
+++ b/great_expectations/datasource/fluent/sql_server_datasource.py
@@ -112,9 +112,9 @@ class EntraIDServicePrincipalAuthConnectionDetails(_SQLServerConnectionDetailsBa
     """Entra ID Service Principal authentication."""
 
     authentication: Literal["Entra ID Service Principal"] = "Entra ID Service Principal"
+    tenant_id: str
     client_id: str
     client_secret: Union[ConfigStr, str]
-    tenant_id: str
 
     @override
     def build_connection_string(

--- a/great_expectations/datasource/fluent/sql_server_datasource.py
+++ b/great_expectations/datasource/fluent/sql_server_datasource.py
@@ -223,11 +223,11 @@ class SQLServerDatasource(SQLDatasource):
                     if isinstance(
                         self.connection_string, EntraIDServicePrincipalAuthConnectionDetails
                     ):
-                        raise SQLServerPrincipalAuthError(e.cause) from e
+                        raise MSSQLPrincipalAuthError(e.cause) from e
                     else:
-                        raise SQLServerPasswordAuthError(e.cause) from e
+                        raise MSSQLPasswordAuthError(e.cause) from e
                 else:
-                    raise SQLServerNetworkError(e.cause) from e
+                    raise MSSQLNetworkError(e.cause) from e
             elif isinstance(
                 e.cause, (pyodbc.InterfaceError, sa.exc.DBAPIError)
             ) and "file not found" in str(e.cause):
@@ -254,7 +254,7 @@ class ConfigStrError(ValueError):
         )
 
 
-class SQLServerNetworkError(TestConnectionError):
+class MSSQLNetworkError(TestConnectionError):
     """Raised when a connection test fails due to a network error."""
 
     def __init__(self, cause: pyodbc.OperationalError) -> None:
@@ -262,15 +262,15 @@ class SQLServerNetworkError(TestConnectionError):
             cause=cause,
             message=" ".join(
                 [
-                    "Unable to connect to SQL Server.",
+                    "Unable to connect to the database server.",
                     "Verify the host and port are correct and the server is accessible.",
                 ]
             ),
         )
 
 
-class SQLServerPasswordAuthError(TestConnectionError):
-    """Raised when a connection test fails due to a authentication error."""
+class MSSQLPasswordAuthError(TestConnectionError):
+    """Raised when a connection test fails due to an authentication error."""
 
     def __init__(self, cause: pyodbc.OperationalError) -> None:
         super().__init__(
@@ -279,8 +279,8 @@ class SQLServerPasswordAuthError(TestConnectionError):
         )
 
 
-class SQLServerPrincipalAuthError(TestConnectionError):
-    """Raised when a connection test fails due to a authentication error."""
+class MSSQLPrincipalAuthError(TestConnectionError):
+    """Raised when a connection test fails due to an authentication error."""
 
     def __init__(self, cause: pyodbc.OperationalError) -> None:
         super().__init__(
@@ -296,3 +296,9 @@ class MissingODBCDriverError(TestConnectionError):
         super().__init__(
             cause=cause, message="ODBC driver not found. Ensure the specified driver is installed."
         )
+
+
+# Backwards-compatible aliases
+SQLServerNetworkError = MSSQLNetworkError
+SQLServerPasswordAuthError = MSSQLPasswordAuthError
+SQLServerPrincipalAuthError = MSSQLPrincipalAuthError

--- a/great_expectations/datasource/fluent/sql_server_datasource.py
+++ b/great_expectations/datasource/fluent/sql_server_datasource.py
@@ -296,9 +296,3 @@ class MissingODBCDriverError(TestConnectionError):
         super().__init__(
             cause=cause, message="ODBC driver not found. Ensure the specified driver is installed."
         )
-
-
-# Backwards-compatible aliases
-SQLServerNetworkError = MSSQLNetworkError
-SQLServerPasswordAuthError = MSSQLPasswordAuthError
-SQLServerPrincipalAuthError = MSSQLPrincipalAuthError

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ def get_extras_require():
     extra_key_mapping = {
         "aws_secrets": "boto",
         "azure_secrets": "azure",
+        "fabric": "sql-server",
         "gcp": "bigquery",
         "s3": "boto",
     }

--- a/tests/datasource/fluent/test_fabric_datasource.py
+++ b/tests/datasource/fluent/test_fabric_datasource.py
@@ -29,9 +29,9 @@ def entra_id_connection_details() -> ConnectionDetailsDict:
         "driver": "ODBC Driver 18 for SQL Server",
         "encrypt": "Mandatory",
         "authentication": "Entra ID Service Principal",
+        "tenant_id": "my-tenant-id-456",
         "client_id": "my-client-id-123",
         "client_secret": "my-secret",
-        "tenant_id": "my-tenant-id-456",
     }
 
 
@@ -85,9 +85,9 @@ class TestAddFabricDatasourceAPI:
                 host="myserver.database.fabric.microsoft.com",
                 database="mydb",
                 schema="dbo",
+                tenant_id="my-tenant-id-456",
                 client_id="my-client-id-123",
                 client_secret="my-secret",
-                tenant_id="my-tenant-id-456",
             ),
         )
         assert isinstance(source, FabricDatasource)
@@ -103,9 +103,9 @@ class TestAddFabricDatasourceAPI:
             host="myserver.database.fabric.microsoft.com",
             database="mydb",
             schema="dbo",
+            tenant_id="my-tenant-id-456",
             client_id="my-client-id-123",
             client_secret="my-secret",
-            tenant_id="my-tenant-id-456",
         )
         assert isinstance(source.connection_string, EntraIDServicePrincipalAuthConnectionDetails)
         assert source.connection_string.authentication == "Entra ID Service Principal"

--- a/tests/datasource/fluent/test_fabric_datasource.py
+++ b/tests/datasource/fluent/test_fabric_datasource.py
@@ -1,26 +1,17 @@
 from __future__ import annotations
 
-import functools
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
 
 import pytest
 
 from great_expectations.compatibility.pydantic import ValidationError
-from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.datasource.fluent.fabric_datasource import FabricDatasource
-from great_expectations.datasource.fluent.interfaces import TestConnectionError
 from great_expectations.datasource.fluent.sql_server_datasource import (
     EntraIDServicePrincipalAuthConnectionDetails,
-    MissingODBCDriverError,
-    MSSQLNetworkError,
-    MSSQLPrincipalAuthError,
     SQLServerAuthConnectionDetails,
 )
 
 if TYPE_CHECKING:
-    from typing import Callable, Union
-
     from typing_extensions import TypeAlias
 
     from great_expectations.data_context import AbstractDataContext
@@ -55,26 +46,6 @@ class TestFabricDatasource:
         )
         assert ds.type == "fabric"
 
-    def test_schema_property(self, entra_id_connection_details: ConnectionDetailsDict) -> None:
-        ds = FabricDatasource(
-            name="test_ds",
-            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                **entra_id_connection_details
-            ),
-        )
-        assert ds.schema_ == "dbo"
-
-    def test_connection_string_type(
-        self, entra_id_connection_details: ConnectionDetailsDict
-    ) -> None:
-        ds = FabricDatasource(
-            name="test_ds",
-            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                **entra_id_connection_details
-            ),
-        )
-        assert isinstance(ds.connection_string, EntraIDServicePrincipalAuthConnectionDetails)
-
     def test_rejects_sql_server_auth(self) -> None:
         with pytest.raises(ValidationError):
             FabricDatasource(
@@ -87,78 +58,6 @@ class TestFabricDatasource:
                     password="mypassword",
                 ),
             )
-
-    @pytest.mark.usefixtures("create_engine_fake")
-    def test_get_engine(self, entra_id_connection_details: ConnectionDetailsDict) -> None:
-        ds = FabricDatasource(
-            name="test_ds",
-            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                **entra_id_connection_details
-            ),
-        )
-        engine = ds.get_engine()
-        assert engine is not None
-
-    @pytest.mark.usefixtures("create_engine_fake")
-    def test_get_engine_caches(self, entra_id_connection_details: ConnectionDetailsDict) -> None:
-        ds = FabricDatasource(
-            name="test_ds",
-            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                **entra_id_connection_details
-            ),
-        )
-        engine1 = ds.get_engine()
-        engine2 = ds.get_engine()
-        assert engine1 is engine2
-
-
-@pytest.mark.unit
-class TestFabricBuildConnectionString:
-    def test_basic_connection_string(
-        self, entra_id_connection_details: ConnectionDetailsDict
-    ) -> None:
-        ds = FabricDatasource(
-            name="test_ds",
-            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                **entra_id_connection_details
-            ),
-        )
-        result = ds._build_connection_string()
-        assert "mssql+pyodbc://@myserver.database.fabric.microsoft.com:1433/mydb" in result
-        assert "authentication=ActiveDirectoryServicePrincipal" in result
-        assert "UID=my-client-id-123" in result
-        assert "PWD=my-secret" in result
-
-    def test_encrypt_optional(self) -> None:
-        ds = FabricDatasource(
-            name="test_ds",
-            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                host="myserver.database.fabric.microsoft.com",
-                database="mydb",
-                schema="dbo",
-                encrypt="Optional",
-                client_id="my-client-id",
-                client_secret="secret",
-                tenant_id="my-tenant-id",
-            ),
-        )
-        result = ds._build_connection_string()
-        assert "Encrypt=no" in result
-
-    def test_special_chars_in_client_secret(self) -> None:
-        ds = FabricDatasource(
-            name="test_ds",
-            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                host="myserver.database.fabric.microsoft.com",
-                database="mydb",
-                schema="dbo",
-                client_id="my-client-id",
-                client_secret="p@ss:w/rd",
-                tenant_id="my-tenant-id",
-            ),
-        )
-        result = ds._build_connection_string()
-        assert "p%40ss%3Aw%2Frd" in result
 
 
 @pytest.mark.unit
@@ -179,27 +78,11 @@ class TestAddFabricDatasourceAPI:
                 tenant_id="my-tenant-id-456",
             ),
         )
-        assert source.dict(by_alias=True, exclude_unset=False, exclude={"id"}) == {
-            "type": "fabric",
-            "name": "my_fabric",
-            "connection_string": {
-                "host": "myserver.database.fabric.microsoft.com",
-                "port": 1433,
-                "database": "mydb",
-                "schema": "dbo",
-                "driver": "ODBC Driver 18 for SQL Server",
-                "encrypt": "Mandatory",
-                "authentication": "Entra ID Service Principal",
-                "client_id": "my-client-id-123",
-                "client_secret": "my-secret",
-                "tenant_id": "my-tenant-id-456",
-            },
-            "create_temp_table": False,
-            "kwargs": {},
-            "assets": [],
-        }
+        assert isinstance(source, FabricDatasource)
+        assert source.type == "fabric"
+        assert source.name == "my_fabric"
 
-    def test_add_fabric_with_flat_kwargs(
+    def test_add_fabric_with_flat_kwargs_defaults_to_entra_id(
         self,
         empty_data_context: AbstractDataContext,
     ) -> None:
@@ -212,120 +95,5 @@ class TestAddFabricDatasourceAPI:
             client_secret="my-secret",
             tenant_id="my-tenant-id-456",
         )
-        assert source.dict(by_alias=True, exclude_unset=False, exclude={"id"}) == {
-            "type": "fabric",
-            "name": "my_fabric_flat",
-            "connection_string": {
-                "host": "myserver.database.fabric.microsoft.com",
-                "port": 1433,
-                "database": "mydb",
-                "schema": "dbo",
-                "driver": "ODBC Driver 18 for SQL Server",
-                "encrypt": "Mandatory",
-                "authentication": "Entra ID Service Principal",
-                "client_id": "my-client-id-123",
-                "client_secret": "my-secret",
-                "tenant_id": "my-tenant-id-456",
-            },
-            "create_temp_table": False,
-            "kwargs": {},
-            "assets": [],
-        }
-
-    def test_add_fabric_flat_kwargs_rejects_connection_string_and_kwargs(
-        self,
-        empty_data_context: AbstractDataContext,
-    ) -> None:
-        with pytest.raises(ValueError, match="not both"):
-            empty_data_context.data_sources.add_fabric(
-                name="bad",
-                connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-                    host="h",
-                    database="d",
-                    schema="s",
-                    client_id="c",
-                    client_secret="s",
-                    tenant_id="t",
-                ),
-                host="other_host",
-            )
-
-
-def _make_mock_engine(connect_exception: Exception):
-    class _MockEngine:
-        def connect(self):
-            raise connect_exception
-
-    return _MockEngine()
-
-
-def with_mock_engine_raising(
-    connect_exception: Union[Exception, Callable[[], Exception]],
-) -> Callable:
-    def decorator(func: Callable) -> Callable:
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            exc = connect_exception() if callable(connect_exception) else connect_exception
-            mock_engine = _make_mock_engine(exc)
-            with patch.object(FabricDatasource, "get_engine", return_value=mock_engine):
-                return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-@pytest.fixture
-def fabric_datasource() -> FabricDatasource:
-    return FabricDatasource(
-        name="test_ds",
-        connection_string=EntraIDServicePrincipalAuthConnectionDetails(
-            host="myserver.database.fabric.microsoft.com",
-            database="mydb",
-            schema="dbo",
-            client_id="my-client-id",
-            client_secret="my-secret",
-            tenant_id="my-tenant-id",
-        ),
-    )
-
-
-@pytest.mark.sql_server
-class TestFabricDatasourceTestConnectionErrors:
-    @with_mock_engine_raising(sa.exc.OperationalError("Login failed for user", None, Exception()))
-    def test_login_failure_raises_principal_auth_error(
-        self, fabric_datasource: FabricDatasource
-    ) -> None:
-        """OperationalError with 'Login' -> MSSQLPrincipalAuthError."""
-        with pytest.raises(MSSQLPrincipalAuthError):
-            fabric_datasource.test_connection()
-
-    @with_mock_engine_raising(
-        sa.exc.OperationalError("Unable to connect: connection refused", None, Exception())
-    )
-    def test_network_error_raises_network_error(self, fabric_datasource: FabricDatasource) -> None:
-        """OperationalError without 'Login' -> MSSQLNetworkError."""
-        with pytest.raises(MSSQLNetworkError):
-            fabric_datasource.test_connection()
-
-    @with_mock_engine_raising(
-        sa.exc.DBAPIError(
-            "ODBC Driver 18 for SQL Server not found: file not found", None, Exception()
-        )
-    )
-    def test_missing_odbc_driver_raises_missing_odbc_driver_error(
-        self, fabric_datasource: FabricDatasource
-    ) -> None:
-        """DBAPIError with 'file not found' -> MissingODBCDriverError."""
-        with pytest.raises(MissingODBCDriverError):
-            fabric_datasource.test_connection()
-
-    @with_mock_engine_raising(ValueError("Something unexpected happened"))
-    def test_unhandled_error_reraises_test_connection_error(
-        self, fabric_datasource: FabricDatasource
-    ) -> None:
-        """Unhandled exception types -> original TestConnectionError re-raised."""
-        with pytest.raises(TestConnectionError) as exc_info:
-            fabric_datasource.test_connection()
-        assert isinstance(exc_info.value.cause, ValueError)
-        assert "Something unexpected" in str(exc_info.value.cause)
+        assert isinstance(source.connection_string, EntraIDServicePrincipalAuthConnectionDetails)
+        assert source.connection_string.authentication == "Entra ID Service Principal"

--- a/tests/datasource/fluent/test_fabric_datasource.py
+++ b/tests/datasource/fluent/test_fabric_datasource.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from great_expectations.compatibility.pydantic import ValidationError
+from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
+from great_expectations.datasource.fluent.fabric_datasource import FabricDatasource
+from great_expectations.datasource.fluent.interfaces import TestConnectionError
+from great_expectations.datasource.fluent.sql_server_datasource import (
+    EntraIDServicePrincipalAuthConnectionDetails,
+    MissingODBCDriverError,
+    MSSQLNetworkError,
+    MSSQLPrincipalAuthError,
+    SQLServerAuthConnectionDetails,
+)
+
+if TYPE_CHECKING:
+    from typing import Callable, Union
+
+    from typing_extensions import TypeAlias
+
+    from great_expectations.data_context import AbstractDataContext
+
+ConnectionDetailsDict: TypeAlias = dict[str, Any]
+
+
+@pytest.fixture
+def entra_id_connection_details() -> ConnectionDetailsDict:
+    return {
+        "host": "myserver.database.fabric.microsoft.com",
+        "port": 1433,
+        "database": "mydb",
+        "schema": "dbo",
+        "driver": "ODBC Driver 18 for SQL Server",
+        "encrypt": "Mandatory",
+        "authentication": "Entra ID Service Principal",
+        "client_id": "my-client-id-123",
+        "client_secret": "my-secret",
+        "tenant_id": "my-tenant-id-456",
+    }
+
+
+@pytest.mark.unit
+class TestFabricDatasource:
+    def test_type_literal(self, entra_id_connection_details: ConnectionDetailsDict) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                **entra_id_connection_details
+            ),
+        )
+        assert ds.type == "fabric"
+
+    def test_schema_property(self, entra_id_connection_details: ConnectionDetailsDict) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                **entra_id_connection_details
+            ),
+        )
+        assert ds.schema_ == "dbo"
+
+    def test_connection_string_type(
+        self, entra_id_connection_details: ConnectionDetailsDict
+    ) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                **entra_id_connection_details
+            ),
+        )
+        assert isinstance(ds.connection_string, EntraIDServicePrincipalAuthConnectionDetails)
+
+    def test_rejects_sql_server_auth(self) -> None:
+        with pytest.raises(ValidationError):
+            FabricDatasource(
+                name="test_ds",
+                connection_string=SQLServerAuthConnectionDetails(
+                    host="myserver",
+                    database="mydb",
+                    schema="dbo",
+                    username="myuser",
+                    password="mypassword",
+                ),
+            )
+
+    @pytest.mark.usefixtures("create_engine_fake")
+    def test_get_engine(self, entra_id_connection_details: ConnectionDetailsDict) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                **entra_id_connection_details
+            ),
+        )
+        engine = ds.get_engine()
+        assert engine is not None
+
+    @pytest.mark.usefixtures("create_engine_fake")
+    def test_get_engine_caches(self, entra_id_connection_details: ConnectionDetailsDict) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                **entra_id_connection_details
+            ),
+        )
+        engine1 = ds.get_engine()
+        engine2 = ds.get_engine()
+        assert engine1 is engine2
+
+
+@pytest.mark.unit
+class TestFabricBuildConnectionString:
+    def test_basic_connection_string(
+        self, entra_id_connection_details: ConnectionDetailsDict
+    ) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                **entra_id_connection_details
+            ),
+        )
+        result = ds._build_connection_string()
+        assert "mssql+pyodbc://@myserver.database.fabric.microsoft.com:1433/mydb" in result
+        assert "authentication=ActiveDirectoryServicePrincipal" in result
+        assert "UID=my-client-id-123" in result
+        assert "PWD=my-secret" in result
+
+    def test_encrypt_optional(self) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                host="myserver.database.fabric.microsoft.com",
+                database="mydb",
+                schema="dbo",
+                encrypt="Optional",
+                client_id="my-client-id",
+                client_secret="secret",
+                tenant_id="my-tenant-id",
+            ),
+        )
+        result = ds._build_connection_string()
+        assert "Encrypt=no" in result
+
+    def test_special_chars_in_client_secret(self) -> None:
+        ds = FabricDatasource(
+            name="test_ds",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                host="myserver.database.fabric.microsoft.com",
+                database="mydb",
+                schema="dbo",
+                client_id="my-client-id",
+                client_secret="p@ss:w/rd",
+                tenant_id="my-tenant-id",
+            ),
+        )
+        result = ds._build_connection_string()
+        assert "p%40ss%3Aw%2Frd" in result
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mock_test_connection")
+class TestAddFabricDatasourceAPI:
+    def test_add_fabric_with_connection_string(
+        self,
+        empty_data_context: AbstractDataContext,
+    ) -> None:
+        source = empty_data_context.data_sources.add_fabric(
+            name="my_fabric",
+            connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                host="myserver.database.fabric.microsoft.com",
+                database="mydb",
+                schema="dbo",
+                client_id="my-client-id-123",
+                client_secret="my-secret",
+                tenant_id="my-tenant-id-456",
+            ),
+        )
+        assert source.dict(by_alias=True, exclude_unset=False, exclude={"id"}) == {
+            "type": "fabric",
+            "name": "my_fabric",
+            "connection_string": {
+                "host": "myserver.database.fabric.microsoft.com",
+                "port": 1433,
+                "database": "mydb",
+                "schema": "dbo",
+                "driver": "ODBC Driver 18 for SQL Server",
+                "encrypt": "Mandatory",
+                "authentication": "Entra ID Service Principal",
+                "client_id": "my-client-id-123",
+                "client_secret": "my-secret",
+                "tenant_id": "my-tenant-id-456",
+            },
+            "create_temp_table": False,
+            "kwargs": {},
+            "assets": [],
+        }
+
+    def test_add_fabric_with_flat_kwargs(
+        self,
+        empty_data_context: AbstractDataContext,
+    ) -> None:
+        source = empty_data_context.data_sources.add_fabric(
+            name="my_fabric_flat",
+            host="myserver.database.fabric.microsoft.com",
+            database="mydb",
+            schema="dbo",
+            client_id="my-client-id-123",
+            client_secret="my-secret",
+            tenant_id="my-tenant-id-456",
+        )
+        assert source.dict(by_alias=True, exclude_unset=False, exclude={"id"}) == {
+            "type": "fabric",
+            "name": "my_fabric_flat",
+            "connection_string": {
+                "host": "myserver.database.fabric.microsoft.com",
+                "port": 1433,
+                "database": "mydb",
+                "schema": "dbo",
+                "driver": "ODBC Driver 18 for SQL Server",
+                "encrypt": "Mandatory",
+                "authentication": "Entra ID Service Principal",
+                "client_id": "my-client-id-123",
+                "client_secret": "my-secret",
+                "tenant_id": "my-tenant-id-456",
+            },
+            "create_temp_table": False,
+            "kwargs": {},
+            "assets": [],
+        }
+
+    def test_add_fabric_flat_kwargs_rejects_connection_string_and_kwargs(
+        self,
+        empty_data_context: AbstractDataContext,
+    ) -> None:
+        with pytest.raises(ValueError, match="not both"):
+            empty_data_context.data_sources.add_fabric(
+                name="bad",
+                connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+                    host="h",
+                    database="d",
+                    schema="s",
+                    client_id="c",
+                    client_secret="s",
+                    tenant_id="t",
+                ),
+                host="other_host",
+            )
+
+
+def _make_mock_engine(connect_exception: Exception):
+    class _MockEngine:
+        def connect(self):
+            raise connect_exception
+
+    return _MockEngine()
+
+
+def with_mock_engine_raising(
+    connect_exception: Union[Exception, Callable[[], Exception]],
+) -> Callable:
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            exc = connect_exception() if callable(connect_exception) else connect_exception
+            mock_engine = _make_mock_engine(exc)
+            with patch.object(FabricDatasource, "get_engine", return_value=mock_engine):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+@pytest.fixture
+def fabric_datasource() -> FabricDatasource:
+    return FabricDatasource(
+        name="test_ds",
+        connection_string=EntraIDServicePrincipalAuthConnectionDetails(
+            host="myserver.database.fabric.microsoft.com",
+            database="mydb",
+            schema="dbo",
+            client_id="my-client-id",
+            client_secret="my-secret",
+            tenant_id="my-tenant-id",
+        ),
+    )
+
+
+@pytest.mark.sql_server
+class TestFabricDatasourceTestConnectionErrors:
+    @with_mock_engine_raising(sa.exc.OperationalError("Login failed for user", None, Exception()))
+    def test_login_failure_raises_principal_auth_error(
+        self, fabric_datasource: FabricDatasource
+    ) -> None:
+        """OperationalError with 'Login' -> MSSQLPrincipalAuthError."""
+        with pytest.raises(MSSQLPrincipalAuthError):
+            fabric_datasource.test_connection()
+
+    @with_mock_engine_raising(
+        sa.exc.OperationalError("Unable to connect: connection refused", None, Exception())
+    )
+    def test_network_error_raises_network_error(self, fabric_datasource: FabricDatasource) -> None:
+        """OperationalError without 'Login' -> MSSQLNetworkError."""
+        with pytest.raises(MSSQLNetworkError):
+            fabric_datasource.test_connection()
+
+    @with_mock_engine_raising(
+        sa.exc.DBAPIError(
+            "ODBC Driver 18 for SQL Server not found: file not found", None, Exception()
+        )
+    )
+    def test_missing_odbc_driver_raises_missing_odbc_driver_error(
+        self, fabric_datasource: FabricDatasource
+    ) -> None:
+        """DBAPIError with 'file not found' -> MissingODBCDriverError."""
+        with pytest.raises(MissingODBCDriverError):
+            fabric_datasource.test_connection()
+
+    @with_mock_engine_raising(ValueError("Something unexpected happened"))
+    def test_unhandled_error_reraises_test_connection_error(
+        self, fabric_datasource: FabricDatasource
+    ) -> None:
+        """Unhandled exception types -> original TestConnectionError re-raised."""
+        with pytest.raises(TestConnectionError) as exc_info:
+            fabric_datasource.test_connection()
+        assert isinstance(exc_info.value.cause, ValueError)
+        assert "Something unexpected" in str(exc_info.value.cause)

--- a/tests/datasource/fluent/test_fabric_datasource.py
+++ b/tests/datasource/fluent/test_fabric_datasource.py
@@ -59,6 +59,18 @@ class TestFabricDatasource:
                 ),
             )
 
+    def test_flat_kwargs_rejects_non_entra_id_authentication(self) -> None:
+        with pytest.raises(ValidationError, match="only supports Entra ID Service Principal"):
+            FabricDatasource(
+                name="test_ds",
+                host="myserver",
+                database="mydb",
+                schema="dbo",
+                authentication="SQL Server",
+                username="myuser",
+                password="mypassword",
+            )
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("mock_test_connection")

--- a/tests/datasource/fluent/test_sql_server_datasource.py
+++ b/tests/datasource/fluent/test_sql_server_datasource.py
@@ -270,9 +270,9 @@ class TestEntraIDServicePrincipalAuthConnectionDetails:
             "driver": "ODBC Driver 18 for SQL Server",
             "encrypt": "Mandatory",
             "authentication": "Entra ID Service Principal",
+            "tenant_id": "my-tenant-id-456",
             "client_id": "my-client-id-123",
             "client_secret": "my-secret",
-            "tenant_id": "my-tenant-id-456",
         }
 
     def test_client_secret_accepts_config_str(self) -> None:
@@ -491,9 +491,9 @@ class TestAddSQLServerDatasourceAPI:
                 "driver": "ODBC Driver 18 for SQL Server",
                 "encrypt": "Mandatory",
                 "authentication": "Entra ID Service Principal",
+                "tenant_id": "my-tenant-id-456",
                 "client_id": "my-client-id-123",
                 "client_secret": "my-secret",
-                "tenant_id": "my-tenant-id-456",
             },
             "create_temp_table": False,
             "kwargs": {},
@@ -556,9 +556,9 @@ class TestAddSQLServerDatasourceAPI:
                 "driver": "ODBC Driver 18 for SQL Server",
                 "encrypt": "Mandatory",
                 "authentication": "Entra ID Service Principal",
+                "tenant_id": "my-tenant-id-456",
                 "client_id": "my-client-id-123",
                 "client_secret": "my-secret",
-                "tenant_id": "my-tenant-id-456",
             },
             "create_temp_table": False,
             "kwargs": {},

--- a/tests/datasource/fluent/test_sql_server_datasource.py
+++ b/tests/datasource/fluent/test_sql_server_datasource.py
@@ -97,9 +97,9 @@ def entra_id_service_principal_connection_details_default() -> ConnectionDetails
         "driver": "ODBC Driver 18 for SQL Server",
         "encrypt": "Mandatory",
         "authentication": "Entra ID Service Principal",
+        "tenant_id": "my-tenant-id-456",
         "client_id": "my-client-id-123",
         "client_secret": "my-secret",
-        "tenant_id": "my-tenant-id-456",
     }
 
 
@@ -258,9 +258,9 @@ class TestEntraIDServicePrincipalAuthConnectionDetails:
             host="myserver.database.windows.net",
             database="mydb",
             schema="dbo",
+            tenant_id="my-tenant-id-456",
             client_id="my-client-id-123",
             client_secret="my-secret",
-            tenant_id="my-tenant-id-456",
         )
         assert details.dict(by_alias=True, exclude_unset=False) == {
             "host": "myserver.database.windows.net",
@@ -280,9 +280,9 @@ class TestEntraIDServicePrincipalAuthConnectionDetails:
             host="myserver",
             database="mydb",
             schema="dbo",
+            tenant_id="my-tenant-id",
             client_id="my-client-id",
             client_secret="${MY_CLIENT_SECRET}",
-            tenant_id="my-tenant-id",
         )
         assert isinstance(details.client_secret, ConfigStr)
         assert str(details.client_secret) == "${MY_CLIENT_SECRET}"
@@ -325,9 +325,9 @@ class TestBuildConnectionStringEntraID:
                 host="myserver.database.windows.net",
                 database="mydb",
                 schema="dbo",
+                tenant_id="my-tenant-id",
                 client_id="my-client-id",
                 client_secret="p@ss:w/rd",
-                tenant_id="my-tenant-id",
             ),
         )
         result = ds._build_connection_string()
@@ -342,9 +342,9 @@ class TestBuildConnectionStringEntraID:
                 database="mydb",
                 schema="dbo",
                 encrypt="Optional",
+                tenant_id="my-tenant-id",
                 client_id="my-client-id",
                 client_secret="secret",
-                tenant_id="my-tenant-id",
             ),
         )
         result = ds._build_connection_string()
@@ -541,9 +541,9 @@ class TestAddSQLServerDatasourceAPI:
             database="mydb",
             schema="dbo",
             authentication="Entra ID Service Principal",
+            tenant_id="my-tenant-id-456",
             client_id="my-client-id-123",
             client_secret="my-secret",
-            tenant_id="my-tenant-id-456",
         )
         assert source.dict(by_alias=True, exclude_unset=False, exclude={"id"}) == {
             "type": "sql_server",
@@ -650,9 +650,9 @@ def azure_ad_service_principal_datasource() -> SQLServerDatasource:
             host="myserver.database.windows.net",
             database="mydb",
             schema="dbo",
+            tenant_id="my-tenant-id",
             client_id="my-client-id",
             client_secret="my-secret",
-            tenant_id="my-tenant-id",
         ),
     )
 

--- a/tests/datasource/fluent/test_sql_server_datasource.py
+++ b/tests/datasource/fluent/test_sql_server_datasource.py
@@ -13,12 +13,12 @@ from great_expectations.datasource.fluent.interfaces import TestConnectionError
 from great_expectations.datasource.fluent.sql_server_datasource import (
     EntraIDServicePrincipalAuthConnectionDetails,
     MissingODBCDriverError,
+    MSSQLNetworkError,
+    MSSQLPasswordAuthError,
+    MSSQLPrincipalAuthError,
     SQLServerAuthConnectionDetails,
     SQLServerDatasource,
     SqlServerDsn,
-    SQLServerNetworkError,
-    SQLServerPasswordAuthError,
-    SQLServerPrincipalAuthError,
 )
 
 if TYPE_CHECKING:
@@ -667,16 +667,16 @@ class TestSQLServerDatasourceTestConnectionErrors:
     def test_login_failure_sql_server_auth_raises_sql_password_auth_error(
         self, sql_server_datasource: SQLServerDatasource
     ) -> None:
-        """OperationalError with 'Login' and SQL Server auth -> SQLServerPasswordAuthError."""
-        with pytest.raises(SQLServerPasswordAuthError):
+        """OperationalError with 'Login' and SQL Server auth -> MSSQLPasswordAuthError."""
+        with pytest.raises(MSSQLPasswordAuthError):
             sql_server_datasource.test_connection()
 
     @with_mock_engine_raising(sa.exc.OperationalError("Login failed for user", None, Exception()))
     def test_login_failure_azure_ad_service_principal_raises_sql_principal_auth_error(
         self, azure_ad_service_principal_datasource: SQLServerDatasource
     ) -> None:
-        """OperationalError with 'Login' -> SQLServerPrincipalAuthError."""
-        with pytest.raises(SQLServerPrincipalAuthError):
+        """OperationalError with 'Login' -> MSSQLPrincipalAuthError."""
+        with pytest.raises(MSSQLPrincipalAuthError):
             azure_ad_service_principal_datasource.test_connection()
 
     @with_mock_engine_raising(
@@ -685,8 +685,8 @@ class TestSQLServerDatasourceTestConnectionErrors:
     def test_network_error_raises_sql_server_network_error(
         self, sql_server_datasource: SQLServerDatasource
     ) -> None:
-        """OperationalError without 'Login' -> SQLServerNetworkError."""
-        with pytest.raises(SQLServerNetworkError):
+        """OperationalError without 'Login' -> MSSQLNetworkError."""
+        with pytest.raises(MSSQLNetworkError):
             sql_server_datasource.test_connection()
 
     @with_mock_engine_raising(
@@ -705,8 +705,8 @@ class TestSQLServerDatasourceTestConnectionErrors:
     def test_pyodbc_operational_error_login_raises_sql_password_auth_error(
         self, sql_server_datasource: SQLServerDatasource
     ) -> None:
-        """pyodbc.OperationalError with 'Login' -> SQLServerPasswordAuthError."""
-        with pytest.raises(SQLServerPasswordAuthError):
+        """pyodbc.OperationalError with 'Login' -> MSSQLPasswordAuthError."""
+        with pytest.raises(MSSQLPasswordAuthError):
             sql_server_datasource.test_connection()
 
     @with_mock_engine_raising(ValueError("Something unexpected happened"))


### PR DESCRIPTION
- Add `FabricDatasource` inheriting from `SQLServerDatasource` with `type = "fabric"` and `connection_string` restricted to `EntraIDServicePrincipalAuthConnectionDetails`
- Override `_convert_root_connection_detail_fields` so flat kwargs default to Entra ID Service Principal authentication
- Rename `SQLServerNetworkError`, `SQLServerPasswordAuthError`, and `SQLServerPrincipalAuthError` to `MSSQLNetworkError`, `MSSQLPasswordAuthError`, and `MSSQLPrincipalAuthError`
- Register `FabricDatasource` in the fluent module (auto-generates `add_fabric`/`update_fabric`/`delete_fabric` APIs)
- Add JSON schema (`FabricDatasource.json`)
- Add unit tests for type literal, auth rejection, and `add_fabric()` API