### PR TITLE
[MAINTENANCE] Skip pact publish on release branch CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,21 @@ jobs:
         run: invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
       - name: Publish pact contracts to PactFlow
-        if: env.PACT_BROKER_READ_WRITE_TOKEN != '' && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        if: >-
+          env.PACT_BROKER_READ_WRITE_TOKEN != ''
+          && !(github.event_name == 'push' && (
+            startsWith(github.ref, 'refs/tags/')
+            || startsWith(github.ref_name, '0.')
+            || startsWith(github.ref_name, '1.')
+            || startsWith(github.ref_name, '2.')
+            || startsWith(github.ref_name, '3.')
+            || startsWith(github.ref_name, '4.')
+            || startsWith(github.ref_name, '5.')
+            || startsWith(github.ref_name, '6.')
+            || startsWith(github.ref_name, '7.')
+            || startsWith(github.ref_name, '8.')
+            || startsWith(github.ref_name, '9.')
+          ))
         env:
           PACT_CLI_VERSION: v2.6.0
         run: |


### PR DESCRIPTION
## Summary
- Extends the fix from #11796 to also skip the PactFlow publish step on release **branch** pushes (e.g. `1.16.0`), not just tag pushes
- Same root cause: `Gx-Version` resolves differently on release branches vs develop, causing PactFlow to reject the changed contract content for the same consumer version
- Matches release branches by checking if `github.ref_name` starts with a digit followed by `.` (e.g. `1.16.0`, `2.0.0`)
- Unblocks the [failing 1.16.0 CI run](https://github.com/great-expectations/great_expectations/actions/runs/24156427610/job/70663478741)

## Test plan
- [ ] CI passes on this PR (pact publish step still runs since this is a PR, not a release branch push)
- [ ] Re-run the 1.16.0 release branch CI after cherry-picking — the pact publish step should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)