### PR TITLE
[MAINTENANCE] Add client-driven Pact contracts for datasource and expectation suite CRUD (GX-2731)

### DIFF
--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -96,6 +96,19 @@ DATA_CONTEXT_CONFIG_RESPONSE_BODY: Final[dict] = {
                 "suppress_store_backend_id": True,
             },
         },
+        "validation_definition_store": {
+            "class_name": "ValidationDefinitionStore",
+            "store_backend": {
+                "class_name": "GXCloudStoreBackend",
+                "ge_cloud_base_url": r"${GX_CLOUD_BASE_URL}",
+                "ge_cloud_credentials": {
+                    "access_token": r"${GX_CLOUD_ACCESS_TOKEN}",
+                    "organization_id": r"${GX_CLOUD_ORGANIZATION_ID}",
+                },
+                "ge_cloud_resource_type": "validation_definition",
+                "suppress_store_backend_id": True,
+            },
+        },
     },
 }
 
@@ -158,6 +171,7 @@ def cloud_data_context(
 def setup_data_context_config_interaction(
     pact_test: Pact,
     access_token: str,
+    description_suffix: str = "",
 ) -> None:
     """Register the GET /data-context-configuration Pact interaction.
 
@@ -174,14 +188,20 @@ def setup_data_context_config_interaction(
             ``PACT_DUMMY_ACCESS_TOKEN`` when no real credentials are needed (e.g.
             in the ``pact_cloud_context`` fixture), or a real token when testing
             against a live provider.
+        description_suffix: Optional suffix to make the ``upon_receiving``
+            description unique when multiple tests share the same ``pact_test``
+            fixture (pact v3 requires unique descriptions per interaction).
     """
     session = create_session(access_token=access_token)
     path = (
         f"/api/v1/organizations/{EXISTING_ORGANIZATION_ID}/"
         f"workspaces/{EXISTING_WORKSPACE_ID}/data-context-configuration"
     )
+    description = "a request for Data Context configuration (client-driven setup)"
+    if description_suffix:
+        description = f"{description} [{description_suffix}]"
     (
-        pact_test.upon_receiving("a request for Data Context configuration (client-driven setup)")
+        pact_test.upon_receiving(description)
         .given("the Data Context exists")
         .with_request("GET", path)
         .with_headers({k: str(v) for k, v in session.headers.items()})
@@ -207,7 +227,9 @@ def pact_cloud_context(
     Use this fixture in new client-driven contract tests instead of
     ``cloud_data_context``.
     """
-    setup_data_context_config_interaction(pact_test, access_token=PACT_DUMMY_ACCESS_TOKEN)
+    setup_data_context_config_interaction(
+        pact_test, access_token=PACT_DUMMY_ACCESS_TOKEN, description_suffix="pact-cloud-context"
+    )
 
     with pact_test.serve() as srv:
         context = CloudDataContext(
@@ -224,15 +246,18 @@ def get_git_commit_hash() -> str:
     return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
 
 
-@pytest.fixture(scope="package")
-def pact_test(request) -> Generator[Pact, None, None]:
+@pytest.fixture
+def pact_test() -> Generator[Pact, None, None]:
     """
-    pact_test yields a Pact v3 instance. Interactions are registered on it,
-    then ``pact.serve()`` is used as a context manager in each test to start
-    the mock server.  After all tests complete, the pact file is written to
-    disk.
+    pact_test yields a fresh Pact v3 instance per test.  Each test registers
+    interactions, calls ``pact.serve()`` to start the mock server, and on
+    teardown the pact file is written (merged) to disk.
+
+    Must be function-scoped because the pact-python v3 Rust FFI permanently
+    locks the ``PactHandle`` after ``serve()`` is called, preventing any new
+    interactions from being registered on the same instance.
     """
     _pact = Pact(CONSUMER_NAME, PROVIDER_NAME)
     yield _pact
     PACT_DIR.mkdir(parents=True, exist_ok=True)
-    _pact.write_file(str(PACT_DIR), overwrite=True)
+    _pact.write_file(str(PACT_DIR), overwrite=False)

--- a/tests/integration/cloud/rest_contracts/test_datasource_suite_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource_suite_contracts.py
@@ -1,0 +1,462 @@
+"""Client-driven Pact contract tests for datasource and expectation suite CRUD.
+
+Each test:
+1. Registers the GET /data-context-configuration interaction via
+   ``setup_data_context_config_interaction()``.
+2. Registers resource-specific Pact interaction(s).
+3. Constructs a ``CloudDataContext`` and exercises the Python client API
+   inside the ``with pact_test.serve() as srv:`` block.
+4. Asserts the client correctly parses the response.
+
+URL patterns (V2 with workspace):
+  /api/v2/organizations/{org_id}/workspaces/{ws_id}/datasources
+  /api/v2/organizations/{org_id}/workspaces/{ws_id}/expectation-suites
+"""
+
+from __future__ import annotations
+
+from typing import Final
+from unittest.mock import patch
+
+import pytest
+from pact import Pact, match
+
+import great_expectations as gx
+from great_expectations import __version__ as ge_version
+from great_expectations.core.http import create_session
+from tests.integration.cloud.rest_contracts.conftest import (
+    EXISTING_ORGANIZATION_ID,
+    EXISTING_WORKSPACE_ID,
+    PACT_DUMMY_ACCESS_TOKEN,
+    setup_data_context_config_interaction,
+)
+
+# ---------------------------------------------------------------------------
+# Shared constants -- datasources
+# ---------------------------------------------------------------------------
+
+DATASOURCE_NAME: Final[str] = "my_contract_test_datasource"
+EXISTING_DATASOURCE_ID: Final[str] = "bbbbcccc-0001-4abc-8def-aabbccddeeff"
+
+DATASOURCES_PATH: Final[str] = (
+    f"/api/v2/organizations/{EXISTING_ORGANIZATION_ID}"
+    f"/workspaces/{EXISTING_WORKSPACE_ID}/datasources"
+)
+DATASOURCE_BY_ID_PATH: Final[str] = f"{DATASOURCES_PATH}/{EXISTING_DATASOURCE_ID}"
+
+# ---------------------------------------------------------------------------
+# Shared constants -- expectation suites
+# ---------------------------------------------------------------------------
+
+SUITE_NAME: Final[str] = "my_contract_test_suite"
+EXISTING_SUITE_ID: Final[str] = "bbbbcccc-0002-4abc-8def-aabbccddeeff"
+
+SUITES_PATH: Final[str] = (
+    f"/api/v2/organizations/{EXISTING_ORGANIZATION_ID}"
+    f"/workspaces/{EXISTING_WORKSPACE_ID}/expectation-suites"
+)
+SUITE_BY_ID_PATH: Final[str] = f"{SUITES_PATH}/{EXISTING_SUITE_ID}"
+
+# ---------------------------------------------------------------------------
+# Shared response payloads
+# ---------------------------------------------------------------------------
+
+# Minimal datasource payload returned by the cloud API.
+_DATASOURCE_RESPONSE: Final[dict] = {
+    "id": EXISTING_DATASOURCE_ID,
+    "type": "pandas",
+    "name": DATASOURCE_NAME,
+    "assets": [],
+}
+
+# Minimal expectation suite payload returned by the cloud API.
+# ``meta.great_expectations_version`` MUST match the installed GX version
+# exactly -- the freshness check compares the local suite against the
+# deserialized cloud response and a mismatch causes
+# ``ExpectationSuiteNotFreshError``.
+_SUITE_RESPONSE: Final[dict] = {
+    "id": EXISTING_SUITE_ID,
+    "name": SUITE_NAME,
+    "expectations": [],
+    "meta": {"great_expectations_version": match.like(ge_version)},
+    "notes": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _session_headers() -> dict:
+    """Return request headers matching what the Python client sends."""
+    session = create_session(access_token=PACT_DUMMY_ACCESS_TOKEN)
+    return {k: str(v) for k, v in session.headers.items()}
+
+
+# ---------------------------------------------------------------------------
+# Datasource tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+def test_get_datasource_by_name(pact_test: Pact) -> None:
+    """context.data_sources.get(name=...) retrieves a datasource from the store.
+
+    ``CacheableDatasourceDict.__getitem__`` calls
+    ``DatasourceStore.retrieve_by_name()`` which issues ``has_key`` + ``get``
+    -- two identical GET requests served by a single Pact interaction.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration           (context init)
+      2. GET /datasources?name=...                 (serves has_key + get)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="get-datasource",
+    )
+
+    # 2. GET /datasources?name=...
+    (
+        pact_test.upon_receiving("a request to get a datasource by name (client-driven)")
+        .given("a datasource with this name exists")
+        .with_request("GET", DATASOURCES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": DATASOURCE_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_DATASOURCE_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        result = ctx.data_sources.get(name=DATASOURCE_NAME)
+
+    assert result is not None
+    assert result.name == DATASOURCE_NAME
+
+
+@pytest.mark.cloud
+def test_delete_datasource(pact_test: Pact) -> None:
+    """context.data_sources.delete(name=...) fetches the datasource then DELETEs it.
+
+    ``_delete_fluent_datasource`` calls ``data_sources.all().get(name)`` to
+    resolve the datasource (and its cloud id) via the store, then issues
+    ``DatasourceStore.delete()`` -> ``remove_key()`` -> HTTP DELETE.
+
+    ``_save_project_config()`` is a no-op in CloudDataContext.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration           (context init)
+      2. GET /datasources?name=...                 (resolve datasource for deletion)
+      3. DELETE /datasources/{id}                  (delete by id)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="delete-datasource",
+    )
+
+    # 2. GET /datasources?name=...
+    (
+        pact_test.upon_receiving(
+            "fetch datasource by name to resolve id for delete (client-driven)"
+        )
+        .given("a datasource with this name exists for deletion")
+        .with_request("GET", DATASOURCES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": DATASOURCE_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_DATASOURCE_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    # 3. DELETE /datasources/{id}
+    (
+        pact_test.upon_receiving("a request to delete a datasource by id (client-driven)")
+        .given("a datasource with this name exists for deletion")
+        .with_request("DELETE", DATASOURCE_BY_ID_PATH)
+        .with_headers(headers)
+        .will_respond_with(200)
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+
+        # _delete_fluent_datasource ends with
+        # ``del self.config.fluent_datasources[name]``.
+        # Seed the config dict so the cleanup line doesn't KeyError.
+        from great_expectations.datasource.fluent.pandas_datasource import (
+            PandasDatasource,
+        )
+
+        placeholder = PandasDatasource(name=DATASOURCE_NAME)
+        ctx.config.fluent_datasources[DATASOURCE_NAME] = placeholder
+
+        ctx.data_sources.delete(name=DATASOURCE_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Expectation suite tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+def test_get_expectation_suite_by_name(pact_test: Pact) -> None:
+    """context.suites.get(name=...) issues has_key then GET.
+
+    ``SuiteFactory.get`` calls ``store.has_key(key)`` then ``store.get(key)``
+    -- both issue identical GET requests served by a single Pact interaction.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration           (context init)
+      2. GET /expectation-suites?name=...          (serves has_key + get)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="get-suite",
+    )
+
+    # 2. GET /expectation-suites?name=...
+    (
+        pact_test.upon_receiving("a request to get an expectation suite by name (client-driven)")
+        .given("an expectation suite with this name exists")
+        .with_request("GET", SUITES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": SUITE_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_SUITE_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        result = ctx.suites.get(name=SUITE_NAME)
+
+    assert result is not None
+    assert result.name == SUITE_NAME
+
+
+@pytest.mark.cloud
+def test_add_expectation_suite(pact_test: Pact) -> None:
+    """context.suites.add(suite) issues has_key probe then POST.
+
+    ``SuiteFactory.add`` checks ``store.has_key()`` (empty list -> suite
+    absent), then calls ``store.add()`` which POSTs the suite.  After the
+    POST, ``add()`` calls ``self.get(name)`` to re-fetch the persisted suite,
+    which would issue the same GET ?name=... but expects a *non-empty*
+    response.  The Pact v3 mock server cannot serve different responses for
+    the same request criteria, so we patch the re-fetch.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration           (context init)
+      2. GET /expectation-suites?name=...          (has_key probe -- empty list)
+      3. POST /expectation-suites                  (create the suite)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="add-suite",
+    )
+
+    # 2. GET /expectation-suites?name=... -- has_key probe (empty -> suite absent)
+    (
+        pact_test.upon_receiving("has_key probe for suite before add (client-driven)")
+        .given("no expectation suite with this name exists")
+        .with_request("GET", SUITES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": SUITE_NAME})
+        .will_respond_with(200)
+        .with_body({"data": []}, content_type="application/json")
+    )
+
+    # 3. POST /expectation-suites
+    request_body: match.AbstractMatcher = match.like(
+        {
+            "data": match.like(
+                {
+                    "name": match.like(SUITE_NAME),
+                    "id": None,
+                    "expectations": match.like([]),
+                    "meta": match.like({"great_expectations_version": match.like("1.0.0")}),
+                    "notes": None,
+                }
+            )
+        }
+    )
+    response_body = {"data": match.like(_SUITE_RESPONSE)}
+    (
+        pact_test.upon_receiving("a request to create an expectation suite (client-driven)")
+        .given("no expectation suite with this name exists")
+        .with_request("POST", SUITES_PATH)
+        .with_headers(headers)
+        .with_body(request_body, content_type="application/vnd.api+json")
+        .will_respond_with(201)
+        .with_body(response_body, content_type="application/json")
+    )
+
+    # Build a mock suite for the patched SuiteFactory.get() re-fetch.
+    from great_expectations.core.expectation_suite import ExpectationSuite
+
+    refetched_suite = ExpectationSuite(name=SUITE_NAME)
+    refetched_suite.id = EXISTING_SUITE_ID
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+
+        with patch.object(
+            type(ctx.suites),
+            "get",
+            return_value=refetched_suite,
+        ):
+            result = ctx.suites.add(ExpectationSuite(name=SUITE_NAME))
+
+    assert result is not None
+    assert result.name == SUITE_NAME
+
+
+@pytest.mark.cloud
+def test_delete_expectation_suite(pact_test: Pact) -> None:
+    """context.suites.delete(name=...) fetches the suite then DELETE /{id}.
+
+    ``SuiteFactory.delete`` calls ``self.get(name)`` to resolve the cloud id
+    (which issues has_key + get -- two identical GETs served by one
+    interaction), then issues ``store.remove_key(key)`` -> HTTP DELETE.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration           (context init)
+      2. GET /expectation-suites?name=...          (serves has_key + get)
+      3. DELETE /expectation-suites/{id}           (delete by id)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="delete-suite",
+    )
+
+    # 2. GET /expectation-suites?name=... -- serves has_key + get
+    (
+        pact_test.upon_receiving("fetch suite by name to resolve id for delete (client-driven)")
+        .given("an expectation suite with this name exists for deletion")
+        .with_request("GET", SUITES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": SUITE_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_SUITE_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    # 3. DELETE /expectation-suites/{id}
+    (
+        pact_test.upon_receiving("a request to delete an expectation suite by id (client-driven)")
+        .given("an expectation suite with this name exists for deletion")
+        .with_request("DELETE", SUITE_BY_ID_PATH)
+        .with_headers(headers)
+        .will_respond_with(200)
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        ctx.suites.delete(name=SUITE_NAME)
+
+
+@pytest.mark.cloud
+def test_get_all_expectation_suites(pact_test: Pact) -> None:
+    """context.suites.all() retrieves all suites from the store.
+
+    ``SuiteFactory.all`` calls ``store.get_all()`` which issues a single GET
+    to the collection endpoint without query parameters.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration           (context init)
+      2. GET /expectation-suites                   (get all)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="get-all-suites",
+    )
+
+    # 2. GET /expectation-suites (no query params)
+    (
+        pact_test.upon_receiving("a request to get all expectation suites (client-driven)")
+        .given("expectation suites exist")
+        .with_request("GET", SUITES_PATH)
+        .with_headers(headers)
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_SUITE_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        result = list(ctx.suites.all())
+
+    assert len(result) >= 1
+    assert result[0].name == SUITE_NAME

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -1,0 +1,839 @@
+"""Client-driven Pact contract tests for validation definition and checkpoint CRUD.
+
+Each test:
+1. Registers the GET /data-context-configuration interaction via
+   ``setup_data_context_config_interaction()``.
+2. Registers resource-specific Pact interaction(s).
+3. Constructs a ``CloudDataContext`` and exercises the Python client API
+   inside the ``with pact_test.serve() as srv:`` block.
+4. Asserts the client correctly parses the response.
+
+URL patterns (V1 with workspace):
+  /api/v1/organizations/{org_id}/workspaces/{ws_id}/validation-definitions
+  /api/v1/organizations/{org_id}/workspaces/{ws_id}/checkpoints
+
+Note on checkpoint.run():
+  Testing checkpoint.run() API interactions is deferred to a multi-step
+  workflow test (GX-2731) because it requires a fully configured datasource,
+  suite, and validation definition to already exist.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+from unittest.mock import patch
+
+import pytest
+from pact import Pact, match
+
+import great_expectations as gx
+from great_expectations import __version__ as ge_version
+from great_expectations.core.http import create_session
+from tests.integration.cloud.rest_contracts.conftest import (
+    EXISTING_ORGANIZATION_ID,
+    EXISTING_WORKSPACE_ID,
+    PACT_DUMMY_ACCESS_TOKEN,
+    setup_data_context_config_interaction,
+)
+
+# ---------------------------------------------------------------------------
+# Shared constants -- validation definitions
+# ---------------------------------------------------------------------------
+
+VALDEF_NAME: Final[str] = "my_contract_test_valdef"
+EXISTING_VALDEF_ID: Final[str] = "ccccdddd-1234-4abc-8def-aabbccddeeff"
+
+VALDEF_PATH: Final[str] = (
+    f"/api/v1/organizations/{EXISTING_ORGANIZATION_ID}"
+    f"/workspaces/{EXISTING_WORKSPACE_ID}/validation-definitions"
+)
+VALDEF_BY_ID_PATH: Final[str] = f"{VALDEF_PATH}/{EXISTING_VALDEF_ID}"
+
+# ---------------------------------------------------------------------------
+# Shared constants -- checkpoints
+# ---------------------------------------------------------------------------
+
+CHECKPOINT_NAME: Final[str] = "my_contract_test_checkpoint"
+EXISTING_CHECKPOINT_ID: Final[str] = "eeeeffff-5678-4cde-9fab-112233445566"
+
+CHECKPOINTS_PATH: Final[str] = (
+    f"/api/v1/organizations/{EXISTING_ORGANIZATION_ID}"
+    f"/workspaces/{EXISTING_WORKSPACE_ID}/checkpoints"
+)
+CHECKPOINT_BY_ID_PATH: Final[str] = f"{CHECKPOINTS_PATH}/{EXISTING_CHECKPOINT_ID}"
+
+# ---------------------------------------------------------------------------
+# Shared constants -- supporting resources for validation definition tests
+# ---------------------------------------------------------------------------
+
+EXISTING_DATASOURCE_ID: Final[str] = "aaaabbbb-0001-4abc-8def-112233445566"
+EXISTING_ASSET_ID: Final[str] = "aaaabbbb-0002-4abc-8def-112233445566"
+EXISTING_BATCH_DEF_ID: Final[str] = "aaaabbbb-0003-4abc-8def-112233445566"
+EXISTING_SUITE_ID: Final[str] = "aaaabbbb-0004-4abc-8def-112233445566"
+
+DATASOURCE_NAME: Final[str] = "my_valdef_test_datasource"
+ASSET_NAME: Final[str] = "my_valdef_test_asset"
+BATCH_DEF_NAME: Final[str] = "my_valdef_test_batch_def"
+SUITE_NAME: Final[str] = "my_valdef_test_suite"
+
+DATASOURCES_PATH: Final[str] = (
+    f"/api/v2/organizations/{EXISTING_ORGANIZATION_ID}"
+    f"/workspaces/{EXISTING_WORKSPACE_ID}/datasources"
+)
+SUITES_PATH: Final[str] = (
+    f"/api/v2/organizations/{EXISTING_ORGANIZATION_ID}"
+    f"/workspaces/{EXISTING_WORKSPACE_ID}/expectation-suites"
+)
+
+# ---------------------------------------------------------------------------
+# Shared response payloads
+# ---------------------------------------------------------------------------
+
+# Minimal validation definition payload returned by the cloud API.
+_VALDEF_RESPONSE: Final[dict] = {
+    "id": EXISTING_VALDEF_ID,
+    "name": VALDEF_NAME,
+    "data": {
+        "datasource": {
+            "name": match.like(DATASOURCE_NAME),
+            "id": EXISTING_DATASOURCE_ID,
+        },
+        "asset": {
+            "name": match.like(ASSET_NAME),
+            "id": EXISTING_ASSET_ID,
+        },
+        "batch_definition": {
+            "name": match.like(BATCH_DEF_NAME),
+            "id": EXISTING_BATCH_DEF_ID,
+        },
+    },
+    "suite": {
+        "name": match.like(SUITE_NAME),
+        "id": EXISTING_SUITE_ID,
+    },
+}
+
+# Datasource payload with one DataFrameAsset that has one BatchDefinition.
+_DATASOURCE_WITH_ASSET_AND_BATCH_DEF: Final[dict] = {
+    "id": EXISTING_DATASOURCE_ID,
+    "type": "pandas",
+    "name": DATASOURCE_NAME,
+    "assets": [
+        {
+            "id": EXISTING_ASSET_ID,
+            "type": "dataframe",
+            "name": ASSET_NAME,
+            "batch_definitions": [
+                {
+                    "id": EXISTING_BATCH_DEF_ID,
+                    "name": BATCH_DEF_NAME,
+                }
+            ],
+        }
+    ],
+}
+
+
+# Suite payload (minimal) returned for the test suite.
+# The ``meta.great_expectations_version`` value MUST match the installed GX
+# version exactly.  The freshness check (``ExpectationSuite._is_fresh``)
+# compares the locally-created suite object against the one deserialized from
+# the cloud response.  A locally-created suite automatically stamps its meta
+# with the real ``ge_version``, so the mock must return the same value or the
+# equality check fails with ``ExpectationSuiteNotFreshError``.
+_SUITE_RESPONSE: Final[dict] = {
+    "id": EXISTING_SUITE_ID,
+    "name": SUITE_NAME,
+    "expectations": [],
+    "meta": {"great_expectations_version": match.like(ge_version)},
+    "notes": None,
+}
+
+# Minimal checkpoint payload returned by the cloud API.
+_CHECKPOINT_RESPONSE: Final[dict] = {
+    "id": EXISTING_CHECKPOINT_ID,
+    "name": CHECKPOINT_NAME,
+    "validation_definitions": [],
+    "actions": [],
+    "result_format": match.like("SUMMARY"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _session_headers() -> dict:
+    """Return request headers matching what the Python client sends."""
+    session = create_session(access_token=PACT_DUMMY_ACCESS_TOKEN)
+    return {k: str(v) for k, v in session.headers.items()}
+
+
+def _register_datasource_get_interactions(
+    pact_test: Pact,
+    headers: dict,
+) -> None:
+    """Register an interaction to retrieve an existing Pandas datasource by name.
+
+    ``ctx.data_sources.get(name=...)`` calls ``retrieve_by_name`` which issues
+    two identical GET requests (``has_key`` + actual fetch) to the same URL.
+    Pact v3 reuses a single interaction for both.
+
+    After retrieval the datasource is cached in ``CacheableDatasourceDict``,
+    so subsequent freshness checks during validation definition serialization
+    hit the cache and do NOT make additional HTTP calls.
+
+    Interaction sequence:
+      1. GET /datasources?name=...  (serves both has_key + fetch in retrieve_by_name)
+    """
+    response_body = {"data": match.each_like(_DATASOURCE_WITH_ASSET_AND_BATCH_DEF, min=1)}
+    (
+        pact_test.upon_receiving(
+            "fetch existing datasource by name for valdef test (client-driven)"
+        )
+        .given("the datasource with asset and batch def exists for valdef test")
+        .with_request("GET", DATASOURCES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": DATASOURCE_NAME})
+        .will_respond_with(200)
+        .with_body(response_body, content_type="application/json")
+    )
+
+
+def _register_suite_setup_interactions(
+    pact_test: Pact,
+    headers: dict,
+) -> None:
+    """Register interactions to create an ExpectationSuite.
+
+    The factory ``has_key`` probe issues a GET ?name=... that returns an empty
+    list.  The POST creates the suite.
+
+    After the POST, ``SuiteFactory.add()`` calls ``self.get(name)`` to re-fetch
+    the persisted suite, which would issue the same GET ?name=... but expects a
+    *non-empty* response.  The pact v3 mock server matches by
+    method/path/query -- not by provider state -- so it cannot serve two
+    different responses for the same request.  The caller must patch
+    ``SuiteFactory.get`` to avoid this extra GET.
+
+    Interaction sequence:
+      1. GET /expectation-suites?name=... (factory has_key probe -- empty list)
+      2. POST /expectation-suites         (create the suite)
+    """
+    # 1. GET ?name=... -- serves factory has_key probe (empty -> suite absent)
+    (
+        pact_test.upon_receiving(
+            "has_key probe for suite before add for valdef test (client-driven)"
+        )
+        .given("no expectation suite with this name exists for valdef test")
+        .with_request("GET", SUITES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": SUITE_NAME})
+        .will_respond_with(200)
+        .with_body({"data": []}, content_type="application/json")
+    )
+
+    # 2. POST /expectation-suites
+    request_body: match.AbstractMatcher = match.like(
+        {
+            "data": match.like(
+                {
+                    "name": match.like(SUITE_NAME),
+                    "id": None,
+                    "expectations": match.like([]),
+                    "meta": match.like({"great_expectations_version": match.like("1.0.0")}),
+                    "notes": None,
+                }
+            )
+        }
+    )
+    response_body = {"data": match.like(_SUITE_RESPONSE)}
+    (
+        pact_test.upon_receiving("create expectation suite for valdef test (client-driven)")
+        .given("no expectation suite with this name exists for valdef test")
+        .with_request("POST", SUITES_PATH)
+        .with_headers(headers)
+        .with_body(request_body, content_type="application/vnd.api+json")
+        .will_respond_with(201)
+        .with_body(response_body, content_type="application/json")
+    )
+
+
+def _register_suite_freshness_interactions(
+    pact_test: Pact,
+    headers: dict,
+    scenario_suffix: str,
+) -> None:
+    """Register the GET interaction that the suite's is_fresh() check makes.
+
+    When the ValidationDefinition serializer calls suite.identifier_bundle(),
+    it runs is_fresh() which calls store.get(key) with the suite id.
+    This results in a GET /expectation-suites/{id} request.
+    """
+    suite_by_id_path = f"{SUITES_PATH}/{EXISTING_SUITE_ID}"
+    response_body = {"data": match.like(_SUITE_RESPONSE)}
+    (
+        pact_test.upon_receiving(
+            f"fetch suite by id for freshness check {scenario_suffix} (client-driven)"
+        )
+        .given("the expectation suite exists and is fresh for valdef test")
+        .with_request("GET", suite_by_id_path)
+        .with_headers(headers)
+        .with_query_parameters({"name": SUITE_NAME})
+        .will_respond_with(200)
+        .with_body(response_body, content_type="application/json")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation definition tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+def test_add_validation_definition(pact_test: Pact) -> None:
+    """context.validation_definitions.add() issues has_key probes then POST.
+
+    Creating a ValidationDefinition requires a persisted BatchDefinition (with
+    datasource + asset) and a persisted ExpectationSuite.
+
+    The datasource is retrieved (not created) via ``ctx.data_sources.get()``,
+    which calls ``retrieve_by_name`` -> ``GET /datasources?name=...``.  After
+    retrieval the datasource is cached, so the freshness check during
+    validation definition serialization hits the cache without additional
+    HTTP calls.
+
+    After the suite POST, ``SuiteFactory.add()`` re-fetches via ``self.get()``
+    which issues the same GET ?name=... as the has_key probe but expects a
+    different response.  The pact v3 mock server matches by
+    method/path/query -- not by provider state -- so we patch the re-fetch.
+
+    Full interaction sequence:
+      1.  GET /data-context-configuration          (context init)
+      2.  GET /datasources?name=...          (retrieve existing datasource -- cached afterward)
+      3.  GET /expectation-suites?name=...   (factory has_key probe -- empty list)
+      4.  POST /expectation-suites                 (create suite)
+      5.  GET  /expectation-suites/{id}            (suite freshness check)
+      6.  GET  /validation-definitions?name=... (factory has_key for valdef -- empty list)
+      7.  POST /validation-definitions             (create)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="add-validation-definition",
+    )
+
+    # 2. Retrieve existing datasource (cached -- no freshness interaction needed)
+    _register_datasource_get_interactions(pact_test=pact_test, headers=headers)
+
+    # 3-4. Create expectation suite (has_key probe + POST; re-fetch is patched)
+    _register_suite_setup_interactions(pact_test=pact_test, headers=headers)
+
+    # 5. Suite freshness check (called during valdef serialization)
+    _register_suite_freshness_interactions(
+        pact_test=pact_test,
+        headers=headers,
+        scenario_suffix="before valdef add",
+    )
+
+    # 6. GET /validation-definitions?name=... -- factory has_key probe (empty list)
+    (
+        pact_test.upon_receiving(
+            "has_key probe for validation definition before add (client-driven)"
+        )
+        .given("no validation definition with this name exists")
+        .with_request("GET", VALDEF_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": VALDEF_NAME})
+        .will_respond_with(200)
+        .with_body({"data": []}, content_type="application/json")
+    )
+
+    # 7. POST /validation-definitions
+    post_valdef_request_body: match.AbstractMatcher = match.like(
+        {
+            "data": match.like(
+                {
+                    "name": match.like(VALDEF_NAME),
+                    "data": match.like(
+                        {
+                            "datasource": match.like(
+                                {
+                                    "name": match.like(DATASOURCE_NAME),
+                                    "id": match.uuid(),
+                                }
+                            ),
+                            "asset": match.like(
+                                {
+                                    "name": match.like(ASSET_NAME),
+                                    "id": match.uuid(),
+                                }
+                            ),
+                            "batch_definition": match.like(
+                                {
+                                    "name": match.like(BATCH_DEF_NAME),
+                                    "id": match.uuid(),
+                                }
+                            ),
+                        }
+                    ),
+                    "suite": match.like(
+                        {
+                            "name": match.like(SUITE_NAME),
+                            "id": match.uuid(),
+                        }
+                    ),
+                }
+            )
+        }
+    )
+    post_valdef_response_body = {"data": match.like(_VALDEF_RESPONSE)}
+    (
+        pact_test.upon_receiving("a request to add a validation definition (client-driven)")
+        .given("no validation definition with this name exists")
+        .with_request("POST", VALDEF_PATH)
+        .with_headers(headers)
+        .with_body(post_valdef_request_body, content_type="application/vnd.api+json")
+        .will_respond_with(201)
+        .with_body(post_valdef_response_body, content_type="application/json")
+    )
+
+    # Build a mock suite for the patched SuiteFactory.get() re-fetch.
+    # This avoids the pact v3 limitation where two interactions with the same
+    # method/path/query cannot return different responses.
+    from great_expectations.core.expectation_suite import ExpectationSuite
+
+    refetched_suite = ExpectationSuite(name=SUITE_NAME)
+    refetched_suite.id = EXISTING_SUITE_ID
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+
+        # Retrieve the existing datasource + asset + batch definition
+        datasource = ctx.data_sources.get(name=DATASOURCE_NAME)
+        asset = datasource.get_asset(name=ASSET_NAME)
+        batch_def = asset.get_batch_definition(name=BATCH_DEF_NAME)
+
+        # Create the expectation suite (patch the post-creation re-fetch)
+        with patch.object(
+            type(ctx.suites),
+            "get",
+            return_value=refetched_suite,
+        ):
+            suite = ctx.suites.add(ExpectationSuite(name=SUITE_NAME))
+
+        # Create the validation definition
+        from great_expectations.core.validation_definition import ValidationDefinition
+
+        val_def = ValidationDefinition(
+            name=VALDEF_NAME,
+            data=batch_def,
+            suite=suite,
+        )
+        result = ctx.validation_definitions.add(val_def)
+
+    assert result is not None
+    assert result.name == VALDEF_NAME
+
+
+@pytest.mark.cloud
+def test_get_validation_definition_by_name(pact_test: Pact) -> None:
+    """context.validation_definitions.get(name=...) issues has_key then GET.
+
+    Deserializing the response triggers additional GETs for the datasource
+    and suite.  The datasource uses ``retrieve_by_name`` (two identical GETs:
+    ``has_key`` + actual get to the collection URL), so a single interaction
+    serves that pair.  The suite is fetched by id+name via
+    ``expectation_store.get(key)`` which hits ``GET /expectation-suites/{id}``.
+
+    Full interaction sequence:
+      1.  GET /data-context-configuration           (context init)
+      2.  GET /validation-definitions?name=...      (serves factory has_key + store.get fetch)
+      3.  GET /datasources?name=...          (serves datasource has_key + fetch in _decode_data)
+      4.  GET /expectation-suites/{id}       (suite fetch by id in _decode_suite)
+    """
+    headers = _session_headers()
+
+    datasource_by_name_response = {
+        "data": match.each_like(_DATASOURCE_WITH_ASSET_AND_BATCH_DEF, min=1)
+    }
+    suite_by_id_path = f"{SUITES_PATH}/{EXISTING_SUITE_ID}"
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="get-validation-definition",
+    )
+
+    # 2. GET /validation-definitions?name=... -- serves factory has_key + store.get fetch
+    (
+        pact_test.upon_receiving("a request to get a validation definition by name (client-driven)")
+        .given("a validation definition with this name exists")
+        .with_request("GET", VALDEF_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": VALDEF_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_VALDEF_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    # 3. GET /datasources?name=... -- serves both retrieve_by_name calls in _decode_data
+    (
+        pact_test.upon_receiving(
+            "fetch datasource during validation definition deserialization (client-driven)"
+        )
+        .given("the datasource exists for validation definition get")
+        .with_request("GET", DATASOURCES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": DATASOURCE_NAME})
+        .will_respond_with(200)
+        .with_body(datasource_by_name_response, content_type="application/json")
+    )
+
+    # 4. GET /expectation-suites/{id}?name=... -- suite fetch by id during _decode_suite
+    (
+        pact_test.upon_receiving(
+            "fetch suite by id during validation definition deserialization (client-driven)"
+        )
+        .given("the expectation suite exists for validation definition get")
+        .with_request("GET", suite_by_id_path)
+        .with_headers(headers)
+        .with_query_parameters({"name": SUITE_NAME})
+        .will_respond_with(200)
+        .with_body({"data": match.like(_SUITE_RESPONSE)}, content_type="application/json")
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        result = ctx.validation_definitions.get(name=VALDEF_NAME)
+
+    assert result is not None
+    assert result.name == VALDEF_NAME
+
+
+@pytest.mark.cloud
+def test_delete_validation_definition(pact_test: Pact) -> None:
+    """context.validation_definitions.delete(name) fetches then DELETE /{id}.
+
+    ``ValidationDefinitionFactory.delete`` first calls ``self.get(name)``
+    to resolve the cloud id, then issues DELETE to the id-scoped URL.
+    The get() step triggers suite and datasource deserialization.  The
+    datasource uses ``retrieve_by_name`` (two identical GETs to the
+    collection URL); the suite is fetched by id via
+    ``expectation_store.get(key)`` -> ``GET /expectation-suites/{id}``.
+
+    Full interaction sequence:
+      1.  GET /data-context-configuration           (context init)
+      2.  GET /validation-definitions?name=...      (serves factory has_key + store.get in get())
+      3.  GET /datasources?name=...          (serves datasource has_key + fetch in _decode_data)
+      4.  GET /expectation-suites/{id}       (suite fetch by id in _decode_suite)
+      5.  DELETE /validation-definitions/{id}       (delete by id)
+    """
+    headers = _session_headers()
+
+    datasource_by_name_response = {
+        "data": match.each_like(_DATASOURCE_WITH_ASSET_AND_BATCH_DEF, min=1)
+    }
+    suite_by_id_path = f"{SUITES_PATH}/{EXISTING_SUITE_ID}"
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="delete-validation-definition",
+    )
+
+    # 2. GET /validation-definitions?name=... -- serves factory has_key + store.get in get()
+    (
+        pact_test.upon_receiving(
+            "fetch validation definition by name to resolve id for delete (client-driven)"
+        )
+        .given("a validation definition with this name exists for deletion")
+        .with_request("GET", VALDEF_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": VALDEF_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_VALDEF_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    # 3. GET /datasources?name=... -- serves both retrieve_by_name calls in _decode_data
+    (
+        pact_test.upon_receiving(
+            "fetch datasource during validation definition delete deserialization (client-driven)"
+        )
+        .given("the datasource exists for validation definition delete")
+        .with_request("GET", DATASOURCES_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": DATASOURCE_NAME})
+        .will_respond_with(200)
+        .with_body(datasource_by_name_response, content_type="application/json")
+    )
+
+    # 4. GET /expectation-suites/{id}?name=... -- suite fetch by id during _decode_suite
+    (
+        pact_test.upon_receiving(
+            "fetch suite by id during validation definition delete deserialization (client-driven)"
+        )
+        .given("the expectation suite exists for validation definition delete")
+        .with_request("GET", suite_by_id_path)
+        .with_headers(headers)
+        .with_query_parameters({"name": SUITE_NAME})
+        .will_respond_with(200)
+        .with_body({"data": match.like(_SUITE_RESPONSE)}, content_type="application/json")
+    )
+
+    # 5. DELETE /validation-definitions/{id}
+    (
+        pact_test.upon_receiving(
+            "a request to delete a validation definition by id (client-driven)"
+        )
+        .given("a validation definition with this name exists for deletion")
+        .with_request("DELETE", VALDEF_BY_ID_PATH)
+        .with_headers(headers)
+        .will_respond_with(204)
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        ctx.validation_definitions.delete(name=VALDEF_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint tests
+#
+# These tests use an empty validation_definitions list to avoid the cascading
+# lookups required when deserializing ValidationDefinition objects.  Full
+# workflow tests including checkpoint.run() are covered in GX-2731.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+def test_add_checkpoint(pact_test: Pact) -> None:
+    """context.checkpoints.add_or_update(checkpoint) exercises create-or-update.
+
+    ``CheckpointFactory.add`` requires three ``GET /checkpoints?name=...``
+    calls (has_key probes returning empty, then a post-POST re-fetch returning
+    the checkpoint).  Pact v3 cannot serve different responses for the same
+    request criteria, so we use ``add_or_update`` instead.  When the checkpoint
+    already exists, the factory fetches it (has_key + get -- two identical GETs
+    served by one interaction), then updates via ``checkpoint.save()``.
+
+    The save path uses ``GET /checkpoints/{id}?name=...`` (a DIFFERENT URL
+    that includes the id) for the update's existence check, so there is no
+    conflict with the name-only GET.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration              (context init)
+      2. GET /checkpoints?name=...               (serves factory has_key + get in add_or_update)
+      3. GET /checkpoints/{id}?name=...          (update existence check in _update)
+      4. PUT /checkpoints/{id}                   (update the checkpoint)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="add-checkpoint",
+    )
+
+    # 2. GET /checkpoints?name=... -- serves factory has_key + store.get (checkpoint exists)
+    (
+        pact_test.upon_receiving("fetch checkpoint by name for add_or_update (client-driven)")
+        .given("the checkpoint already exists for add_or_update")
+        .with_request("GET", CHECKPOINTS_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": CHECKPOINT_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_CHECKPOINT_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    # 3. GET /checkpoints/{id}?name=... (update existence check via _update -> _get)
+    (
+        pact_test.upon_receiving(
+            "fetch checkpoint by id for update existence check (client-driven)"
+        )
+        .given("the checkpoint already exists for add_or_update")
+        .with_request("GET", CHECKPOINT_BY_ID_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": CHECKPOINT_NAME})
+        .will_respond_with(200)
+        .with_body({"data": match.like(_CHECKPOINT_RESPONSE)}, content_type="application/json")
+    )
+
+    # 4. PUT /checkpoints/{id} (update)
+    put_checkpoint_request_body: match.AbstractMatcher = match.like(
+        {
+            "data": match.like(
+                {
+                    "id": match.like(EXISTING_CHECKPOINT_ID),
+                    "name": match.like(CHECKPOINT_NAME),
+                    "validation_definitions": match.like([]),
+                    "actions": match.like([]),
+                    "result_format": match.like("SUMMARY"),
+                }
+            )
+        }
+    )
+    (
+        pact_test.upon_receiving("a request to update a checkpoint via PUT (client-driven)")
+        .given("the checkpoint already exists for add_or_update")
+        .with_request("PUT", CHECKPOINT_BY_ID_PATH)
+        .with_headers(headers)
+        .with_body(put_checkpoint_request_body, content_type="application/vnd.api+json")
+        .will_respond_with(200)
+        .with_body({"data": match.like(_CHECKPOINT_RESPONSE)}, content_type="application/json")
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        from great_expectations.checkpoint.checkpoint import Checkpoint
+
+        checkpoint = Checkpoint(name=CHECKPOINT_NAME, validation_definitions=[])
+        result = ctx.checkpoints.add_or_update(checkpoint)
+
+    assert result is not None
+    assert result.name == CHECKPOINT_NAME
+
+
+@pytest.mark.cloud
+def test_get_checkpoint_by_name(pact_test: Pact) -> None:
+    """context.checkpoints.get(name=...) issues has_key then GET.
+
+    Both the ``has_key`` probe and the actual ``store.get`` fetch issue
+    identical GET requests; a single interaction serves both.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration        (context init)
+      2. GET /checkpoints?name=...              (serves factory has_key + store.get fetch)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="get-checkpoint",
+    )
+
+    # 2. GET /checkpoints?name=... -- serves both factory has_key and store.get fetch
+    (
+        pact_test.upon_receiving("a request to get a checkpoint by name (client-driven)")
+        .given("a checkpoint with this name exists")
+        .with_request("GET", CHECKPOINTS_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": CHECKPOINT_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_CHECKPOINT_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        result = ctx.checkpoints.get(name=CHECKPOINT_NAME)
+
+    assert result is not None
+    assert result.name == CHECKPOINT_NAME
+
+
+@pytest.mark.cloud
+def test_delete_checkpoint(pact_test: Pact) -> None:
+    """context.checkpoints.delete(name) fetches (has_key + get) then DELETE /{id}.
+
+    ``CheckpointFactory.delete`` calls ``self.get(name)`` to resolve the cloud
+    id before issuing DELETE.  The two GET requests (``has_key`` + actual get)
+    are identical; a single interaction serves both.
+
+    Full interaction sequence:
+      1. GET /data-context-configuration        (context init)
+      2. GET /checkpoints?name=...              (serves factory has_key + store.get)
+      3. DELETE /checkpoints/{id}               (delete by id)
+    """
+    headers = _session_headers()
+
+    # 1. GET /data-context-configuration
+    setup_data_context_config_interaction(
+        pact_test,
+        access_token=PACT_DUMMY_ACCESS_TOKEN,
+        description_suffix="delete-checkpoint",
+    )
+
+    # 2. GET /checkpoints?name=... -- serves both factory has_key and store.get
+    (
+        pact_test.upon_receiving(
+            "fetch checkpoint by name to resolve id for delete (client-driven)"
+        )
+        .given("a checkpoint with this name exists for deletion")
+        .with_request("GET", CHECKPOINTS_PATH)
+        .with_headers(headers)
+        .with_query_parameters({"name": CHECKPOINT_NAME})
+        .will_respond_with(200)
+        .with_body(
+            {"data": match.each_like(match.like(_CHECKPOINT_RESPONSE), min=1)},
+            content_type="application/json",
+        )
+    )
+
+    # 3. DELETE /checkpoints/{id}
+    (
+        pact_test.upon_receiving("a request to delete a checkpoint by id (client-driven)")
+        .given("a checkpoint with this name exists for deletion")
+        .with_request("DELETE", CHECKPOINT_BY_ID_PATH)
+        .with_headers(headers)
+        .will_respond_with(204)
+    )
+
+    with pact_test.serve() as srv:
+        ctx = gx.get_context(
+            mode="cloud",
+            cloud_base_url=str(srv.url),
+            cloud_organization_id=EXISTING_ORGANIZATION_ID,
+            cloud_workspace_id=EXISTING_WORKSPACE_ID,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
+        )
+        ctx.checkpoints.delete(name=CHECKPOINT_NAME)


### PR DESCRIPTION
## Summary
- Adds 6 new Pact v3 client-driven contract tests for datasource and expectation suite CRUD operations, completing part 2 of GX-2731
- Tests cover: get datasource by name, delete datasource, get suite by name, add suite, delete suite, get all suites
- Follows the same patterns established in `test_valdef_checkpoint_contracts.py` (from GX-2730)

## Test plan
- [x] All 6 new tests pass locally with `--cloud` flag
- [x] All 12 contract tests pass together (6 new + 6 existing)
- [x] Pact file generated with 46 total interactions
- [ ] CI passes