### PR TITLE
[MAINTENANCE] Match Gx-Version with regex for stable PactFlow publish

### DIFF
--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -8,13 +8,13 @@ from typing import TYPE_CHECKING, Any, Dict, Final, List, Union
 
 import pytest
 from pact import Pact, match
+from requests import Session
 
 from great_expectations.core.http import create_session
 from great_expectations.data_context import CloudDataContext
 from great_expectations.data_context.data_context.context_factory import project_manager
 
 if TYPE_CHECKING:
-    from requests import Session
     from typing_extensions import TypeAlias
 
 
@@ -23,7 +23,6 @@ PROVIDER_NAME: Final[str] = "mercury"
 
 # Dummy token used by pact_cloud_context — the Pact mock server does not validate credentials.
 PACT_DUMMY_ACCESS_TOKEN: Final[str] = "dummy-pact-access-token"
-
 
 PACT_DIR: Final[pathlib.Path] = pathlib.Path(pathlib.Path(__file__, ".."), "pacts").resolve()
 
@@ -111,6 +110,13 @@ DATA_CONTEXT_CONFIG_RESPONSE_BODY: Final[dict] = {
         },
     },
 }
+
+
+def pact_headers(session: Session) -> dict[str, Any]:
+    """Session headers for ``.with_headers()``; ``Gx-Version`` is a regex so pact JSON is stable per git SHA."""
+    headers = {k: str(v) for k, v in session.headers.items()}
+    headers["Gx-Version"] = match.regex("1.0.0", regex=r"^[0-9A-Za-z._+\-]+$")
+    return headers
 
 
 @pytest.fixture
@@ -204,7 +210,7 @@ def setup_data_context_config_interaction(
         pact_test.upon_receiving(description)
         .given("the Data Context exists")
         .with_request("GET", path)
-        .with_headers({k: str(v) for k, v in session.headers.items()})
+        .with_headers(pact_headers(session))
         .will_respond_with(200)
         .with_body(DATA_CONTEXT_CONFIG_RESPONSE_BODY, content_type="application/json")
     )

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -8,13 +8,13 @@ from typing import TYPE_CHECKING, Any, Dict, Final, List, Union
 
 import pytest
 from pact import Pact, match
-from requests import Session
 
 from great_expectations.core.http import create_session
 from great_expectations.data_context import CloudDataContext
 from great_expectations.data_context.data_context.context_factory import project_manager
 
 if TYPE_CHECKING:
+    from requests import Session
     from typing_extensions import TypeAlias
 
 
@@ -113,7 +113,10 @@ DATA_CONTEXT_CONFIG_RESPONSE_BODY: Final[dict] = {
 
 
 def pact_headers(session: Session) -> dict[str, Any]:
-    """Session headers for ``.with_headers()``; ``Gx-Version`` is a regex so pact JSON is stable per git SHA."""
+    """Headers for ``.with_headers()``.
+
+    ``Gx-Version`` uses a regex so pact JSON is stable per git SHA.
+    """
     headers = {k: str(v) for k, v in session.headers.items()}
     headers["Gx-Version"] = match.regex("1.0.0", regex=r"^[0-9A-Za-z._+\-]+$")
     return headers

--- a/tests/integration/cloud/rest_contracts/test_data_asset_batch_def_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_data_asset_batch_def_contracts.py
@@ -29,6 +29,7 @@ from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
     PACT_DUMMY_ACCESS_TOKEN,
+    pact_headers,
     setup_data_context_config_interaction,
 )
 
@@ -106,7 +107,7 @@ _DATASOURCE_WITH_ASSET_AND_BATCH_DEF: Final[dict] = {
 
 def _session_headers() -> dict[str, str]:
     session = create_session(access_token=PACT_DUMMY_ACCESS_TOKEN)
-    return {k: str(v) for k, v in session.headers.items()}
+    return pact_headers(session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -9,6 +9,7 @@ import great_expectations as gx
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
+    pact_headers,
 )
 
 if TYPE_CHECKING:
@@ -47,7 +48,7 @@ def test_data_context_configuration(
         pact_test.upon_receiving(scenario)
         .given(provider_state)
         .with_request(method, path)
-        .with_headers({k: str(v) for k, v in gx_cloud_session.headers.items()})
+        .with_headers(pact_headers(gx_cloud_session))
         .will_respond_with(status)
         .with_body(response_body, content_type="application/json")
     )

--- a/tests/integration/cloud/rest_contracts/test_datasource_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource_contracts.py
@@ -25,6 +25,7 @@ from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
     PACT_DUMMY_ACCESS_TOKEN,
+    pact_headers,
     setup_data_context_config_interaction,
 )
 
@@ -91,9 +92,8 @@ PANDAS_DATASOURCE_UPDATE_REQUEST_BODY: Final[dict] = {
 
 
 def _session_headers() -> dict[str, str]:
-    """Return request headers matching what the Python client sends."""
     session = create_session(access_token=PACT_DUMMY_ACCESS_TOKEN)
-    return {k: str(v) for k, v in session.headers.items()}
+    return pact_headers(session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/cloud/rest_contracts/test_expectation_suite_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_expectation_suite_contracts.py
@@ -30,6 +30,7 @@ from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
     PACT_DUMMY_ACCESS_TOKEN,
+    pact_headers,
     setup_data_context_config_interaction,
 )
 
@@ -84,7 +85,7 @@ _SUITE_WITH_EXPECTATION_RESPONSE: Final[dict] = {
 
 def _session_headers() -> dict[str, str]:
     session = create_session(access_token=PACT_DUMMY_ACCESS_TOKEN)
-    return {k: str(v) for k, v in session.headers.items()}
+    return pact_headers(session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -33,6 +33,7 @@ from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
     PACT_DUMMY_ACCESS_TOKEN,
+    pact_headers,
     setup_data_context_config_interaction,
 )
 
@@ -165,9 +166,8 @@ _CHECKPOINT_RESPONSE: Final[dict] = {
 
 
 def _session_headers() -> dict:
-    """Return request headers matching what the Python client sends."""
     session = create_session(access_token=PACT_DUMMY_ACCESS_TOKEN)
-    return {k: str(v) for k, v in session.headers.items()}
+    return pact_headers(session)
 
 
 def _register_datasource_get_interactions(

--- a/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
@@ -57,9 +57,9 @@ import pytest
 from pact import Pact, match
 
 import great_expectations as gx
+from great_expectations import __version__ as ge_version
 from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.core.expectation_suite import ExpectationSuite
-from great_expectations import __version__ as ge_version
 from great_expectations.core.http import create_session
 from great_expectations.core.validation_definition import ValidationDefinition
 from tests.integration.cloud.rest_contracts.conftest import (

--- a/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
@@ -57,15 +57,16 @@ import pytest
 from pact import Pact, match
 
 import great_expectations as gx
-from great_expectations import __version__ as ge_version
 from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.core.expectation_suite import ExpectationSuite
+from great_expectations import __version__ as ge_version
 from great_expectations.core.http import create_session
 from great_expectations.core.validation_definition import ValidationDefinition
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
     PACT_DUMMY_ACCESS_TOKEN,
+    pact_headers,
     setup_data_context_config_interaction,
 )
 
@@ -204,7 +205,7 @@ def _make_checkpoint_response() -> dict:
 
 def _session_headers() -> dict[str, str]:
     session = create_session(access_token=PACT_DUMMY_ACCESS_TOKEN)
-    return {k: str(v) for k, v in session.headers.items()}
+    return pact_headers(session)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

GX Cloud Pact consumer tests register HTTP interactions and publish the resulting pact to PactFlow. The broker treats each consumer version (typically the git SHA) as owning one contract payload. If two pipelines publish different pact JSON for the same consumer version, PactFlow rejects the upload.

## Problem

We were registering request headers with a plain copy of `create_session()`’s defaults, including Gx-Version as a literal string from `great_expectations.__version__`. That value depends on how GX is built/installed (e.g. editable `setuptools-scm` strings vs a release semver) even when the git commit is identical. The published pact therefore flipped bytes for the same consumer version, triggering broker [errors](https://github.com/great-expectations/great_expectations/actions/runs/24156427610/job/70508595017#step:11:188) like “cannot change the content of the pact.”

## Solution

Add `pact_headers(session)` and use it wherever we pass headers into `.with_headers(...)` for these tests. It mirrors the session’s headers as before, but replaces Gx-Version with a regex matcher and a fixed example so the recorded contract stays stable across install flavors.

## Scope

This only affects Pact consumer tests and the published pact contract. It changes how request headers are recorded in each registered interaction (the Gx-Version header is matched with a regex in the pact file). It does not change GX runtime behavior for end users: the client still sends the real Gx-Version from `create_session`; only the Pact contract’s description of that header is generalized.

## Provider impact

Mercury’s Pact verification will assert Gx-Version matches the regex rather than matching one exact string, which is the intended tradeoff so `can-i-deploy` / publishing stays reliable.
