### PR TITLE
[MAINTENANCE] Increase SQL test connection pool size

### DIFF
--- a/tests/integration/sql_session_manager.py
+++ b/tests/integration/sql_session_manager.py
@@ -44,8 +44,8 @@ class PoolConfig:
 class SessionSQLEngineManager:
     POOL_CONFIG = PoolConfig(
         poolclass=QueuePool,
-        pool_size=2,
-        max_overflow=3,
+        pool_size=5,
+        max_overflow=5,
         pool_recycle=5400,  # 1.5 hours
         pool_timeout=30,  # 30 seconds
         pool_pre_ping=True,


### PR DESCRIPTION
With ~420 test instances per cloud backend (Databricks, Snowflake), the previous pool_size=2 / max_overflow=3 configuration caused frequent pool exhaustion, forcing tests to block up to 30 seconds waiting for a connection.

Increased to pool_size=5 / max_overflow=5 (10 total connections) to reduce contention while staying well within cloud warehouse connection limits.

Expected to improve wall-clock time on databricks/snowflake CI jobs by ~10-20% by reducing pool checkout wait times.