### PR TITLE
[BUGFIX] replace bare except with except BaseException (E722)

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
@@ -34,7 +34,7 @@ class ColumnValuesMatchJsonSchema(ColumnMapMetricProvider):
                 return False
             except jsonschema.SchemaError:
                 raise
-            except:
+            except BaseException:
                 raise
 
         return column.map(matches_json_schema)
@@ -57,7 +57,7 @@ class ColumnValuesMatchJsonSchema(ColumnMapMetricProvider):
                 return False
             except jsonschema.SchemaError:
                 raise
-            except:
+            except BaseException:
                 raise
 
         matches_json_schema_udf = F.udf(


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with explicit `except BaseException:` in the JSON schema validation metric.

**Why:** Bare `except:` is a PEP 8 E722 violation. Since these blocks immediately re-raise the caught exception, `except BaseException:` is the correct explicit form — it preserves the existing behavior while making the intent clear.

**Change:**
```python
# Before
except:
    raise

# After
except BaseException:
    raise
```

## Files Changed
- `great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py` (2 instances)

## Testing
No behavior change — `except BaseException:` catches the same exceptions as bare `except:`. This is a style/correctness fix only.