### PR TITLE
[CONTRIB] Fix row_condition handling for SQLAlchemyExecutionEngine

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -685,7 +685,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 sa.select(sa.text("*"))
                 .select_from(selectable)  # type: ignore[arg-type] # FIXME CoP
                 .where(parsed_condition)
-            ) 
+            )
 
         # Filtering by filter_conditions
         filter_conditions: List[RowCondition] = domain_kwargs.get("filter_conditions", [])

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -660,7 +660,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
 
             # PassThroughCondition is not supported for SQLAlchemy
             if isinstance(row_condition, PassThroughCondition):
-                raise GreatExpectationsError(  # noqa: TRY003 # FIXME
+                raise GreatExpectationsError(  # noqa: TRY003 # FIXME CoP
                     "PassThroughCondition (pandas/spark syntax) is not supported for "
                     "SqlAlchemyExecutionEngine. Please use the latest documented "
                     "row_condition syntax, which does not require condition_parser."
@@ -677,7 +677,15 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 raise GreatExpectationsError(  # noqa: TRY003 # FIXME CoP
                     "SqlAlchemyExecutionEngine only supports the great_expectations condition_parser."  # noqa: E501 # FIXME CoP
                 )
-            selectable = sa.select(sa.text("*")).select_from(selectable).where(parsed_condition)  # type: ignore[arg-type] # FIXME CoP
+
+            if not isinstance(selectable, (sa.Table, Subquery)):
+                selectable = selectable.subquery()  # type: ignore[attr-defined] # FIXME CoP
+
+            selectable = (
+                sa.select(sa.text("*"))
+                .select_from(selectable)  # type: ignore[arg-type] # FIXME CoP
+                .where(parsed_condition)
+            ) 
 
         # Filtering by filter_conditions
         filter_conditions: List[RowCondition] = domain_kwargs.get("filter_conditions", [])


### PR DESCRIPTION
## Summary
Fixes row_condition handling in SqlAlchemyExecutionEngine by wrapping non-table selectables in a subquery before applying the filter.

## Problem
When applying row_condition, the code used select_from(selectable) directly. For non-table selectables, this could generate malformed SQL or fail under SQLAlchemy 2.0-style handling.

## Changes
- added a guard to convert non-table/non-subquery selectables into a subquery
- preserved the existing row_condition behavior otherwise

## Testing
python -m pytest tests\expectations\test_row_conditions.py -x -k "not spark"

## Related Issue
Closes #11319