### PR TITLE
[BUGFIX] Warn instead of raise when schema absent from get_schema_names() in test_connection (#10499)

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1171,9 +1171,17 @@ class TableAsset(_SQLAsset):
 
         effective_schema = self._effective_schema_name
         if effective_schema and effective_schema not in schema_names:
-            raise TestConnectionError(  # noqa: TRY003 # FIXME CoP
-                f'Attempt to connect to table: "{self.qualified_name}" failed because the schema '
-                f'"{effective_schema}" does not exist.'
+            # Some backends (e.g. SQL Server / MSSQL) only list schemas the connected
+            # user has VIEW DEFINITION on via get_schema_names().  A user with only
+            # SELECT permission on a table can still access the schema, so a missing
+            # entry here does not reliably indicate the schema is absent.  Log a warning
+            # and fall through to the table-level access check, which will surface a
+            # clear error if the schema or table genuinely does not exist (issue #10499).
+            LOGGER.warning(
+                f'Schema "{effective_schema}" was not found in the list returned by '
+                "inspector.get_schema_names(). This can occur when the connected user "
+                "lacks VIEW DEFINITION permission on the schema (e.g. SQL Server). "
+                "Proceeding to validate table accessibility directly."
             )
 
         try:

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -512,7 +512,10 @@ class TestTableAssetTestConnection:
                 new_callable=mock.PropertyMock,
                 return_value=mock.MagicMock(get_engine=mock.MagicMock(return_value=mock_engine)),
             ),
-            mock.patch("great_expectations.datasource.fluent.sql_datasource.sa.inspect", return_value=mock_inspector),
+            mock.patch(
+                "great_expectations.datasource.fluent.sql_datasource.sa.inspect",
+                return_value=mock_inspector,
+            ),
         ):
             # Should not raise even though "my_schema" is not in schema_names.
             asset.test_connection()
@@ -542,7 +545,10 @@ class TestTableAssetTestConnection:
                 new_callable=mock.PropertyMock,
                 return_value=mock.MagicMock(get_engine=mock.MagicMock(return_value=mock_engine)),
             ),
-            mock.patch("great_expectations.datasource.fluent.sql_datasource.sa.inspect", return_value=mock_inspector),
+            mock.patch(
+                "great_expectations.datasource.fluent.sql_datasource.sa.inspect",
+                return_value=mock_inspector,
+            ),
         ):
             with pytest.raises(TestConnectionError):
                 asset.test_connection()

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -473,5 +473,80 @@ class TestTableAsset:
             assert serialized["table_name"] == serialized_name
 
 
+@pytest.mark.unit
+class TestTableAssetTestConnection:
+    """Tests for TableAsset.test_connection schema-listing behaviour (issue #10499)."""
+
+    def _make_table_asset(self, schema_name: str) -> TableAsset:
+        """Return a TableAsset with a fixed datasource whose schema_ matches schema_name."""
+        ds = SQLDatasource(
+            name="my_datasource",
+            connection_string="sqlite:///",
+        )
+        asset = ds.add_table_asset(name="my_asset", table_name="my_table")
+        # Override schema_name directly on the asset so _effective_schema_name returns it.
+        object.__setattr__(asset, "schema_name", schema_name)
+        return asset
+
+    def test_schema_absent_from_get_schema_names_does_not_raise(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When inspector.get_schema_names() omits the schema (e.g. because the
+        connected SQL Server user lacks VIEW DEFINITION on that schema), test_connection
+        should NOT raise.  It should log a warning and let the table-level query decide
+        whether the asset is reachable (issue #10499)."""
+        asset = self._make_table_asset("my_schema")
+
+        mock_engine = mock.MagicMock()
+        mock_inspector = mock.MagicMock()
+        # get_schema_names() returns only system schemas — omits "my_schema".
+        mock_inspector.get_schema_names.return_value = ["dbo", "guest", "information_schema"]
+        mock_conn = mock.MagicMock()
+        mock_engine.connect.return_value.__enter__ = mock.MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = mock.MagicMock(return_value=False)
+
+        with (
+            mock.patch(
+                "great_expectations.datasource.fluent.sql_datasource.TableAsset.datasource",
+                new_callable=mock.PropertyMock,
+                return_value=mock.MagicMock(get_engine=mock.MagicMock(return_value=mock_engine)),
+            ),
+            mock.patch("great_expectations.datasource.fluent.sql_datasource.sa.inspect", return_value=mock_inspector),
+        ):
+            # Should not raise even though "my_schema" is not in schema_names.
+            asset.test_connection()
+
+    def test_schema_absent_and_table_inaccessible_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the schema is absent from get_schema_names() AND the table query also
+        fails, test_connection must still surface a TestConnectionError so the caller
+        knows the asset is not reachable."""
+        from great_expectations.datasource.fluent.interfaces import TestConnectionError
+
+        asset = self._make_table_asset("nonexistent_schema")
+
+        mock_engine = mock.MagicMock()
+        mock_inspector = mock.MagicMock()
+        mock_inspector.get_schema_names.return_value = ["dbo"]
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.side_effect = Exception("schema or table not found")
+        mock_engine.connect.return_value.__enter__ = mock.MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = mock.MagicMock(return_value=False)
+
+        with (
+            mock.patch(
+                "great_expectations.datasource.fluent.sql_datasource.TableAsset.datasource",
+                new_callable=mock.PropertyMock,
+                return_value=mock.MagicMock(get_engine=mock.MagicMock(return_value=mock_engine)),
+            ),
+            mock.patch("great_expectations.datasource.fluent.sql_datasource.sa.inspect", return_value=mock_inspector),
+        ):
+            with pytest.raises(TestConnectionError):
+                asset.test_connection()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vv"])


### PR DESCRIPTION
## Summary

Fixes #10499

`TableAsset.test_connection` raised `TestConnectionError` immediately when the configured schema name was not returned by `inspector.get_schema_names()`. On **SQL Server** (and potentially other backends), `get_schema_names()` only lists schemas the connected user has `VIEW DEFINITION` permission on. A user with only `SELECT` permission on a table in a given schema can still access the table, but the schema is absent from the inspector's list — causing false-positive failures.

The error message was:
> Attempt to connect to table: 'my_schema.my_table' failed because the schema 'my_schema' does not exist.

even though the table was fully accessible.

## Root Cause

The pre-check on `inspector.get_schema_names()` is unreliable when the connected user lacks `VIEW DEFINITION` on the schema. It is redundant anyway because the subsequent `SELECT 1 FROM <table> LIMIT 1` query serves as a definitive accessibility test.

## Changes

- **`great_expectations/datasource/fluent/sql_datasource.py`** — Replace the hard `raise TestConnectionError` when `effective_schema not in schema_names` with a `LOGGER.warning`. The table-level SELECT query that follows will catch any genuine connection failures and raise `TestConnectionError` with a clear message.
- **`tests/datasource/fluent/test_sql_datasources.py`** — Add `TestTableAssetTestConnection` with two unit tests:
  - `test_schema_absent_from_get_schema_names_does_not_raise`: verifies that when the schema is omitted by `get_schema_names()` but the table query succeeds, no error is raised.
  - `test_schema_absent_and_table_inaccessible_raises`: verifies that if the table query also fails, `TestConnectionError` is still surfaced.

## Workaround (before fix)

Users had to use `add_query_asset()` instead of `add_table_asset()` to bypass the schema pre-check.

## Test plan

- [x] `TestTableAssetTestConnection::test_schema_absent_from_get_schema_names_does_not_raise`
- [x] `TestTableAssetTestConnection::test_schema_absent_and_table_inaccessible_raises`
- [ ] Manually verified against a SQL Server instance where the user has SELECT-only permission on a schema