### PR TITLE
[MAINTENANCE] Improve error message on ConfigStr substitution

### DIFF
--- a/great_expectations/core/config_substitutor.py
+++ b/great_expectations/core/config_substitutor.py
@@ -128,8 +128,9 @@ class _ConfigurationSubstitutor:
                 template_str = template_str.replace(m.group(), config_variable_value)
             else:
                 raise gx_exceptions.MissingConfigVariableError(  # noqa: TRY003 # FIXME CoP
-                    f"""\n\nUnable to find a match for config substitution variable: `{config_variable_name}`.
-    Please add this missing variable to your `uncommitted/config_variables.yml` file or your environment variables.
+                    """\n\nUnable to find a match for a config substitution variable.
+    Please add the missing variable to your `uncommitted/config_variables.yml` file or your environment variables.
+    If your value contains a literal `$`, it must be escaped as `\\$`.
     See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials""",  # noqa: E501 # FIXME CoP
                     missing_config_variable=config_variable_name,
                 )

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -77,7 +77,9 @@ class ConfigStr(SecretStr):
         raise ValueError(
             cls.__name__
             + " - contains no config template strings in the format"
-            + r" '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'"
+            + r" '${MY_CONFIG_VAR}'."
+            + " If your value contains a literal '$', it must be escaped as '\\$'."
+            + " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials"
         )
 
     @classmethod

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -127,7 +127,7 @@ def test_substitute_config_variable():
         config_substitutor.substitute_config_variable(
             "abc${arg1} def${foo}", config_variables_dict
         )  # does NOT equal "abc${arg1}"
-    assert "Unable to find a match for config substitution variable: `arg1`." in exc.value.message
+    assert "Unable to find a match for a config substitution variable" in exc.value.message
     assert (
         config_substitutor.substitute_config_variable("${arg2}", config_variables_dict)
         == config_variables_dict["arg2"]

--- a/tests/data_context/test_data_context_on_teams.py
+++ b/tests/data_context/test_data_context_on_teams.py
@@ -24,10 +24,7 @@ def test_incomplete_uncommitted(tmp_path):
     with pytest.raises(InvalidConfigError) as exc:
         _ = get_context(context_root_dir=local_dir)
 
-    assert (
-        "Unable to find a match for config substitution variable: "
-        "`secret_validation_results_store_name`." in exc.value.message
-    )
+    assert "Unable to find a match for a config substitution variable" in exc.value.message
     assert (
         "See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials"
         in exc.value.message

--- a/tests/datasource/fluent/test_databricks_sql_datasource.py
+++ b/tests/datasource/fluent/test_databricks_sql_datasource.py
@@ -19,9 +19,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -37,9 +35,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -55,9 +51,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -73,9 +67,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -91,9 +83,7 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {

--- a/tests/datasource/fluent/test_databricks_sql_datasource.py
+++ b/tests/datasource/fluent/test_databricks_sql_datasource.py
@@ -19,7 +19,9 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -35,7 +37,9 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -51,7 +55,9 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -67,7 +73,9 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -83,7 +91,9 @@ from great_expectations.datasource.fluent.databricks_sql_datasource import (
             [
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",  # noqa: E501 # FIXME CoP
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -456,8 +456,9 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {
@@ -491,8 +492,9 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {
@@ -527,8 +529,9 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {
@@ -562,8 +565,9 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {
@@ -598,8 +602,9 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format "
-                    "'${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {
@@ -655,8 +660,9 @@ def test_missing_required_params(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format"
-                    " '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {
@@ -690,8 +696,9 @@ def test_missing_required_params(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format"
-                    " '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {
@@ -725,8 +732,9 @@ def test_missing_required_params(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format"
-                    " '${MY_CONFIG_VAR}' or '$MY_CONFIG_VAR'",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
+                    " If your value contains a literal '$', it must be escaped as '\\$'."
+                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
                     "type": "value_error",
                 },
                 {

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -456,9 +456,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -492,9 +490,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -529,9 +525,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -565,9 +559,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -602,9 +594,7 @@ def test_valid_config(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -660,9 +650,7 @@ def test_missing_required_params(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -696,9 +684,7 @@ def test_missing_required_params(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {
@@ -732,9 +718,7 @@ def test_missing_required_params(
                 },
                 {
                     "loc": ("connection_string",),
-                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'."
-                    " If your value contains a literal '$', it must be escaped as '\\$'."
-                    " See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",
+                    "msg": "ConfigStr - contains no config template strings in the format '${MY_CONFIG_VAR}'. If your value contains a literal '$', it must be escaped as '\\$'. See https://docs.greatexpectations.io/docs/core/configure_project_settings/configure_credentials",  # noqa: E501 # FIXME CoP
                     "type": "value_error",
                 },
                 {


### PR DESCRIPTION
This PR prevents partial password leakage in config substitution error messages and removes the deprecated $MY_CONFIG_VAR syntax from error guidance. When a user provides a password or secret containing a literal $ (e.g., mypass$word), GX interprets the text after $ as a config variable name and raises a MissingConfigVariableError that includes that text in its message — potentially leaking part of the password.