### PR TITLE
[BUGFIX] Fix default exact_match value in ExpectTableColumnsToMatchSet renderers

### DIFF
--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -51,6 +51,7 @@ EXACT_MATCH_DESCRIPTION = (
     "If True, the list of columns must exactly match the observed columns. "
     "If False, observed columns must include column_set but additional columns will pass."
 )
+EXACT_MATCH_DEFAULT = True
 DATA_QUALITY_ISSUES = [DataQualityIssues.SCHEMA.value]
 SUPPORTED_DATA_SOURCES = [
     SupportedDataSources.PANDAS.value,
@@ -199,7 +200,7 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
         description=COLUMN_SET_DESCRIPTION
     )
     exact_match: Union[bool, SuiteParameterDict, None] = pydantic.Field(
-        default=True, description=EXACT_MATCH_DESCRIPTION
+        default=EXACT_MATCH_DEFAULT, description=EXACT_MATCH_DESCRIPTION
     )
 
     library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
@@ -285,9 +286,10 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
                 renderer_configuration=renderer_configuration,
             )
 
-            exact_match_str = (
-                "exactly" if params.exact_match and params.exact_match.value is True else "at least"
+            exact_match = (
+                params.exact_match.value if params.exact_match is not None else EXACT_MATCH_DEFAULT
             )
+            exact_match_str = "at least" if not exact_match else "exactly"
 
             template_str = (
                 f"Must have {exact_match_str} these columns (in any order): {column_set_str}"
@@ -323,7 +325,10 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
                 [f"$column_list_{idx}" for idx in range(len(params["column_list"]))]
             )
 
-            exact_match_str = "exactly" if params["exact_match"] is True else "at least"
+            exact_match = (
+                params["exact_match"] if params["exact_match"] is not None else EXACT_MATCH_DEFAULT
+            )
+            exact_match_str = "at least" if not exact_match else "exactly"
 
             template_str = f"Must have {exact_match_str} these columns (in any order): {column_list_template_str}"  # noqa: E501 # FIXME CoP
 

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -1945,10 +1945,10 @@ def test_atomic_prescriptive_summary_expect_table_columns_to_match_set(
 
 
 @pytest.mark.unit
-def test_atomic_prescriptive_summary_expect_table_columns_to_match_set_omitted_exact_match_defaults_to_true(
+def test_atomic_prescriptive_columns_match_set_no_exact_match_uses_default(
     get_prescriptive_rendered_content,
 ):
-    """Omitted exact_match is not serialized into renderer params; template must use model default (True)."""
+    """When exact_match is omitted, renderer uses model default (True)."""
     update_dict = {
         "type": "expect_table_columns_to_match_set",
         "kwargs": {
@@ -1976,7 +1976,7 @@ def test_atomic_prescriptive_summary_expect_table_columns_to_match_set_omitted_e
 
 
 @pytest.mark.unit
-def test_legacy_prescriptive_expect_table_columns_to_match_set_omitted_exact_match_defaults_to_true():
+def test_legacy_prescriptive_columns_match_set_no_exact_match_uses_default():
     from great_expectations.expectations.core.expect_table_columns_to_match_set import (
         ExpectTableColumnsToMatchSet,
     )

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -1945,6 +1945,55 @@ def test_atomic_prescriptive_summary_expect_table_columns_to_match_set(
 
 
 @pytest.mark.unit
+def test_atomic_prescriptive_summary_expect_table_columns_to_match_set_omitted_exact_match_defaults_to_true(
+    get_prescriptive_rendered_content,
+):
+    """Omitted exact_match is not serialized into renderer params; template must use model default (True)."""
+    update_dict = {
+        "type": "expect_table_columns_to_match_set",
+        "kwargs": {
+            "column_set": ["a", "b", "c"],
+        },
+    }
+    rendered_content = get_prescriptive_rendered_content(update_dict)
+
+    res = rendered_content.to_json_dict()
+    pprint(res)
+    assert res == {
+        "name": "atomic.prescriptive.summary",
+        "value": {
+            "params": {
+                "column_set": {"schema": {"type": "array"}, "value": ["a", "b", "c"]},
+                "column_set_0": {"schema": {"type": "string"}, "value": "a"},
+                "column_set_1": {"schema": {"type": "string"}, "value": "b"},
+                "column_set_2": {"schema": {"type": "string"}, "value": "c"},
+            },
+            "schema": {"type": "com.superconductive.rendered.string"},
+            "template": "Must have exactly these columns (in any order): $column_set_0 $column_set_1 $column_set_2",  # noqa: E501 # FIXME CoP
+        },
+        "value_type": "StringValueType",
+    }
+
+
+@pytest.mark.unit
+def test_legacy_prescriptive_expect_table_columns_to_match_set_omitted_exact_match_defaults_to_true():
+    from great_expectations.expectations.core.expect_table_columns_to_match_set import (
+        ExpectTableColumnsToMatchSet,
+    )
+
+    config = ExpectationConfiguration(
+        type="expect_table_columns_to_match_set",
+        kwargs={"column_set": ["x", "y"]},
+    )
+    rendered = ExpectTableColumnsToMatchSet._prescriptive_renderer(configuration=config)
+    assert len(rendered) == 1
+    template = rendered[0].string_template["template"]
+    assert template == (
+        "Must have exactly these columns (in any order): $column_list_0, $column_list_1"
+    )
+
+
+@pytest.mark.unit
 def test_atomic_prescriptive_summary_expect_table_row_count_to_be_between(
     get_prescriptive_rendered_content,
 ):


### PR DESCRIPTION
This fixes https://github.com/great-expectations/great_expectations/issues/10978 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
