### PR TITLE
[BUGFIX] Fix incorrect exception_info structure when raised_exception is True

### DIFF
--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -415,9 +415,9 @@ class ExpectationValidationGraph:
     def get_exception_info(
         self,
         metric_info: _AbortedMetricsInfoDict,
-    ) -> Dict[str, Union[MetricConfiguration, ExceptionInfo, int]]:
+    ) -> Dict[str, ExceptionInfo]:
         metric_info = self._filter_metric_info_in_graph(metric_info=metric_info)
-        metric_exception_info: Dict[str, Union[MetricConfiguration, ExceptionInfo, int]] = {}
+        metric_exception_info: Dict[str, ExceptionInfo] = {}
         metric_id: MetricConfigurationID
         metric_info_item: MetricsCalculatorErrorResultValue
         for metric_id, metric_info_item in metric_info.items():

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -788,9 +788,14 @@ class Validator:
             # Report all MetricResolutionError occurrences impacting expectation and append it to rejected list.  # noqa: E501 # FIXME CoP
             if len(metric_exception_info) > 0:
                 configuration = expectation_validation_graph.configuration
+                # Flatten the metric_exception_info dict to get a single ExceptionInfo
+                # instead of a dict keyed by metric identifiers, so that exception_info
+                # has the expected flat structure: {raised_exception, exception_traceback,
+                # exception_message}. See https://github.com/great-expectations/great_expectations/issues/10849
+                first_exception_info = next(iter(metric_exception_info.values()))
                 result = ExpectationValidationResult(
                     success=False,
-                    exception_info=metric_exception_info,
+                    exception_info=first_exception_info,
                     expectation_config=configuration,
                 )
                 evrs.append(result)

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -782,7 +782,7 @@ class Validator:
         # Trace MetricResolutionError occurrences to expectations relying on corresponding malfunctioning metrics.  # noqa: E501 # FIXME CoP
         rejected_configurations: List[ExpectationConfiguration] = []
         for expectation_validation_graph in expectation_validation_graphs:
-            metric_exception_info: Dict[str, Union[MetricConfiguration, ExceptionInfo, int]] = (
+            metric_exception_info: Dict[str, ExceptionInfo] = (
                 expectation_validation_graph.get_exception_info(metric_info=aborted_metrics_info)
             )
             # Report all MetricResolutionError occurrences impacting expectation and append it to rejected list.  # noqa: E501 # FIXME CoP

--- a/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
@@ -106,7 +106,7 @@ class TestNumericExpectationAgainstStrDataMisconfiguration:
     def _assert_misconfiguration(self, batch_for_datasource: Batch, exception_message: str) -> None:
         result = batch_for_datasource.validate(self._EXPECTATION)
         assert not result.success
-        assert exception_message in str(result.exception_info)
+        assert exception_message in result.exception_info["exception_message"]
 
 
 class TestNonExistentColumnMisconfiguration:
@@ -136,7 +136,7 @@ class TestNonExistentColumnMisconfiguration:
     def _assert_misconfiguration(self, batch_for_datasource: Batch, exception_message: str) -> None:
         result = batch_for_datasource.validate(self._EXPECTATION)
         assert not result.success
-        assert exception_message in str(result.exception_info)
+        assert exception_message in result.exception_info["exception_message"]
 
 
 @parameterize_batch_for_data_sources(

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -852,5 +852,5 @@ def test_validator_with_exception_info_in_result():
         assert len(result) == 3  # One to one mapping of Expectations to results
         for evr in result:
             assert evr.exception_info is not None
-            assert evr.exception_info[str(metric_id)].exception_traceback == exception_traceback
-            assert evr.exception_info[str(metric_id)].exception_message == exception_message
+            assert evr.exception_info["exception_traceback"] == exception_traceback
+            assert evr.exception_info["exception_message"] == exception_message


### PR DESCRIPTION
## Summary

Fixes #10849

When a metric resolution error occurs during validation (e.g. referencing a non-existent column), `_resolve_suite_level_graph_and_process_metric_evaluation_errors` passes the raw `metric_exception_info` dict — keyed by metric identifier strings — directly as the `exception_info` argument to `ExpectationValidationResult`. This produces a nested structure like:

```python
{"('column_values.nonnull.condition', '242ce...', ())": {"raised_exception": True, ...}}
```

instead of the expected flat structure:

```python
{"raised_exception": True, "exception_traceback": "...", "exception_message": "..."}
```

Every other exception handling path in the validator passes a single `ExceptionInfo` object, so consumers that check `result.exception_info["raised_exception"]` break on this code path.

The fix extracts the first `ExceptionInfo` value from the dict before passing it to the result, normalizing the structure across all paths. This follows the same approach as #11657 which was closed for administrative reasons.

## Changes

- `great_expectations/validator/validator.py`: Extract first `ExceptionInfo` value from `metric_exception_info` before passing to `ExpectationValidationResult`

## Test plan

- `result.exception_info["raised_exception"]` returns `True` directly without nested keys
- `result.exception_info["exception_message"]` and `exception_traceback` accessible at top level
- Existing renderers in `expectation.py` continue working (they already check `"raised_exception" in result.exception_info` which now succeeds on the first branch)