### PR TITLE
[MAINTENANCE] Update Pact contract tests to align with Mercury API and use isolated org/workspace

### DIFF
--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -50,16 +50,10 @@ EXISTING_WORKSPACE_ID: Final[str] = (
 # constructing a CloudDataContext in tests.  Store backend URLs use the environment-variable
 # placeholder so they resolve correctly at runtime regardless of mock host/port.
 DATA_CONTEXT_CONFIG_RESPONSE_BODY: Final[dict] = {
-    "anonymous_usage_statistics": match.like(
-        {
-            "data_context_id": match.uuid(),
-            "enabled": False,
-        }
-    ),
-    "datasources": match.like({}),
+    "analytics_enabled": match.like(True),
     "checkpoint_store_name": "default_checkpoint_store",
     "expectations_store_name": "default_expectations_store",
-    "validation_results_store_name": "default_validation_results_store",
+    "validation_results_store_name": "default_validations_store",
     "stores": {
         "default_expectations_store": {
             "class_name": "ExpectationsStore",

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -81,7 +81,7 @@ DATA_CONTEXT_CONFIG_RESPONSE_BODY: Final[dict] = {
                 "suppress_store_backend_id": True,
             },
         },
-        "default_validation_results_store": {
+        "default_validations_store": {
             "class_name": "ValidationResultsStore",
             "store_backend": {
                 "class_name": "GXCloudStoreBackend",

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -40,10 +40,10 @@ PactBody: TypeAlias = Union[
 
 
 EXISTING_ORGANIZATION_ID: Final[str] = (
-    os.environ.get("GX_CLOUD_ORGANIZATION_ID", "") or "0ccac18e-7631-4bdd-8a42-3c35cce574c6"
+    os.environ.get("GX_CLOUD_ORGANIZATION_ID", "") or "d2179c7d-685d-49ec-b1e2-85e54308e8b6"
 )
 EXISTING_WORKSPACE_ID: Final[str] = (
-    os.environ.get("GX_CLOUD_WORKSPACE_ID", "") or "44444444-4444-4bdd-8a42-3c35cce574c6"
+    os.environ.get("GX_CLOUD_WORKSPACE_ID", "") or "003e13da-9d39-47b3-8b9b-b290280ccc37"
 )
 
 # Full data-context-configuration response body used as the Pact mock response when

--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -17,13 +17,7 @@ if TYPE_CHECKING:
 
 
 GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
-    "anonymous_usage_statistics": match.like(
-        {
-            "data_context_id": match.uuid(),
-            "enabled": False,
-        }
-    ),
-    "datasources": match.like({}),
+    "analytics_enabled": match.like(True),
 }
 
 

--- a/tests/integration/cloud/rest_contracts/test_datasource_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource_contracts.py
@@ -153,7 +153,7 @@ def test_add_pandas_datasource(pact_test: Pact) -> None:
         .with_request("POST", DATASOURCES_PATH)
         .with_headers(headers)
         .with_body(PANDAS_DATASOURCE_REQUEST_BODY, content_type="application/vnd.api+json")
-        .will_respond_with(200)
+        .will_respond_with(201)
         .with_body(post_response_body, content_type="application/json")
     )
 

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -363,19 +363,19 @@ def test_add_validation_definition(pact_test: Pact) -> None:
                             "datasource": match.like(
                                 {
                                     "name": match.like(DATASOURCE_NAME),
-                                    "id": match.uuid(),
+                                    "id": match.uuid(EXISTING_DATASOURCE_ID),
                                 }
                             ),
                             "asset": match.like(
                                 {
                                     "name": match.like(ASSET_NAME),
-                                    "id": match.uuid(),
+                                    "id": match.uuid(EXISTING_ASSET_ID),
                                 }
                             ),
                             "batch_definition": match.like(
                                 {
                                     "name": match.like(BATCH_DEF_NAME),
-                                    "id": match.uuid(),
+                                    "id": match.uuid(EXISTING_BATCH_DEF_ID),
                                 }
                             ),
                         }
@@ -383,7 +383,7 @@ def test_add_validation_definition(pact_test: Pact) -> None:
                     "suite": match.like(
                         {
                             "name": match.like(SUITE_NAME),
-                            "id": match.uuid(),
+                            "id": match.uuid(EXISTING_SUITE_ID),
                         }
                     ),
                 }

--- a/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
@@ -355,9 +355,7 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
                             "name": match.like(SUITE_NAME),
                             "id": None,
                             "expectations": match.like([]),
-                            "meta": match.like(
-                                {"great_expectations_version": match.like("1.0.0")}
-                            ),
+                            "meta": match.like({"great_expectations_version": match.like("1.0.0")}),
                             "notes": None,
                         }
                     )

--- a/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
@@ -280,7 +280,20 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
         .given("the Pandas datasource is being created with asset and batch definition")
         .with_request("POST", DATASOURCES_PATH)
         .with_headers(headers)
-        .will_respond_with(200)
+        .with_body(
+            match.like(
+                {
+                    "data": match.like(
+                        {
+                            "type": match.like("pandas"),
+                            "name": match.like(DATASOURCE_NAME),
+                        }
+                    )
+                }
+            ),
+            content_type="application/vnd.api+json",
+        )
+        .will_respond_with(201)
         .with_body(
             {"data": match.like(_make_datasource_response())},
             content_type="application/json",
@@ -334,6 +347,24 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
         .given("no expectation suite with this name exists")
         .with_request("POST", SUITES_PATH)
         .with_headers(headers)
+        .with_body(
+            match.like(
+                {
+                    "data": match.like(
+                        {
+                            "name": match.like(SUITE_NAME),
+                            "id": None,
+                            "expectations": match.like([]),
+                            "meta": match.like(
+                                {"great_expectations_version": match.like("1.0.0")}
+                            ),
+                            "notes": None,
+                        }
+                    )
+                }
+            ),
+            content_type="application/vnd.api+json",
+        )
         .will_respond_with(201)
         .with_body(
             {"data": match.like(_make_suite_response())},
@@ -392,6 +423,46 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
         .given("no validation definition with this name exists")
         .with_request("POST", VALDEF_PATH)
         .with_headers(headers)
+        .with_body(
+            match.like(
+                {
+                    "data": match.like(
+                        {
+                            "name": match.like(VALDEF_NAME),
+                            "data": match.like(
+                                {
+                                    "datasource": match.like(
+                                        {
+                                            "name": match.like(DATASOURCE_NAME),
+                                            "id": match.uuid(),
+                                        }
+                                    ),
+                                    "asset": match.like(
+                                        {
+                                            "name": match.like(ASSET_NAME),
+                                            "id": match.uuid(),
+                                        }
+                                    ),
+                                    "batch_definition": match.like(
+                                        {
+                                            "name": match.like(BATCH_DEF_NAME),
+                                            "id": match.uuid(),
+                                        }
+                                    ),
+                                }
+                            ),
+                            "suite": match.like(
+                                {
+                                    "name": match.like(SUITE_NAME),
+                                    "id": match.uuid(),
+                                }
+                            ),
+                        }
+                    )
+                }
+            ),
+            content_type="application/vnd.api+json",
+        )
         .will_respond_with(201)
         .with_body(
             {"data": match.like(_make_valdef_response())},
@@ -417,6 +488,23 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
         .given("no checkpoint with this name exists")
         .with_request("POST", CHECKPOINTS_PATH)
         .with_headers(headers)
+        .with_body(
+            match.like(
+                {
+                    "data": match.like(
+                        {
+                            "name": match.like(CHECKPOINT_NAME),
+                            "validation_definitions": match.like(
+                                [{"id": match.uuid(), "name": match.like(VALDEF_NAME)}]
+                            ),
+                            "actions": match.like([]),
+                            "result_format": match.like("SUMMARY"),
+                        }
+                    )
+                }
+            ),
+            content_type="application/vnd.api+json",
+        )
         .will_respond_with(201)
         .with_body(
             {"data": match.like(_make_checkpoint_response())},

--- a/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_workflow_contracts.py
@@ -432,19 +432,19 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
                                     "datasource": match.like(
                                         {
                                             "name": match.like(DATASOURCE_NAME),
-                                            "id": match.uuid(),
+                                            "id": match.uuid(EXISTING_DATASOURCE_ID),
                                         }
                                     ),
                                     "asset": match.like(
                                         {
                                             "name": match.like(ASSET_NAME),
-                                            "id": match.uuid(),
+                                            "id": match.uuid(EXISTING_ASSET_ID),
                                         }
                                     ),
                                     "batch_definition": match.like(
                                         {
                                             "name": match.like(BATCH_DEF_NAME),
-                                            "id": match.uuid(),
+                                            "id": match.uuid(EXISTING_BATCH_DEF_ID),
                                         }
                                     ),
                                 }
@@ -452,7 +452,7 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
                             "suite": match.like(
                                 {
                                     "name": match.like(SUITE_NAME),
-                                    "id": match.uuid(),
+                                    "id": match.uuid(EXISTING_SUITE_ID),
                                 }
                             ),
                         }
@@ -493,7 +493,12 @@ def test_pandas_datasource_workflow(pact_test: Pact) -> None:
                         {
                             "name": match.like(CHECKPOINT_NAME),
                             "validation_definitions": match.like(
-                                [{"id": match.uuid(), "name": match.like(VALDEF_NAME)}]
+                                [
+                                    {
+                                        "id": match.uuid(EXISTING_VALDEF_ID),
+                                        "name": match.like(VALDEF_NAME),
+                                    }
+                                ]
                             ),
                             "actions": match.like([]),
                             "result_format": match.like("SUMMARY"),


### PR DESCRIPTION
## Summary

Updates the Pact consumer contract tests to match Mercury's current API responses and use a dedicated isolated org/workspace for provider verification.

## Changes

- **Data context configuration** (`conftest.py`): Replace `anonymous_usage_statistics` with `analytics_enabled`, remove `datasources` key, fix `validation_results_store_name` and stores key to `default_validations_store` — all matching Mercury's actual response.
- **Isolated org/workspace** (`conftest.py`): Update `EXISTING_ORGANIZATION_ID` and `EXISTING_WORKSPACE_ID` defaults to a dedicated pact org (`d2179c7d-...`) and workspace (`003e13da-...`), preventing test data interference.
- **POST status codes**: Change expected status from 200 to 201 for `POST /datasources` in `test_datasource_contracts.py` and `test_workflow_contracts.py` — Mercury correctly returns 201 Created.
- **Workflow POST bodies** (`test_workflow_contracts.py`): Add `.with_body()` to all four workflow POST interactions (datasource, suite, valdef, checkpoint). The Pact v4 Rust FFI verifier only sends request bodies when they're recorded in the contract.
- **Actual UUIDs in request bodies** (`test_valdef_checkpoint_contracts.py`, `test_workflow_contracts.py`): Replace bare `match.uuid()` with `match.uuid(EXISTING_ID)` in POST valdef/checkpoint request bodies so Mercury can look up the referenced resources during verification.
- **Min response body** (`test_data_context_configuration.py`): Same `analytics_enabled` / `datasources` removal as conftest.

## Why

Mercury's `data-context-configuration` endpoint response has evolved — fields were renamed (`anonymous_usage_statistics` → `analytics_enabled`, `datasources` → `data_sources`) and the validation results store was renamed. The published contracts must match for provider verification to pass.

The isolated org/workspace prevents "expected empty list but got existing seed data" failures during verification. The POST body and UUID fixes address Pact v4 verifier behavior where bodies aren't sent unless recorded, and random UUIDs can't be looked up in the provider database.

## User impact

No end-user impact. These are test-only changes to Pact contract fixtures. The contracts describe the same API interactions — they're updated to match Mercury's current response shapes.

## How to review

- `conftest.py` changes are the core: verify `DATA_CONTEXT_CONFIG_RESPONSE_BODY` matches what Mercury actually returns. The stores dict key must match `validation_results_store_name`.
- `test_workflow_contracts.py` has the most new code — the `.with_body()` matchers on POST interactions. Compare against the equivalent patterns in `test_datasource_contracts.py` and `test_valdef_checkpoint_contracts.py`.
- The `match.uuid(EXISTING_ID)` changes are only in **request** bodies. Response bodies keep bare `match.uuid()` since those are type-checked only.
- This PR must merge before the Mercury provider PR (greatexpectationslabs/mercury#6207) can verify successfully, since the published contracts must contain the updated org/workspace IDs and request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)