### PR TITLE
[BUGFIX] Pin invoke==3.0.0 to avoid breaking change in 3.0.2

### DIFF
--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -1,5 +1,5 @@
 adr-tools-python==1.0.3
-invoke>=2.0.0
+invoke==3.0.0
 mypy==1.19.0
 pre-commit>=2.21.0
 ruff==0.14.9

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -1,4 +1,5 @@
 adr-tools-python==1.0.3
+# Pinned: invoke 3.0.2 introduced a breaking change that causes CI failures
 invoke==3.0.0
 mypy==1.19.0
 pre-commit>=2.21.0

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -193,7 +193,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 33
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 36
     assert set(sorted_packages_with_pins_or_upper_bounds) == {
         (
             "requirements-dev-api-docs-test.txt",
@@ -201,6 +201,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             (("==", "0.16"),),
         ),
         ("requirements-dev-contrib.txt", "adr-tools-python", (("==", "1.0.3"),)),
+        ("requirements-dev-contrib.txt", "invoke", (("==", "3.0.0"),)),
         ("requirements-dev-dremio.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev-excel.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements-dev-lite.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
@@ -231,12 +232,14 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             (("==", "17.0.0.5"),),
         ),
         ("requirements-dev-test.txt", "adr-tools-python", (("==", "1.0.3"),)),
+        ("requirements-dev-test.txt", "invoke", (("==", "3.0.0"),)),
         ("requirements-dev-test.txt", "docstring-parser", (("==", "0.16"),)),
         ("requirements-dev-test.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-test.txt", "pact-python", (("<", "4"), (">=", "3.1.0"))),
         ("requirements-dev.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev.txt", "altair", (("<", "7.0.0"), (">=", "5.0.0"))),
         ("requirements-dev.txt", "docstring-parser", (("==", "0.16"),)),
+        ("requirements-dev.txt", "invoke", (("==", "3.0.0"),)),
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev.txt", "pact-python", (("<", "4"), (">=", "3.1.0"))),


### PR DESCRIPTION
## Summary
- Pins `invoke` to `==3.0.0` in `reqs/requirements-dev-contrib.txt` (was `>=2.0.0`)
- `invoke` 3.0.2 introduced a breaking change that causes CI failures

## Test plan
- [ ] CI passes with pinned version