### PR TITLE
[MAINTENANCE] Hardcode pact org/workspace IDs for contract test isolation

### DIFF
--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -39,12 +39,8 @@ PactBody: TypeAlias = Union[
 ]
 
 
-EXISTING_ORGANIZATION_ID: Final[str] = (
-    os.environ.get("GX_CLOUD_ORGANIZATION_ID", "") or "d2179c7d-685d-49ec-b1e2-85e54308e8b6"
-)
-EXISTING_WORKSPACE_ID: Final[str] = (
-    os.environ.get("GX_CLOUD_WORKSPACE_ID", "") or "003e13da-9d39-47b3-8b9b-b290280ccc37"
-)
+EXISTING_ORGANIZATION_ID: Final[str] = "d2179c7d-685d-49ec-b1e2-85e54308e8b6"
+EXISTING_WORKSPACE_ID: Final[str] = "003e13da-9d39-47b3-8b9b-b290280ccc37"
 
 # Full data-context-configuration response body used as the Pact mock response when
 # constructing a CloudDataContext in tests.  Store backend URLs use the environment-variable

--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 import pytest
 from pact import Pact, match
@@ -9,11 +9,9 @@ import great_expectations as gx
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
-    GX_VERSION_REGEX,
+    PACT_DUMMY_ACCESS_TOKEN,
+    pact_session_headers,
 )
-
-if TYPE_CHECKING:
-    import requests
 
 
 GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
@@ -23,8 +21,6 @@ GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
 
 @pytest.mark.cloud
 def test_data_context_configuration(
-    gx_cloud_session: requests.Session,
-    cloud_access_token: str,
     pact_test: Pact,
 ) -> None:
     # Arrange: set up the data context configuration endpoint interaction
@@ -37,11 +33,7 @@ def test_data_context_configuration(
     )
     status = 200
     response_body = GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY
-
-    headers: dict = {
-        k: (match.regex(str(v), regex=GX_VERSION_REGEX) if k == "Gx-Version" else str(v))
-        for k, v in gx_cloud_session.headers.items()
-    }
+    headers = pact_session_headers()
 
     (
         pact_test.upon_receiving(scenario)
@@ -59,7 +51,7 @@ def test_data_context_configuration(
             cloud_base_url=str(srv.url),
             cloud_organization_id=EXISTING_ORGANIZATION_ID,
             cloud_workspace_id=EXISTING_WORKSPACE_ID,
-            cloud_access_token=cloud_access_token,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
         )
 
     # Assert

--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -13,7 +13,6 @@ from tests.integration.cloud.rest_contracts.conftest import (
     pact_session_headers,
 )
 
-
 GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
     "analytics_enabled": match.like(True),
 }


### PR DESCRIPTION
## Summary

- Hardcode the pact-specific org (`d2179c7d-...`) and workspace (`003e13da-...`) IDs in the contract test conftest instead of reading from `GX_CLOUD_ORGANIZATION_ID` / `GX_CLOUD_WORKSPACE_ID` env vars
- These IDs must match the Mercury provider seed data; they should never vary by environment

## Why

The `cloud-tests` CI job sets `GX_CLOUD_ORGANIZATION_ID` to the real Superconductive org ID. The pact conftest was using `os.environ.get(...)` with the pact IDs as fallback, but the fallback never triggered in CI. This meant published pacts contained URLs with the Superconductive org ID, while Mercury's provider verification uses an auth token scoped to the pact org — causing all 75 interactions to fail with 401 Unauthorized.

## Test plan

- [ ] CI cloud-tests pass (pact tests still run, just with hardcoded IDs)
- [ ] After merge, verify the published pact on PactFlow contains the pact org ID in request URLs
- [ ] Mercury PR #6207 contract-tests should pass once this publishes corrected pacts

GX-2733

🤖 Generated with [Claude Code](https://claude.com/claude-code)