### PR TITLE
[FEATURE] Add element_count to unexpected rows results

### DIFF
--- a/great_expectations/expectations/core/unexpected_rows_expectation.py
+++ b/great_expectations/expectations/core/unexpected_rows_expectation.py
@@ -113,6 +113,7 @@ class UnexpectedRowsExpectation(BatchExpectation):
     metric_dependencies: ClassVar[Tuple[str, ...]] = (
         "unexpected_rows_query.table",
         "unexpected_rows_query.row_count",
+        "table.row_count",
     )
     success_keys: ClassVar[Tuple[str, ...]] = ("unexpected_rows_query",)
     domain_keys: ClassVar[Tuple[str, ...]] = (
@@ -281,6 +282,7 @@ class UnexpectedRowsExpectation(BatchExpectation):
 
         metric_value = metrics["unexpected_rows_query.table"]
         unexpected_row_count = metrics["unexpected_rows_query.row_count"]
+        element_count = metrics["table.row_count"]
         success = unexpected_row_count == 0
 
         if result_format == ResultFormat.BOOLEAN_ONLY:
@@ -290,6 +292,7 @@ class UnexpectedRowsExpectation(BatchExpectation):
                 "success": success,
                 "result": {
                     "observed_value": unexpected_row_count,
+                    "element_count": element_count,
                     "details": {"unexpected_rows": metric_value},
                 },
             }
@@ -299,5 +302,6 @@ class UnexpectedRowsExpectation(BatchExpectation):
                 "success": success,
                 "result": {
                     "observed_value": unexpected_row_count,
+                    "element_count": element_count,
                 },
             }

--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -104,6 +104,7 @@ def test_unexpected_rows_expectation_validate(
 
     res = result.result
     assert res["observed_value"] == expected_observed_value
+    assert res["element_count"] == 100000
 
     unexpected_count_rows_returned = len(res["details"]["unexpected_rows"])
     assert unexpected_count_rows_returned == expected_count_unexpected_rows_returned
@@ -140,10 +141,12 @@ def test_result_format_controls_details_visibility(
         assert "details" in result.result
         assert "unexpected_rows" in result.result["details"]
         assert "observed_value" in result.result
+        assert result.result["element_count"] == 100000
     else:
         # BASIC and SUMMARY should not have details
         assert "details" not in result.result
         assert "observed_value" in result.result
+        assert result.result["element_count"] == 100000
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #11045

## Changes
- Add `table.row_count` as a metric dependency for `UnexpectedRowsExpectation`.
- Return `element_count` in `BASIC`, `SUMMARY`, and `COMPLETE` validation result payloads.
- Add regression assertions for `element_count` while preserving existing `result_format` behavior.

## Tests
- `.\.venv\Scripts\python.exe -m pytest tests/expectations/core/test_unexpected_rows_expectation.py -v`
- `.\.venv\Scripts\python.exe -m invoke lint --no-pty`

- [x] Description of PR changes above includes a link to an existing GitHub issue: #11045
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated