### PR TITLE
[MAINTENANCE] Fix pact-broker publish step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,9 +553,8 @@ jobs:
 
       - name: Publish pact contracts to PactFlow
         if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
-        continue-on-error: true
         env:
-          PACT_CLI_VERSION: 2.6.0
+          PACT_CLI_VERSION: v2.6.0
         run: |
           PACT_DIR="tests/integration/cloud/rest_contracts/pacts"
           if [ ! -d "${PACT_DIR}" ] || ! compgen -G "${PACT_DIR}/*.json" > /dev/null; then
@@ -564,8 +563,8 @@ jobs:
           fi
           echo "Publishing pact files from ${PACT_DIR}:"
           ls -la ${PACT_DIR}/*.json
-          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/v${PACT_CLI_VERSION}/install.sh | bash
-          export PATH="${PATH}:${HOME}/pact/bin"
+          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/${PACT_CLI_VERSION}/install.sh | bash
+          export PATH="${PATH}:$(pwd)/pact/bin"
           pact-broker publish "${PACT_DIR}" \
             --broker-base-url=https://greatexpectations.pactflow.io \
             --broker-token="${PACT_BROKER_READ_WRITE_TOKEN}" \


### PR DESCRIPTION
## Summary
- **Fix PACT_CLI_VERSION**: `2.6.0` → `v2.6.0` to match the actual GitHub release tag. Without the `v` prefix, the download URL returned a 404 and `curl -sLO` silently saved the error page as the tarball.
- **Fix PATH**: `${HOME}/pact/bin` → `$(pwd)/pact/bin` to match where the install script actually places binaries.
- **Remove `continue-on-error: true`**: CI should fail if pact contracts can't be published. This flag was masking the above bugs since the publish step was introduced.

## Context
The pact v2→v3 migration (073dcd1f0) removed the built-in `pact-python` broker publish. The replacement CI step (ee270a9ce) has never successfully published due to these bugs. The last version in PactFlow (`ee9a46d82..._39b08`) was from the old v2 auto-publish.

## Test plan
- [ ] CI cloud-tests job passes
- [ ] "Publish pact contracts to PactFlow" step succeeds (no longer silently failing)
- [ ] New pact version appears in PactFlow UI for this commit