### PR TITLE
[FEATURE] Support `column.unique_proportion` in metric list runs

### DIFF
--- a/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
@@ -16,6 +16,12 @@ from great_expectations.experimental.metric_repository.metrics import (
 
 logger = logging.getLogger(__name__)
 
+# Non-numeric column metrics: value type → metric type
+_NON_NUMERIC_METRICS: dict[type, set[MetricTypes]] = {
+    int: {MetricTypes.COLUMN_NON_NULL_COUNT},
+    float: {MetricTypes.COLUMN_UNIQUE_PROPORTION},
+}
+
 if TYPE_CHECKING:
     from great_expectations.data_context import AbstractDataContext
     from great_expectations.datasource.fluent.batch_request import BatchRequest
@@ -111,32 +117,18 @@ class MetricListMetricRetriever(MetricRetriever):
         Returns:
             Sequence[Metric]: List of metrics for non-numeric columns.
         """
-        # Int-valued metrics (e.g. non-null count) and float-valued metrics (e.g. unique proportion)
-        # are computed separately because ColumnMetric is typed per value.
         metrics: list[Metric] = []
         metrics_list_as_set = set(metrics_list)
-        int_column_metrics = {MetricTypes.COLUMN_NON_NULL_COUNT}
-        float_column_metrics = {MetricTypes.COLUMN_UNIQUE_PROPORTION}
-
-        int_metrics_to_calculate = sorted(int_column_metrics.intersection(metrics_list_as_set))
-        float_metrics_to_calculate = sorted(float_column_metrics.intersection(metrics_list_as_set))
-
-        if int_metrics_to_calculate:
+        for value_type, metric_types in _NON_NUMERIC_METRICS.items():
+            metrics_to_calculate = sorted(metric_types.intersection(metrics_list_as_set))
+            if not metrics_to_calculate:
+                continue
             metrics.extend(
                 self._get_column_metrics(
                     batch_request=batch_request,
                     column_list=column_list,
-                    column_metric_names=list(int_metrics_to_calculate),
-                    column_metric_type=ColumnMetric[int],
-                )
-            )
-        if float_metrics_to_calculate:
-            metrics.extend(
-                self._get_column_metrics(
-                    batch_request=batch_request,
-                    column_list=column_list,
-                    column_metric_names=list(float_metrics_to_calculate),
-                    column_metric_type=ColumnMetric[float],
+                    column_metric_names=list(metrics_to_calculate),
+                    column_metric_type=ColumnMetric[value_type],  # type: ignore[valid-type]
                 )
             )
         return metrics

--- a/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
@@ -111,21 +111,35 @@ class MetricListMetricRetriever(MetricRetriever):
         Returns:
             Sequence[Metric]: List of metrics for non-numeric columns.
         """
-        # currently only the null-count is supported. If more metrics are added, this set will need to be updated.  # noqa: E501 # FIXME CoP
-        column_metric_names = {MetricTypes.COLUMN_NON_NULL_COUNT}
+        # Int-valued metrics (e.g. non-null count) and float-valued metrics (e.g. unique proportion)
+        # are computed separately because ColumnMetric is typed per value.
         metrics: list[Metric] = []
         metrics_list_as_set = set(metrics_list)
-        metrics_to_calculate = sorted(column_metric_names.intersection(metrics_list_as_set))
+        int_column_metrics = {MetricTypes.COLUMN_NON_NULL_COUNT}
+        float_column_metrics = {MetricTypes.COLUMN_UNIQUE_PROPORTION}
 
-        if not metrics_to_calculate:
-            return metrics
-        else:
-            return self._get_column_metrics(
-                batch_request=batch_request,
-                column_list=column_list,
-                column_metric_names=list(metrics_to_calculate),
-                column_metric_type=ColumnMetric[int],
+        int_metrics_to_calculate = sorted(int_column_metrics.intersection(metrics_list_as_set))
+        float_metrics_to_calculate = sorted(float_column_metrics.intersection(metrics_list_as_set))
+
+        if int_metrics_to_calculate:
+            metrics.extend(
+                self._get_column_metrics(
+                    batch_request=batch_request,
+                    column_list=column_list,
+                    column_metric_names=list(int_metrics_to_calculate),
+                    column_metric_type=ColumnMetric[int],
+                )
             )
+        if float_metrics_to_calculate:
+            metrics.extend(
+                self._get_column_metrics(
+                    batch_request=batch_request,
+                    column_list=column_list,
+                    column_metric_names=list(float_metrics_to_calculate),
+                    column_metric_type=ColumnMetric[float],
+                )
+            )
+        return metrics
 
     def _get_numeric_column_metrics(
         self,
@@ -247,5 +261,6 @@ class MetricListMetricRetriever(MetricRetriever):
             MetricTypes.COLUMN_MEAN,
             MetricTypes.COLUMN_NULL_COUNT,
             MetricTypes.COLUMN_NON_NULL_COUNT,
+            MetricTypes.COLUMN_UNIQUE_PROPORTION,
         ]
         return any(metric in metric_list for metric in column_metrics)

--- a/great_expectations/experimental/metric_repository/metrics.py
+++ b/great_expectations/experimental/metric_repository/metrics.py
@@ -49,6 +49,7 @@ class MetricTypes(str, enum.Enum, metaclass=MetricTypesMeta):
     COLUMN_MEAN = "column.mean"
     COLUMN_NULL_COUNT = "column_values.null.count"
     COLUMN_NON_NULL_COUNT = "column.non_null_count"
+    COLUMN_UNIQUE_PROPORTION = "column.unique_proportion"
 
 
 class MetricRepositoryBaseModel(BaseModel):

--- a/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
@@ -145,6 +145,8 @@ def test_get_metrics_full_list(
         ("column.median", "column=col2", ()): 2.7,
         ("column.non_null_count", "column=col1", ()): 0,
         ("column.non_null_count", "column=col2", ()): 0,
+        ("column.unique_proportion", "column=col1", ()): 0.5,
+        ("column.unique_proportion", "column=col2", ()): 0.75,
     }
     metrics_list = [
         MetricTypes.TABLE_ROW_COUNT,
@@ -155,6 +157,7 @@ def test_get_metrics_full_list(
         MetricTypes.COLUMN_MEAN,
         MetricTypes.COLUMN_MEDIAN,
         MetricTypes.COLUMN_NON_NULL_COUNT,
+        MetricTypes.COLUMN_UNIQUE_PROPORTION,
     ]
     aborted_metrics: Dict[str, str] = {}
     mock_validator.compute_metrics.return_value = (
@@ -255,6 +258,20 @@ def test_get_metrics_full_list(
             batch_id="batch_id",
             metric_name="column.non_null_count",
             value=0,
+            exception=None,
+            column="col2",
+        ),
+        ColumnMetric[float](
+            batch_id="batch_id",
+            metric_name="column.unique_proportion",
+            value=0.5,
+            exception=None,
+            column="col1",
+        ),
+        ColumnMetric[float](
+            batch_id="batch_id",
+            metric_name="column.unique_proportion",
+            value=0.75,
             exception=None,
             column="col2",
         ),
@@ -725,6 +742,7 @@ def test_valid_metric_types_true(mock_context, metric_retriever):
         MetricTypes.COLUMN_MEAN,
         MetricTypes.COLUMN_MEDIAN,
         MetricTypes.COLUMN_NON_NULL_COUNT,
+        MetricTypes.COLUMN_UNIQUE_PROPORTION,
     ]
     assert metric_retriever._check_valid_metric_types(valid_metric_types) is True
 


### PR DESCRIPTION
This PR adds support for `column.unique_proportion` in metric list runs: 

- Adds new `COLUMN_UNIQUE_PROPORTION` enum member to `MetricTypes`

- Updates the `MetricListMetricRetriever` to treat it as a non-numeric column-level metric. Compute Integer and float column metrics in separate batches so types stay correct. 

