### PR TITLE
[MAINTENANCE] Suppress mypy assignment errors in Trino compatibility module

### DIFF
--- a/great_expectations/compatibility/trino.py
+++ b/great_expectations/compatibility/trino.py
@@ -9,24 +9,24 @@ TRINO_NOT_IMPORTED = NotImported(
 try:
     import trino
 except ImportError:
-    trino = TRINO_NOT_IMPORTED
+    trino = TRINO_NOT_IMPORTED  # type: ignore[assignment] # NotImported is used at runtime when trino is not installed
 
 try:
     from trino.sqlalchemy import datatype as trinotypes
 except (ImportError, AttributeError):
-    trinotypes = TRINO_NOT_IMPORTED
+    trinotypes = TRINO_NOT_IMPORTED  # type: ignore[assignment] # NotImported is used at runtime when trino is not installed
 
 try:
     from trino.sqlalchemy import dialect as trinodialect
 except (ImportError, AttributeError):
-    trinodialect = TRINO_NOT_IMPORTED
+    trinodialect = TRINO_NOT_IMPORTED  # type: ignore[assignment] # NotImported is used at runtime when trino is not installed
 
 try:
     import trino.drivers as trinodrivers
 except (ImportError, AttributeError):
-    trinodrivers = TRINO_NOT_IMPORTED
+    trinodrivers = TRINO_NOT_IMPORTED  # type: ignore[assignment] # NotImported is used at runtime when trino is not installed
 
 try:
     import trino.exceptions as trinoexceptions
 except (ImportError, AttributeError):
-    trinoexceptions = TRINO_NOT_IMPORTED
+    trinoexceptions = TRINO_NOT_IMPORTED  # type: ignore[assignment] # NotImported is used at runtime when trino is not installed

--- a/great_expectations/compatibility/trino.py
+++ b/great_expectations/compatibility/trino.py
@@ -24,7 +24,7 @@ except (ImportError, AttributeError):
 try:
     import trino.drivers as trinodrivers
 except (ImportError, AttributeError):
-    trinodrivers = TRINO_NOT_IMPORTED  # type: ignore[assignment] # NotImported is used at runtime when trino is not installed
+    trinodrivers = TRINO_NOT_IMPORTED
 
 try:
     import trino.exceptions as trinoexceptions


### PR DESCRIPTION
## Why

The `trino` package added a [PEP-561 `py.typed` marker](https://github.com/trinodb/trino-python-client/pull/514) in version 0.337.0 (released 2026-03-06). Before this, mypy treated `trino` as an untyped package and silently ignored its type information. Now that `trino` is recognized as typed, mypy type-checks both branches of the `try`/`except ImportError` pattern in `compatibility/trino.py` and flags assigning `NotImported` to variables it infers as `ModuleType`.

This doesn't reproduce locally when `trino` is installed because mypy considers the `except` branch unreachable. In CI, where `trino` is not installed, mypy still infers module types from the `import` statements and checks both branches.

## What

Add `# type: ignore[assignment]` with explanatory comments to each fallback assignment in `compatibility/trino.py`, matching the pattern already used in `postgresql.py` and other compatibility modules.