### PR TITLE
[MINORBUMP] Deprecate DBFS datasources (GX-2543)

### DIFF
--- a/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, ClassVar, Literal, Type
 
-from great_expectations._docs_decorators import public_api
+from great_expectations._docs_decorators import deprecated_method_or_class, public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.util import DBFSPath
 from great_expectations.datasource.fluent import PandasFilesystemDatasource
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 
 
 @public_api
+@deprecated_method_or_class(
+    version="1.0",
+    message="DBFS is deprecated by Databricks. Use Unity Catalog volumes, external locations, "
+    "or workspace files with PandasFilesystemDatasource instead.",
+)
 class PandasDBFSDatasource(PandasFilesystemDatasource):
     """Pandas based Datasource for DataBricks File System (DBFS) based data assets."""
 

--- a/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 @public_api
 @deprecated_method_or_class(
-    version="1.0",
+    version="1.16.0",
     message="DBFS is deprecated by Databricks. Use Unity Catalog volumes, external locations, "
     "or workspace files with PandasFilesystemDatasource instead.",
 )

--- a/great_expectations/datasource/fluent/spark_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/spark_dbfs_datasource.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 @public_api
 @deprecated_method_or_class(
-    version="1.0",
+    version="1.16.0",
     message="DBFS is deprecated by Databricks. Use Unity Catalog volumes, external locations, "
     "or workspace files with SparkFilesystemDatasource instead.",
 )

--- a/great_expectations/datasource/fluent/spark_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/spark_dbfs_datasource.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, ClassVar, Literal, Type
 
-from great_expectations._docs_decorators import public_api
+from great_expectations._docs_decorators import deprecated_method_or_class, public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.util import DBFSPath
 from great_expectations.datasource.fluent import SparkFilesystemDatasource
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 
 
 @public_api
+@deprecated_method_or_class(
+    version="1.0",
+    message="DBFS is deprecated by Databricks. Use Unity Catalog volumes, external locations, "
+    "or workspace files with SparkFilesystemDatasource instead.",
+)
 class SparkDBFSDatasource(SparkFilesystemDatasource):
     """Spark based Datasource for DataBricks File System (DBFS) based data assets."""
 

--- a/tests/datasource/fluent/test_pandas_dbfs_datasource.py
+++ b/tests/datasource/fluent/test_pandas_dbfs_datasource.py
@@ -73,8 +73,9 @@ def pandas_dbfs_datasource(
 
 @pytest.mark.unit
 def test_pandas_dbfs_datasource_has_deprecation_notice():
-    assert PandasDBFSDatasource.__doc__ is not None
-    assert "deprecated" in PandasDBFSDatasource.__doc__.lower()
+    doc = PandasDBFSDatasource.__doc__
+    assert doc is not None
+    assert ".. deprecated::" in doc
 
 
 @pytest.mark.filesystem

--- a/tests/datasource/fluent/test_pandas_dbfs_datasource.py
+++ b/tests/datasource/fluent/test_pandas_dbfs_datasource.py
@@ -71,6 +71,12 @@ def pandas_dbfs_datasource(
     return pandas_dbfs_datasource
 
 
+@pytest.mark.unit
+def test_pandas_dbfs_datasource_has_deprecation_notice():
+    assert PandasDBFSDatasource.__doc__ is not None
+    assert "deprecated" in PandasDBFSDatasource.__doc__.lower()
+
+
 @pytest.mark.filesystem
 def test_construct_pandas_dbfs_datasource(pandas_dbfs_datasource: PandasDBFSDatasource):
     assert pandas_dbfs_datasource.name == "pandas_dbfs_datasource"

--- a/tests/datasource/fluent/test_spark_dbfs_datasource.py
+++ b/tests/datasource/fluent/test_spark_dbfs_datasource.py
@@ -58,8 +58,9 @@ def spark_dbfs_datasource(fs: FakeFilesystem, test_backends) -> SparkDBFSDatasou
 
 @pytest.mark.unit
 def test_spark_dbfs_datasource_has_deprecation_notice():
-    assert SparkDBFSDatasource.__doc__ is not None
-    assert "deprecated" in SparkDBFSDatasource.__doc__.lower()
+    doc = SparkDBFSDatasource.__doc__
+    assert doc is not None
+    assert ".. deprecated::" in doc
 
 
 @pytest.mark.spark

--- a/tests/datasource/fluent/test_spark_dbfs_datasource.py
+++ b/tests/datasource/fluent/test_spark_dbfs_datasource.py
@@ -56,6 +56,12 @@ def spark_dbfs_datasource(fs: FakeFilesystem, test_backends) -> SparkDBFSDatasou
     )
 
 
+@pytest.mark.unit
+def test_spark_dbfs_datasource_has_deprecation_notice():
+    assert SparkDBFSDatasource.__doc__ is not None
+    assert "deprecated" in SparkDBFSDatasource.__doc__.lower()
+
+
 @pytest.mark.spark
 def test_construct_spark_dbfs_datasource(spark_dbfs_datasource: SparkDBFSDatasource):
     assert spark_dbfs_datasource.name == "spark_dbfs_datasource"


### PR DESCRIPTION
## Summary

- Adds `@deprecated_method_or_class` decorator to `PandasDBFSDatasource` and `SparkDBFSDatasource` classes
- Adds unit tests verifying the deprecation notice is present in the class docstrings

## Jira

https://greatexpectations.atlassian.net/browse/GX-2543

## Reason

Databricks has deprecated DBFS (Databricks File System). Both DBFS root and DBFS mounts are deprecated and not recommended by Databricks. New accounts are provisioned without access to these features. Databricks recommends using Unity Catalog volumes, external locations, or workspace files instead.

The DBFS-specific fluent datasources (`PandasDBFSDatasource`, `SparkDBFSDatasource`) should be marked as deprecated to inform users. The code is not being removed (that will happen in a future major release), only the deprecation decorators are being added per the acceptance criteria.

## What was changed

- `great_expectations/datasource/fluent/pandas_dbfs_datasource.py`: Added `@deprecated_method_or_class` decorator to `PandasDBFSDatasource`
- `great_expectations/datasource/fluent/spark_dbfs_datasource.py`: Added `@deprecated_method_or_class` decorator to `SparkDBFSDatasource`
- `tests/datasource/fluent/test_pandas_dbfs_datasource.py`: Added unit test verifying deprecation notice
- `tests/datasource/fluent/test_spark_dbfs_datasource.py`: Added unit test verifying deprecation notice

---

This PR was created completely autonomously by AI (Claude Code).