### PR TITLE
fix: replace bare `except:` with `except BaseException:` (PEP 8 E722)

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
@@ -34,7 +34,7 @@ class ColumnValuesMatchJsonSchema(ColumnMapMetricProvider):
                 return False
             except jsonschema.SchemaError:
                 raise
-            except:
+            except BaseException:
                 raise
 
         return column.map(matches_json_schema)
@@ -57,7 +57,7 @@ class ColumnValuesMatchJsonSchema(ColumnMapMetricProvider):
                 return False
             except jsonschema.SchemaError:
                 raise
-            except:
+            except BaseException:
                 raise
 
         matches_json_schema_udf = F.udf(


### PR DESCRIPTION
## Summary

Replace two bare `except:` clauses with `except BaseException:` in `column_values_match_json_schema.py` to comply with PEP 8 E722.

Both bare `except` blocks catch all exceptions after a specific `jsonschema.SchemaError` handler and immediately re-raise. Using `except BaseException:` makes the intent explicit.

**Change (applied at lines 37 and 60):**
```python
# Before
except:
    raise

# After
except BaseException:
    raise
```

## Testing
No behavior change — bare `except:` is equivalent to `except BaseException:`, this just makes the intent explicit.