### PR TITLE
[MAINTENANCE] Add pact-broker publish step to CI (GX-3025)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,6 +551,24 @@ jobs:
       - name: Run the tests
         run: invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
+      - name: Publish pact contracts to PactFlow
+        if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
+        run: |
+          PACT_DIR="tests/integration/cloud/rest_contracts/pacts"
+          if [ ! -d "${PACT_DIR}" ] || [ -z "$(ls -A ${PACT_DIR}/*.json 2>/dev/null)" ]; then
+            echo "No pact files found in ${PACT_DIR}, skipping publish"
+            exit 0
+          fi
+          echo "Publishing pact files from ${PACT_DIR}:"
+          ls -la ${PACT_DIR}/*.json
+          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
+          export PATH="${PATH}:${HOME}/pact/bin"
+          pact-broker publish "${PACT_DIR}" \
+            --broker-base-url=https://greatexpectations.pactflow.io \
+            --broker-token="${PACT_BROKER_READ_WRITE_TOKEN}" \
+            --consumer-app-version="${GITHUB_SHA}" \
+            --branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+
       - name: Show cloud logs on test failure
         if: failure()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,15 +553,18 @@ jobs:
 
       - name: Publish pact contracts to PactFlow
         if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
+        continue-on-error: true
+        env:
+          PACT_CLI_VERSION: 2.4.7
         run: |
           PACT_DIR="tests/integration/cloud/rest_contracts/pacts"
-          if [ ! -d "${PACT_DIR}" ] || [ -z "$(ls -A ${PACT_DIR}/*.json 2>/dev/null)" ]; then
+          if [ ! -d "${PACT_DIR}" ] || ! compgen -G "${PACT_DIR}/*.json" > /dev/null; then
             echo "No pact files found in ${PACT_DIR}, skipping publish"
             exit 0
           fi
           echo "Publishing pact files from ${PACT_DIR}:"
           ls -la ${PACT_DIR}/*.json
-          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/v${PACT_CLI_VERSION}/install.sh | bash
           export PATH="${PATH}:${HOME}/pact/bin"
           pact-broker publish "${PACT_DIR}" \
             --broker-base-url=https://greatexpectations.pactflow.io \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,7 @@ jobs:
         if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
         continue-on-error: true
         env:
-          PACT_CLI_VERSION: 2.4.7
+          PACT_CLI_VERSION: 2.6.0
         run: |
           PACT_DIR="tests/integration/cloud/rest_contracts/pacts"
           if [ ! -d "${PACT_DIR}" ] || ! compgen -G "${PACT_DIR}/*.json" > /dev/null; then


### PR DESCRIPTION
## Summary

- Adds a CI step to publish pact contract files to PactFlow after cloud tests pass
- Required because pact-python v3 (GX-3024) removes built-in broker publishing — `Pact.write_file()` only writes locally
- Installs the Pact standalone CLI and runs `pact-broker publish` with the commit SHA as version

## Details

The step:
- **Only runs in CI** — gated on `PACT_BROKER_READ_WRITE_TOKEN` being set
- **Skips gracefully** if no pact files exist in `tests/integration/cloud/rest_contracts/pacts/`
- **Tags with branch name** via `--branch` for PactFlow branch-based matching
- Uses `GITHUB_SHA` as the consumer app version for traceability

## Dependencies

Depends on GX-3024 (pact-python v2 → v3 migration) to be fully effective. Until then, pact v2's built-in `publish_to_broker=True` handles publishing. Once v3 lands, this step becomes the sole publishing mechanism.

## Test plan

- [ ] CI passes on this branch (cloud-tests job runs the publish step)
- [ ] After GX-3024 merges, verify pact files appear in PactFlow at https://greatexpectations.pactflow.io
- [ ] Mercury provider verification continues to find and verify latest pacts
