### PR TITLE
fix: replace bare except with except BaseException

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_match_json_schema.py
@@ -34,7 +34,7 @@ class ColumnValuesMatchJsonSchema(ColumnMapMetricProvider):
                 return False
             except jsonschema.SchemaError:
                 raise
-            except:
+            except BaseException:
                 raise
 
         return column.map(matches_json_schema)
@@ -57,7 +57,7 @@ class ColumnValuesMatchJsonSchema(ColumnMapMetricProvider):
                 return False
             except jsonschema.SchemaError:
                 raise
-            except:
+            except BaseException:
                 raise
 
         matches_json_schema_udf = F.udf(


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except BaseException:` in `column_values_match_json_schema.py`.

PEP 8 recommends against bare `except:` — it should specify an exception type. Since both catch blocks re-raise the exception with `raise`, `except BaseException:` preserves the original behavior while being explicit.

**Changes (2 occurrences):**
```python
# Before
except:
    raise

# After
except BaseException:
    raise
```

## Testing
No behavior change — style/correctness fix only. Both `except:` blocks already re-raise, so replacing with `except BaseException:` is semantically identical.