### PR TITLE
[MAINTENANCE] Use pact dummy token in test_data_context_configuration

### DIFF
--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 import pytest
 from pact import Pact, match
@@ -9,11 +9,9 @@ import great_expectations as gx
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     EXISTING_WORKSPACE_ID,
-    GX_VERSION_REGEX,
+    PACT_DUMMY_ACCESS_TOKEN,
+    pact_session_headers,
 )
-
-if TYPE_CHECKING:
-    import requests
 
 
 GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
@@ -23,8 +21,6 @@ GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
 
 @pytest.mark.cloud
 def test_data_context_configuration(
-    gx_cloud_session: requests.Session,
-    cloud_access_token: str,
     pact_test: Pact,
 ) -> None:
     # Arrange: set up the data context configuration endpoint interaction
@@ -37,11 +33,7 @@ def test_data_context_configuration(
     )
     status = 200
     response_body = GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY
-
-    headers: dict = {
-        k: (match.regex(str(v), regex=GX_VERSION_REGEX) if k == "Gx-Version" else str(v))
-        for k, v in gx_cloud_session.headers.items()
-    }
+    headers = pact_session_headers()
 
     (
         pact_test.upon_receiving(scenario)
@@ -59,7 +51,7 @@ def test_data_context_configuration(
             cloud_base_url=str(srv.url),
             cloud_organization_id=EXISTING_ORGANIZATION_ID,
             cloud_workspace_id=EXISTING_WORKSPACE_ID,
-            cloud_access_token=cloud_access_token,
+            cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
         )
 
     # Assert

--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -13,7 +13,6 @@ from tests.integration.cloud.rest_contracts.conftest import (
     pact_session_headers,
 )
 
-
 GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
     "analytics_enabled": match.like(True),
 }


### PR DESCRIPTION
## Summary

Migrates `test_data_context_configuration` from the `gx_cloud_session` fixture (which requires `GX_CLOUD_ACCESS_TOKEN` env var) to the pact-native `pact_session_headers()` + `PACT_DUMMY_ACCESS_TOKEN` pattern used by all 17 other contract tests.

## Changes

- Replaced `gx_cloud_session` and `cloud_access_token` fixtures with `pact_session_headers()` and `PACT_DUMMY_ACCESS_TOKEN`
- Removed `TYPE_CHECKING` import block (no longer needed)

## Why

This test was the only contract test that required real cloud credentials to run. All other tests use the dummy token pattern, which lets them run locally without environment setup.

## User impact

None — test-only change.

## How to review

Small, mechanical change. Compare with how other test files (e.g. `test_datasource_contracts.py`) use `pact_session_headers()`.