### PR TITLE
[MAINTENANCE] Fix pact branch resolution for merge_group CI events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,11 +600,25 @@ jobs:
           ls -la ${PACT_DIR}/*.json
           curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/${PACT_CLI_VERSION}/install.sh | bash
           export PATH="${PATH}:$(pwd)/pact/bin"
+
+          CONSUMER_VERSION="${{ github.event.pull_request.head.sha || github.sha }}"
+
+          # For merge_group events, resolve the target branch (e.g. "develop") from
+          # the base_ref instead of using the throwaway queue ref name
+          # (gh-readonly-queue/develop/pr-NNN-SHA).
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            PACT_BRANCH="${{ github.event.merge_group.base_ref }}"
+            PACT_BRANCH="${PACT_BRANCH#refs/heads/}"
+          else
+            PACT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          fi
+
+          echo "Publishing with version=${CONSUMER_VERSION} branch=${PACT_BRANCH}"
           pact-broker publish "${PACT_DIR}" \
             --broker-base-url=https://greatexpectations.pactflow.io \
             --broker-token="${PACT_BROKER_READ_WRITE_TOKEN}" \
-            --consumer-app-version="${{ github.event.pull_request.head.sha || github.sha }}" \
-            --branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+            --consumer-app-version="${CONSUMER_VERSION}" \
+            --branch="${PACT_BRANCH}"
 
       - name: Show cloud logs on test failure
         if: failure()


### PR DESCRIPTION
## Summary
- `merge_group` CI events were publishing pact contracts to PactFlow under the throwaway merge queue ref name (`gh-readonly-queue/develop/pr-NNN-SHA`) instead of the target branch (`develop`)
- This meant the only way pacts appeared under `develop` in PactFlow was via the 3-hourly scheduled CI runs, causing a delay between merge and visibility
- Extracts the target branch from `github.event.merge_group.base_ref` so merge-queue runs publish under the correct branch name immediately

## Test plan
- [ ] Merge this PR via the merge queue and verify the CI logs show `Publishing with version=<sha> branch=develop` (not `branch=gh-readonly-queue/...`)
- [ ] Confirm the new version appears in PactFlow under the `develop` branch
- [ ] Verify PR-triggered runs still publish under the PR branch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)