### PR TITLE
[MAJOR BUMP] Remove unsupported config var substitution

### DIFF
--- a/docs/docusaurus/docs/core/configure_project_settings/configure_credentials/_config_yml.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_credentials/_config_yml.md
@@ -25,8 +25,10 @@ MY_POSTGRES_PASSWORD: <PASSWORD>
 POSTGRES_CONNECTION_STRING: postgresql+psycopg2://${MY_POSTGRES_USERNAME}:${MY_POSTGRES_PASSWORD}@<HOST>:<PORT>/<DATABASE>
 ```
 
-Because the dollar sign character `$` is used to indicate the start of a string substitution they should be escaped using a backslash `\` if they are part of your credentials. For example, if your password is `pa$$word` then in the previous examples you would use the command:
+Because the `${` sequence is used to indicate the start of a config variable substitution (e.g. `${MY_PASSWORD}`), it should be escaped using a backslash `\` if it appears literally in your credentials. For example, if your password is `pa${word}` then in the previous examples you would use the command:
 
 ```bash title="Terminal"
-export MY_POSTGRES_PASSWORD=pa\$\$word
+export MY_POSTGRES_PASSWORD=pa\${word}
 ```
+
+Note: a bare `$` that is not followed by `{` does not need to be escaped. For example, a password like `pa$word` can be used as-is.

--- a/docs/docusaurus/docs/core/configure_project_settings/configure_credentials/_environment_variables.md
+++ b/docs/docusaurus/docs/core/configure_project_settings/configure_credentials/_environment_variables.md
@@ -23,8 +23,10 @@ export MY_POSTGRES_PASSWORD=<PASSWORD>
 export POSTGRES_CONNECTION_STRING=postgresql+psycopg2://${MY_POSTGRES_USERNAME}:${MY_POSTGRES_PASSWORD}@<HOST>:<PORT>/<DATABASE>
 ```
 
-Because the dollar sign character `$` is used to indicate the start of a string substitution they should be escaped using a backslash `\` if they are part of your credentials. For example, if your password is `pa$$word` then in the previous examples you would use the command:
+Because the `${` sequence is used to indicate the start of a config variable substitution (e.g. `${MY_PASSWORD}`), it should be escaped using a backslash `\` if it appears literally in your credentials. For example, if your password is `pa${word}` then in the previous examples you would use the command:
 
 ```bash title="Terminal or ~/.bashrc"
-export MY_POSTGRES_PASSWORD=pa\$\$word
+export MY_POSTGRES_PASSWORD=pa\${word}
 ```
+
+Note: a bare `$` that is not followed by `{` does not need to be escaped. For example, a password like `pa$word` can be used as-is.

--- a/docs/docusaurus/docs/core/connect_to_data/configure_credentials/_config_yml.md
+++ b/docs/docusaurus/docs/core/connect_to_data/configure_credentials/_config_yml.md
@@ -23,8 +23,10 @@ MY_POSTGRES_PASSWORD: <PASSWORD>
 POSTGRES_CONNECTION_STRING: postgresql+psycopg2://${MY_POSTGRES_USERNAME}:${MY_POSTGRES_PASSWORD}@<HOST>:<PORT>/<DATABASE>
 ```
 
-Because the dollar sign character `$` is used to indicate the start of a string substitution they should be escaped using a backslash `\` if they are part of your credentials. For example, if your password is `pa$$word` then in the previous examples you would use the command:
+Because the `${` sequence is used to indicate the start of a config variable substitution (e.g. `${MY_PASSWORD}`), it should be escaped using a backslash `\` if it appears literally in your credentials. For example, if your password is `pa${word}` then in the previous examples you would use the command:
 
 ```bash title="Terminal"
-export MY_POSTGRES_PASSWORD=pa\$\$word
+export MY_POSTGRES_PASSWORD=pa\${word}
 ```
+
+Note: a bare `$` that is not followed by `{` does not need to be escaped. For example, a password like `pa$word` can be used as-is.

--- a/docs/docusaurus/docs/core/connect_to_data/configure_credentials/_environment_variables.md
+++ b/docs/docusaurus/docs/core/connect_to_data/configure_credentials/_environment_variables.md
@@ -23,8 +23,10 @@ export MY_POSTGRES_PASSWORD=<PASSWORD>
 export POSTGRES_CONNECTION_STRING=postgresql+psycopg2://${MY_POSTGRES_USERNAME}:${MY_POSTGRES_PASSWORD}@<HOST>:<PORT>/<DATABASE>
 ```
 
-Because the dollar sign character `$` is used to indicate the start of a string substitution they should be escaped using a backslash `\` if they are part of your credentials. For example, if your password is `pa$$word` then in the previous examples you would use the command:
+Because the `${` sequence is used to indicate the start of a config variable substitution (e.g. `${MY_PASSWORD}`), it should be escaped using a backslash `\` if it appears literally in your credentials. For example, if your password is `pa${word}` then in the previous examples you would use the command:
 
 ```bash title="Terminal or ~/.bashrc"
-export MY_POSTGRES_PASSWORD=pa\$\$word
+export MY_POSTGRES_PASSWORD=pa\${word}
 ```
+
+Note: a bare `$` that is not followed by `{` does not need to be escaped. For example, a password like `pa$word` can be used as-is.

--- a/great_expectations/core/config_substitutor.py
+++ b/great_expectations/core/config_substitutor.py
@@ -14,14 +14,12 @@ from great_expectations.data_context.types.base import BaseYamlConfig
 
 logger = logging.getLogger(__name__)
 
-TEMPLATE_STR_REGEX: Final[re.Pattern] = re.compile(
-    r"(?<!\\)\$\{(.*?)\}|(?<!\\)\$([_a-zA-Z][_a-zA-Z0-9]*)"
-)
+TEMPLATE_STR_REGEX: Final[re.Pattern] = re.compile(r"(?<!\\)\$\{(.*?)\}")
 
 
 class _ConfigurationSubstitutor:
     """
-    Responsible for encapsulating all logic around $VARIABLE (or ${VARIABLE}) substitution.
+    Responsible for encapsulating all logic around ${VARIABLE} substitution.
 
     While the config variables utilized for substitution are provided at runtime, all the
     behavior necessary to actually update config objects with their appropriate runtime values
@@ -81,11 +79,11 @@ class _ConfigurationSubstitutor:
         dollar_sign_escape_string: str = r"\$",
     ) -> Optional[str]:
         """
-        This method takes a string, and if it contains a pattern ${SOME_VARIABLE} or $SOME_VARIABLE,
+        This method takes a string, and if it contains a pattern ${SOME_VARIABLE},
         returns a string where the pattern is replaced with the value of SOME_VARIABLE,
-        otherwise returns the string unchanged. These patterns are case sensitive. There can be multiple
-        patterns in a string, e.g. all 3 will be substituted in the following:
-        $SOME_VARIABLE${some_OTHER_variable}$another_variable
+        otherwise returns the string unchanged. The pattern is case sensitive. There can be multiple
+        patterns in a string, e.g. both will be substituted in the following:
+        ${SOME_VARIABLE}${some_OTHER_variable}
 
         If the environment variable SOME_VARIABLE is set, the method uses its value for substitution.
         If it is not set, the value of SOME_VARIABLE is looked up in the config variables store (file).
@@ -97,12 +95,14 @@ class _ConfigurationSubstitutor:
 
         If the value starts with the keyword `secret|`, it tries to apply secret store substitution.
 
+        A bare `$` not followed by `{` is not treated as a substitution marker and passes through
+        unchanged. Only `${` initiates substitution.
+
         :param template_str: a string that might or might not be of the form ${SOME_VARIABLE}
-                or $SOME_VARIABLE
         :param config_variables_dict: a dictionary of config variables. It is loaded from the
                 config variables store (by default, "uncommitted/config_variables.yml file)
-        :param dollar_sign_escape_string: a string that will be used in place of a `$` when substitution
-                is not desired.
+        :param dollar_sign_escape_string: a string that will be used in place of `${` when
+                substitution is not desired (e.g. r"\\${").
 
         :return: a string with values substituted, or the same object if template_str is not a string.
         """  # noqa: E501 # FIXME CoP
@@ -118,8 +118,7 @@ class _ConfigurationSubstitutor:
             return template_str
 
         for m in match:
-            # Match either the first group e.g. ${Variable} or the second e.g. $Variable
-            config_variable_name = m.group(1) or m.group(2)
+            config_variable_name = m.group(1)
             config_variable_value = config_variables_dict.get(config_variable_name)
 
             if config_variable_value is not None:

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -77,7 +77,7 @@ class ConfigStr(SecretStr):
         raise ValueError(
             cls.__name__
             + " - contains no config template strings in the format"
-            + r" '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'"
+            + r" '${MY_CONFIG_VAR}'"
         )
 
     @classmethod

--- a/tests/core/test_config_substitutor.py
+++ b/tests/core/test_config_substitutor.py
@@ -317,3 +317,37 @@ def test_substitute_value_from_azure_keyvault(
                 )
                 == expected
             )
+
+
+@pytest.mark.unit
+def test_bare_dollar_not_substituted():
+    """$word in a value should not be treated as a variable reference."""
+    substitutor = _ConfigurationSubstitutor()
+    result = substitutor.substitute_config_variable("P@ss$word", {})
+    assert result == "P@ss$word"
+
+
+@pytest.mark.unit
+def test_bare_dollar_in_connection_string():
+    """Connection strings with bare $ chars should pass through unmodified."""
+    substitutor = _ConfigurationSubstitutor()
+    conn = "postgresql://user:P@ss$word@host/db"
+    result = substitutor.substitute_config_variable(conn, {})
+    assert result == conn
+
+
+@pytest.mark.unit
+def test_only_curly_brace_form_is_substituted():
+    """Only ${VAR} triggers substitution; $VAR does not."""
+    substitutor = _ConfigurationSubstitutor()
+    variables = {"MYVAR": "replaced"}
+    result = substitutor.substitute_config_variable("prefix_${MYVAR}_suffix", variables)
+    assert result == "prefix_replaced_suffix"
+
+
+@pytest.mark.unit
+def test_escaped_dollar_brace_becomes_literal():
+    r"""\\${ should produce a literal ${ in the output."""
+    substitutor = _ConfigurationSubstitutor()
+    result = substitutor.substitute_config_variable(r"pa\${word}", {})
+    assert result == "pa${word}"

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -651,7 +651,7 @@ def test_modifications_to_env_vars_is_recognized_within_same_program_execution(
     env_var_name: str = "MY_PLUGINS_DIRECTORY"
     env_var_value: str = "my_patched_value"
 
-    context.variables.config.plugins_directory = f"${env_var_name}"
+    context.variables.config.plugins_directory = f"${{{env_var_name}}}"
     monkeypatch.setenv(env_var_name, env_var_value)
 
     assert context.plugins_directory and context.plugins_directory.endswith(env_var_value)
@@ -673,7 +673,7 @@ def test_modifications_to_config_vars_is_recognized_within_same_program_executio
     config_var_name: str = "my_plugins_dir"
     config_var_value: str = "my_patched_value"
 
-    context.variables.config.plugins_directory = f"${config_var_name}"
+    context.variables.config.plugins_directory = f"${{{config_var_name}}}"
     context.save_config_variable(name=config_var_name, value=config_var_value)
 
     assert context.plugins_directory and context.plugins_directory.endswith(config_var_value)

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -113,7 +113,7 @@ def test_substitute_config_variable():
         == "abcval_of_arg_0"
     )
     assert (
-        config_substitutor.substitute_config_variable("abc$arg0", config_variables_dict)
+        config_substitutor.substitute_config_variable("abc${arg0}", config_variables_dict)
         == "abcval_of_arg_0"
     )
     assert (
@@ -151,17 +151,19 @@ def test_substitute_config_variable():
     )
     # Test with upper case
     assert (
-        config_substitutor.substitute_config_variable("prefix_$ARG4/suffix", config_variables_dict)
+        config_substitutor.substitute_config_variable(
+            "prefix_${ARG4}/suffix", config_variables_dict
+        )
         == "prefix_val_of_ARG_4/suffix"
     )
     assert (
-        config_substitutor.substitute_config_variable("$ARG4", config_variables_dict)
+        config_substitutor.substitute_config_variable("${ARG4}", config_variables_dict)
         == "val_of_ARG_4"
     )
 
     # Test with multiple substitutions
     assert (
-        config_substitutor.substitute_config_variable("prefix${arg0}$aRg3", config_variables_dict)
+        config_substitutor.substitute_config_variable("prefix${arg0}${aRg3}", config_variables_dict)
         == "prefixval_of_arg_0val_of_aRg_3"
     )
 
@@ -174,7 +176,7 @@ def test_substitute_config_variable():
     # Multiple configurations together
     assert (
         config_substitutor.substitute_config_variable(
-            r"prefix$ARG4.$arg0/$aRg3:${ARG4}/\$dontsub${arg0}:${aRg3}.suffix",
+            r"prefix${ARG4}.${arg0}/${aRg3}:${ARG4}/\$dontsub${arg0}:${aRg3}.suffix",
             config_variables_dict,
         )
         == "prefixval_of_ARG_4.val_of_arg_0/val_of_aRg_3:val_of_ARG_4/$dontsubval_of_arg_0:val_of_aRg_3.suffix"  # noqa: E501 # FIXME CoP

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -261,7 +261,7 @@ def test_data_context_variables_get_with_substitutions(
     env_var_name: str = "MY_CONFIG_VERSION"
     value_associated_with_env_var: float = 7.0
 
-    data_context_config_dict[DataContextVariableSchema.CONFIG_VERSION] = f"${env_var_name}"
+    data_context_config_dict[DataContextVariableSchema.CONFIG_VERSION] = f"${{{env_var_name}}}"
     config: DataContextConfig = DataContextConfig(**data_context_config_dict)
     config_values: dict = {
         env_var_name: value_associated_with_env_var,

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -459,7 +459,7 @@ def test_file_data_context_variables_e2e(
 
     # Set attributes defined above
     file_data_context.variables.progress_bars = updated_progress_bars
-    file_data_context.variables.plugins_directory = f"${env_var_name}"
+    file_data_context.variables.plugins_directory = f"${{{env_var_name}}}"
     file_data_context.variables.save()
 
     # Review great_expectations.yml where values were written and confirm changes
@@ -473,7 +473,7 @@ def test_file_data_context_variables_e2e(
 
     assert config_saved_to_disk.progress_bars == updated_progress_bars.to_dict()
     assert file_data_context.variables.plugins_directory == value_associated_with_env_var
-    assert config_saved_to_disk.plugins_directory == f"${env_var_name}"
+    assert config_saved_to_disk.plugins_directory == f"${{{env_var_name}}}"
 
 
 @pytest.mark.cloud

--- a/tests/datasource/fluent/test_config_str.py
+++ b/tests/datasource/fluent/test_config_str.py
@@ -373,5 +373,34 @@ class TestConfigUriInvalid:
             _ = pydantic.parse_obj_as(ConfigUri, "snowflake://me:password@account/db")
 
 
+def test_bare_dollar_not_treated_as_template():
+    """Bare $word in a password should not match the config template pattern."""
+    assert not ConfigStr.str_contains_config_template("P@ss$word")
+    assert not ConfigStr.str_contains_config_template("pa$word")
+    assert not ConfigStr.str_contains_config_template("abc$DEF")
+
+
+def test_bare_dollar_passes_through_substitution(env_config_provider: _ConfigurationProvider):
+    """A string with a bare $word should be returned unchanged by the substitutor."""
+    result = env_config_provider.substitute_config("postgresql://user:P@ss$word@host/db")
+    assert result == "postgresql://user:P@ss$word@host/db"
+
+
+def test_union_config_str_or_str_with_bare_dollar():
+    """Union[ConfigStr, str] field with a bare $ in the value should fall through to str."""
+
+    class MyModel(FluentBaseModel):
+        password: Union[ConfigStr, str]
+
+    m = MyModel(password="P@ss$word")
+    assert m.password == "P@ss$word"
+
+
+def test_escaped_dollar_brace_passes_through(env_config_provider: _ConfigurationProvider):
+    r"""\\${ should escape to a literal ${ after substitution."""
+    result = env_config_provider.substitute_config(r"pa\${word}")
+    assert result == "pa${word}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vv"])

--- a/tests/datasource/fluent/test_databricks_sql_datasource.py
+++ b/tests/datasource/fluent/test_databricks_sql_datasource.py
@@ -19,7 +19,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -35,7 +35,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -51,7 +51,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -67,7 +67,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -83,7 +83,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {

--- a/tests/datasource/fluent/test_pandas_datasource.py
+++ b/tests/datasource/fluent/test_pandas_datasource.py
@@ -507,7 +507,7 @@ def test_pandas_data_asset_batch_metadata(
     pandas_datasource = empty_data_context.data_sources.pandas_default
 
     batch_metadata = {
-        "no_curly_pipeline_filename": "$pipeline_filename",
+        "no_curly_pipeline_filename": "${pipeline_filename}",
         "curly_pipeline_filename": "${pipeline_filename}",
         "pipeline_step": "transform_3",
     }

--- a/tests/datasource/fluent/test_pandas_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_pandas_filesystem_datasource.py
@@ -579,7 +579,7 @@ def test_csv_asset_batch_metadata(
 
     asset_specified_metadata = {
         "pipeline_name": "my_pipeline",
-        "no_curly_pipeline_filename": "$pipeline_filename",
+        "no_curly_pipeline_filename": "${pipeline_filename}",
         "curly_pipeline_filename": "${pipeline_filename}",
     }
 

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -1277,7 +1277,7 @@ def test_add_postgres_query_asset_with_batch_metadata(
     years = [2021, 2022]
     asset_specified_metadata = {
         "pipeline_name": "my_pipeline",
-        "no_curly_pipeline_filename": "$pipeline_filename",
+        "no_curly_pipeline_filename": "${pipeline_filename}",
         "curly_pipeline_filename": "${pipeline_filename}",
     }
 
@@ -1321,7 +1321,7 @@ def test_add_postgres_table_asset_with_batch_metadata(
     years = [2021, 2022]
     asset_specified_metadata = {
         "pipeline_name": "my_pipeline",
-        "no_curly_pipeline_filename": "$pipeline_filename",
+        "no_curly_pipeline_filename": "${pipeline_filename}",
         "curly_pipeline_filename": "${pipeline_filename}",
     }
 

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -457,7 +457,7 @@ def test_valid_config(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "'${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -492,7 +492,7 @@ def test_valid_config(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "'${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -528,7 +528,7 @@ def test_valid_config(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "'${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -563,7 +563,7 @@ def test_valid_config(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "'${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -599,7 +599,7 @@ def test_valid_config(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "'${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -656,7 +656,7 @@ def test_missing_required_params(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format"
-                    " '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    " '${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -691,7 +691,7 @@ def test_missing_required_params(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format"
-                    " '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    " '${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -726,7 +726,7 @@ def test_missing_required_params(
                 {
                     "loc": ("connection_string",),
                     "msg": "ConfigStr - contains no config template strings in the format"
-                    " '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    " '${MY_CONFIG_VAR}'",
                     "type": "value_error",
                 },
                 {
@@ -825,7 +825,7 @@ def test_connection_updating_templated_connection_string():
     "private_key",
     [
         pytest.param("${MY_PRIVATE_KEY}", id="Env Variable"),
-        pytest.param("$MY_PRIVATE_KEY", id="Config Variable"),
+        pytest.param("${MY_PRIVATE_KEY}", id="Config Variable"),
     ],
 )
 @pytest.mark.unit
@@ -848,7 +848,7 @@ def test_creating_datasource_with_templated_private_key(private_key):
     "private_key",
     [
         pytest.param("${MY_PRIVATE_KEY}", id="Env Variable"),
-        pytest.param("$MY_PRIVATE_KEY", id="Config Variable"),
+        pytest.param("${MY_PRIVATE_KEY}", id="Config Variable"),
     ],
 )
 @pytest.mark.unit

--- a/tests/datasource/fluent/test_spark_datasource.py
+++ b/tests/datasource/fluent/test_spark_datasource.py
@@ -77,7 +77,7 @@ def test_spark_data_asset_batch_metadata(
     spark_datasource = empty_data_context.data_sources.add_spark("my_spark_datasource")
 
     batch_metadata = {
-        "no_curly_pipeline_filename": "$pipeline_filename",
+        "no_curly_pipeline_filename": "${pipeline_filename}",
         "curly_pipeline_filename": "${pipeline_filename}",
         "pipeline_step": "transform_3",
     }


### PR DESCRIPTION
There is an undocumented code path which allows using the syntax `$MY_SENSITIVE_VALUE` for defining sensitive values in config to be replaced at runtime. This is not a supported path, and can lead to credentials being accidentally logged in the case that a sensitive field (password etc) contains the character `$`, which triggers the substitution logic. This PR removes that unsupported path and updates the documentation for clarity.