### PR TITLE
[BUGFIX] Incorrect HTML report description for ExpectTableColumnsToMatchSet

### DIFF
--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -286,7 +286,9 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
             )
 
             exact_match_str = (
-                "exactly" if params.exact_match is None or params.exact_match.value is True else "at least"
+                "exactly"
+                if params.exact_match is None or params.exact_match.value is True
+                else "at least"
             )
 
             template_str = (

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -286,7 +286,7 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
             )
 
             exact_match_str = (
-                "exactly" if params.exact_match and params.exact_match.value is True else "at least"
+                "exactly" if params.exact_match is None or params.exact_match.value is True else "at least"
             )
 
             template_str = (
@@ -323,7 +323,7 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
                 [f"$column_list_{idx}" for idx in range(len(params["column_list"]))]
             )
 
-            exact_match_str = "exactly" if params["exact_match"] is True else "at least"
+            exact_match_str = "exactly" if params["exact_match"] is not False else "at least"
 
             template_str = f"Must have {exact_match_str} these columns (in any order): {column_list_template_str}"  # noqa: E501 # FIXME CoP
 


### PR DESCRIPTION
## Summary
- When `exact_match` is not explicitly passed to `ExpectTableColumnsToMatchSet`, it defaults to `True`, but both prescriptive renderers resolved the description to "at least" instead of "exactly"
- The atomic renderer checked `params.exact_match and params.exact_match.value is True`, which short-circuits to `False` when `params.exact_match` is `None`
- The legacy renderer checked `params["exact_match"] is True`, which also evaluates `False` for `None`
- Fixed both conditions to treat `None` (the default) the same as `True`

Fixes #10978

## Test plan
- [ ] Validate that `ExpectTableColumnsToMatchSet` with no `exact_match` argument renders "Must have exactly these columns" in the HTML report
- [ ] Validate that explicitly passing `exact_match=True` still renders "exactly"
- [ ] Validate that explicitly passing `exact_match=False` still renders "at least"