### PR TITLE
[MAINTENANCE] Fix pact publish to use PR head SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,7 +568,7 @@ jobs:
           pact-broker publish "${PACT_DIR}" \
             --broker-base-url=https://greatexpectations.pactflow.io \
             --broker-token="${PACT_BROKER_READ_WRITE_TOKEN}" \
-            --consumer-app-version="${GITHUB_SHA}" \
+            --consumer-app-version="${{ github.event.pull_request.head.sha || github.sha }}" \
             --branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
 
       - name: Show cloud logs on test failure


### PR DESCRIPTION
## Summary
- The pact publish step in CI used `GITHUB_SHA` for `--consumer-app-version`, but on `pull_request_target` events `GITHUB_SHA` resolves to the **base branch SHA** (e.g. `develop`), not the PR's head commit
- This caused pact contracts to be published with the wrong version, breaking provider verification against the actual PR changes
- Fixed by using `github.event.pull_request.head.sha` (falls back to `github.sha` for push/schedule/dispatch events)

## Test plan
- [ ] Verify a CI run on this PR publishes the correct SHA to PactFlow (check the "Publish pact contracts" step logs)
- [ ] Confirm non-PR triggers (schedule, manual) still work correctly via `github.sha` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)