### PR TITLE
[MAINTENANCE] Override pact org/workspace IDs in CI for contract test isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,12 @@ jobs:
       - name: Run the tests
         run: invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
+      - name: Regenerate pact contracts with isolated org
+        env:
+          GX_CLOUD_ORGANIZATION_ID: "d2179c7d-685d-49ec-b1e2-85e54308e8b6"
+          GX_CLOUD_WORKSPACE_ID: "003e13da-9d39-47b3-8b9b-b290280ccc37"
+        run: pytest tests/integration/cloud/rest_contracts/ -x
+
       - name: Publish pact contracts to PactFlow
         if: env.PACT_BROKER_READ_WRITE_TOKEN != '' && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
         env:


### PR DESCRIPTION
## Summary

- The `cloud-tests` CI job sets `GX_CLOUD_ORGANIZATION_ID` to the real Superconductive org ID (via `secrets.MERCURY_ORGANIZATION_ID`) at the job level, which means pact contract tests generate pact JSON files with that org ID embedded in all endpoint URLs
- When Mercury runs provider verification against PactFlow, its auth token is scoped to the pact-specific org (`d2179c7d-...`), causing all 75 interactions to fail with **401 Unauthorized**
- Fix: add a step between the main test run and the pact publish step that re-runs just the pact contract tests with the correct isolated org/workspace env vars (`d2179c7d-685d-49ec-b1e2-85e54308e8b6` / `003e13da-9d39-47b3-8b9b-b290280ccc37`), overwriting the pact JSON files before they are published to PactFlow

## References

- GX-2733

## Test plan

- [ ] CI `cloud-tests` job passes (the new step runs pact tests with overridden env vars)
- [ ] Published pact files contain the isolated org ID (`d2179c7d-...`) instead of the Superconductive org ID
- [ ] Mercury provider verification against the published pact no longer returns 401 for all interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)