### PR TITLE
[MAINTENANCE] Skip pact publish on release tag CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
         run: invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
       - name: Publish pact contracts to PactFlow
-        if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
+        if: env.PACT_BROKER_READ_WRITE_TOKEN != '' && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
         env:
           PACT_CLI_VERSION: v2.6.0
         run: |


### PR DESCRIPTION
## Summary
- Skip the "Publish pact contracts to PactFlow" step when CI is triggered by a tag push (release)
- The contracts are already published when the commit lands on develop; re-publishing on a release tag fails because `Gx-Version` resolves differently (e.g. `1.16.0` vs `0+untagged.1.g899d19e`), producing different contract content for the same consumer version
- Unblocks the 1.16.0 release ([failed run](https://github.com/great-expectations/great_expectations/actions/runs/24156427610))

## Test plan
- [ ] CI passes on this PR (pact publish step still runs since this is a PR, not a tag push)
- [ ] Re-run or re-tag the 1.16.0 release — the pact publish step should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)