### PR TITLE
[BUGFIX] Fix exception_info nested under metric ID key instead of flat structure (#10849)

### DIFF
--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -787,9 +787,13 @@ class Validator:
             # Report all MetricResolutionError occurrences impacting expectation and append it to rejected list.  # noqa: E501 # FIXME CoP
             if len(metric_exception_info) > 0:
                 configuration = expectation_validation_graph.configuration
+                # Extract the first ExceptionInfo so that exception_info has the expected flat
+                # structure {raised_exception, exception_traceback, exception_message} rather
+                # than being wrapped under the stringified metric ID key (issue #10849).
+                first_exception_info: ExceptionInfo = next(iter(metric_exception_info.values()))
                 result = ExpectationValidationResult(
                     success=False,
-                    exception_info=metric_exception_info,
+                    exception_info=first_exception_info,
                     expectation_config=configuration,
                 )
                 evrs.append(result)

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_between.py
@@ -218,9 +218,8 @@ class TestColumnValuesBetweenAgainstInvalidColumn:
             max_value=1,
         )
         result = batch_for_datasource.validate(expect=expect)
-        exception_info = list(result.exception_info.values())
-        assert len(exception_info) == 1
-        assert self.EXPECTED_ERROR in exception_info[0]["exception_message"]
+        assert result.exception_info.get("raised_exception") is True
+        assert self.EXPECTED_ERROR in result.exception_info.get("exception_message", "")
 
     @parameterize_batch_for_data_sources(
         data_source_configs=SQL_DATA_SOURCES,
@@ -256,9 +255,8 @@ class TestColumnValuesBetweenAgainstInvalidColumn:
             if result.exception_info.get("raised_exception") is not False
         ]
         assert len(results_with_errors) == 1
-        exception_info = list(results_with_errors[0].exception_info.values())
-        assert len(exception_info) == 1
-        assert self.EXPECTED_ERROR in exception_info[0]["exception_message"]
+        failed_result = results_with_errors[0]
+        assert self.EXPECTED_ERROR in failed_result.exception_info.get("exception_message", "")
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_query_results_to_match_comparison.py
@@ -465,7 +465,7 @@ def test_expect_query_results_to_match_comparison_error(multi_source_batch: Mult
         )
     )
     assert not result.success
-    assert list(result.exception_info.values())[0]["raised_exception"]
+    assert result.exception_info.get("raised_exception")
 
 
 DATA_WITH_MANY_COLUMNS = pd.DataFrame({ch: [1, 2, 3] for ch in "abcdefgh"})

--- a/tests/integration/data_sources_and_expectations/test_expectation_conditions.py
+++ b/tests/integration/data_sources_and_expectations/test_expectation_conditions.py
@@ -597,9 +597,9 @@ class TestSqlAlchemyRejectsPassThroughCondition:
 
         # Validation should fail due to PassThroughCondition not being supported
         assert result.success is False
-        exception_info_str = str(result.exception_info)
-        assert "PassThroughCondition" in exception_info_str
-        assert "not supported for SqlAlchemyExecutionEngine" in exception_info_str
+        exception_msg = result.exception_info.get("exception_message", "")
+        assert "PassThroughCondition" in exception_msg
+        assert "not supported for SqlAlchemyExecutionEngine" in exception_msg
 
 
 class TestSQLConditionClassAcrossExpectationTypes:

--- a/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
@@ -163,4 +163,6 @@ def test_column_min_max_mismatch_misconfiguration(batch_for_datasource) -> None:
     expectation = gxe.ExpectColumnValuesToBeBetween(column="a", min_value=2, max_value=1)
     result = batch_for_datasource.validate(expectation)
     assert not result.success
-    assert "min_value cannot be greater than max_value" in result.exception_info.get("exception_message", "")
+    assert "min_value cannot be greater than max_value" in result.exception_info.get(
+        "exception_message", ""
+    )

--- a/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
@@ -57,10 +57,10 @@ class TestNumericExpectationAgainstStrDataMisconfiguration:
     def test_pandas(self, batch_for_datasource) -> None:
         result = batch_for_datasource.validate(self._EXPECTATION)
         assert not result.success
-        exception_str = str(result.exception_info)
+        exception_msg = result.exception_info.get("exception_message", "")
         assert (
-            "could not convert string to float" in exception_str  # pandas <3.0
-            or "Cannot perform reduction 'std' with string dtype" in exception_str  # pandas 3.x
+            "could not convert string to float" in exception_msg  # pandas <3.0
+            or "Cannot perform reduction 'std' with string dtype" in exception_msg  # pandas 3.x
         )
 
     @parameterize_batch_for_data_sources(
@@ -106,7 +106,7 @@ class TestNumericExpectationAgainstStrDataMisconfiguration:
     def _assert_misconfiguration(self, batch_for_datasource: Batch, exception_message: str) -> None:
         result = batch_for_datasource.validate(self._EXPECTATION)
         assert not result.success
-        assert exception_message in str(result.exception_info)
+        assert exception_message in result.exception_info.get("exception_message", "")
 
 
 class TestNonExistentColumnMisconfiguration:
@@ -136,7 +136,7 @@ class TestNonExistentColumnMisconfiguration:
     def _assert_misconfiguration(self, batch_for_datasource: Batch, exception_message: str) -> None:
         result = batch_for_datasource.validate(self._EXPECTATION)
         assert not result.success
-        assert exception_message in str(result.exception_info)
+        assert exception_message in result.exception_info.get("exception_message", "")
 
 
 @parameterize_batch_for_data_sources(
@@ -152,7 +152,7 @@ def test_datetime_expectation_against_numeric_data_misconfiguration(batch_for_da
     )
     result = batch_for_datasource.validate(expectation)
     assert not result.success
-    assert "into datetime representation" in str(result.exception_info)
+    assert "into datetime representation" in result.exception_info.get("exception_message", "")
 
 
 @parameterize_batch_for_data_sources(
@@ -163,4 +163,4 @@ def test_column_min_max_mismatch_misconfiguration(batch_for_datasource) -> None:
     expectation = gxe.ExpectColumnValuesToBeBetween(column="a", min_value=2, max_value=1)
     result = batch_for_datasource.validate(expectation)
     assert not result.success
-    assert "min_value cannot be greater than max_value" in str(result.exception_info)
+    assert "min_value cannot be greater than max_value" in result.exception_info.get("exception_message", "")

--- a/tests/integration/data_sources_and_expectations/test_spark_nested_columns_unexpected_index.py
+++ b/tests/integration/data_sources_and_expectations/test_spark_nested_columns_unexpected_index.py
@@ -124,13 +124,15 @@ def test_spark_unexpected_index_column_names_missing_nested_path_errors(
         },
     )
 
-    # ``exception_info`` is a dict keyed by failed metric id, each value being
-    # an ExceptionInfo dict with ``raised_exception`` / ``exception_message``.
+    # ``exception_info`` is a flat ExceptionInfo dict with ``raised_exception`` /
+    # ``exception_message`` / ``exception_traceback`` keys.
     exception_info = result.exception_info or {}
-    assert exception_info, f"expected exception_info to be populated, got {exception_info!r}"
-    messages = [str(info.get("exception_message", "")) for info in exception_info.values()]
-    assert any("Data.evt.nonexistent" in msg for msg in messages), (
-        f"expected the bogus column name in an exception message, got: {messages!r}"
+    assert exception_info.get("raised_exception"), (
+        f"expected exception_info to be populated, got {exception_info!r}"
+    )
+    message = str(exception_info.get("exception_message", ""))
+    assert "Data.evt.nonexistent" in message, (
+        f"expected the bogus column name in the exception message, got: {message!r}"
     )
 
 

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -852,5 +852,8 @@ def test_validator_with_exception_info_in_result():
         assert len(result) == 3  # One to one mapping of Expectations to results
         for evr in result:
             assert evr.exception_info is not None
-            assert evr.exception_info[str(metric_id)].exception_traceback == exception_traceback
-            assert evr.exception_info[str(metric_id)].exception_message == exception_message
+            # exception_info must be the flat {raised_exception, exception_traceback,
+            # exception_message} dict, not wrapped under the stringified metric ID key.
+            assert evr.exception_info["raised_exception"] is True
+            assert evr.exception_info["exception_traceback"] == exception_traceback
+            assert evr.exception_info["exception_message"] == exception_message


### PR DESCRIPTION
## Summary

Fixes #10849

When a metric resolution fails (e.g. a validation expectation references a non-existent column on a Spark/Databricks datasource), `graph_validate` passed the entire `metric_exception_info` dict directly as the `exception_info` field of `ExpectationValidationResult`. Because that dict is keyed by stringified metric IDs (e.g. `"('column_values.nonnull.condition', '...')"`), downstream consumers received a nested structure like:

```python
# Actual (broken)
{
    "('column_values.nonnull.condition', '242ce...')": {
        "raised_exception": True,
        "exception_traceback": "...",
        "exception_message": "..."
    }
}
```

instead of the documented flat structure:

```python
# Expected
{
    "raised_exception": True,
    "exception_traceback": "...",
    "exception_message": "..."
}
```

This broke any code that inspects `validation_result["results"][i]["exception_info"]` programmatically (monitoring dashboards, alerting pipelines, etc.).

## Changes

- **`great_expectations/validator/validator.py`** — In `_resolve_metrics_and_identify_aborted_expectations`, extract the first `ExceptionInfo` object from `metric_exception_info` and pass it directly to `ExpectationValidationResult` so callers always receive the flat `{raised_exception, exception_traceback, exception_message}` shape.
- **`tests/validator/test_validator.py`** — Update `test_validator_with_exception_info_in_result` to assert the flat structure rather than the old nested-by-metric-ID structure.

## How to reproduce

```python
import great_expectations as gx

context = gx.get_context()
# add a Spark datasource ...
vd = context.validation_definitions.add(
    gx.ValidationDefinition(
        name="test",
        data=batch_definition,
        suite=gx.ExpectationSuite(
            name="test",
            expectations=[
                gx.expectations.ExpectColumnValuesToNotBeNull(column="___nonexistent___")
            ]
        )
    )
)
result = vd.run()
print(result["results"][0]["exception_info"])  # was nested under metric ID, now flat
```

## Test plan

- [x] Updated `test_validator_with_exception_info_in_result` in `tests/validator/test_validator.py` to assert the flat `exception_info` structure
- [ ] Manually verified that a Spark validation that raises produces a flat `exception_info` with the correct `raised_exception`, `exception_traceback`, and `exception_message` keys