### PR TITLE
[BUGFIX] Fix unclosed SQLite connections causing ResourceWarning on Python 3.13

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1068,6 +1068,19 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         else:
             self.engine.dispose()
 
+    def __del__(self) -> None:
+        """Ensure database connections are closed when this object is garbage collected.
+
+        Python 3.13 raises ResourceWarning for unclosed sqlite3.Connection objects.
+        Calling close() here disposes the underlying SQLAlchemy engine (and its
+        connection pool) before the raw DBAPI connections are collected, preventing
+        those warnings from being emitted.
+        """
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def _finalize_domain_query(
         self,
         domain_id: IDDictID,


### PR DESCRIPTION
## Summary
- Python 3.13 added `ResourceWarning` to `sqlite3.Connection.__del__()` when connections are GC'd without being explicitly closed
- Tests that create `SqlAlchemyExecutionEngine` (directly or via `build_sa_execution_engine`) don't call `engine.close()` on teardown, leaving ~25+ unclosed `sqlite3.Connection` objects per CI run
- These get GC'd mid-test-session and the `ResourceWarning` fires inside a `pytest.warns(UserWarning)` context, which captures it and — since `filterwarnings = ["error"]` — turns it into a test failure for `test_expectation_configuration_has_result_format`

The fix adds `__del__` to `SqlAlchemyExecutionEngine` so the SQLAlchemy engine (and connection pool) is disposed when the execution engine is GC'd, explicitly closing the underlying `sqlite3.Connection` objects before Python's GC would try to collect them.

## Test plan
- [ ] `tests/expectations/metrics/test_map_metric.py::test_expectation_configuration_has_result_format` passes on Python 3.13
- [ ] Full unit test suite on Python 3.13 shows no `ResourceWarning: unclosed database` failures
- [ ] All other Python versions pass as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)