### PR TITLE
[FEATURE] Add localization support to expectation renderers

### DIFF
--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -239,14 +239,18 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
         if not has_value_set:
             template_str = cls._get_localized_renderer_template(
                 key="renderer.expect_column_distinct_values_to_be_in_set.no_value_set",
-                default_template="distinct values must belong to a set, but that set is not specified.",
+                default_template=(
+                    "distinct values must belong to a set, but that set is not specified."
+                ),
                 renderer_configuration=renderer_configuration,
                 runtime_configuration=runtime_configuration,
             )
         else:
             template_str = cls._get_localized_renderer_template(
                 key="renderer.expect_column_distinct_values_to_be_in_set.value_set",
-                default_template=f"distinct values must belong to this set: {value_set_placeholder}.",
+                default_template=(
+                    f"distinct values must belong to this set: {value_set_placeholder}."
+                ),
                 renderer_configuration=renderer_configuration,
                 runtime_configuration=runtime_configuration,
             )

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -226,6 +226,40 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
     }
     _library_metadata = library_metadata
 
+    @classmethod
+    def _get_prescriptive_template_str(
+        cls,
+        *,
+        include_column_name: bool,
+        has_value_set: bool,
+        value_set_placeholder: str,
+        renderer_configuration: Optional[RendererConfiguration] = None,
+        runtime_configuration: Optional[dict] = None,
+    ) -> str:
+        if not has_value_set:
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.expect_column_distinct_values_to_be_in_set.no_value_set",
+                default_template="distinct values must belong to a set, but that set is not specified.",
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+        else:
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.expect_column_distinct_values_to_be_in_set.value_set",
+                default_template=f"distinct values must belong to this set: {value_set_placeholder}.",
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+
+        if include_column_name:
+            template_str = cls._prefix_column_template(
+                template_str,
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+
+        return template_str
+
     # Setting necessary computation metric dependencies and defining kwargs, as well as assigning kwargs default values\  # noqa: E501 # FIXME CoP
     metric_dependencies = (
         "column.distinct_values.not_in_set.count",
@@ -292,12 +326,12 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
         params = renderer_configuration.params
 
         if not params.value_set or len(params.value_set.value) == 0:
-            if renderer_configuration.include_column_name:
-                template_str = "$column distinct values must belong to this set: [ ]"
-            else:
-                template_str = (
-                    "distinct values must belong to a set, but that set is not specified."
-                )
+            template_str = cls._get_prescriptive_template_str(
+                include_column_name=renderer_configuration.include_column_name,
+                has_value_set=False,
+                value_set_placeholder="[ ]",
+                renderer_configuration=renderer_configuration,
+            )
         else:
             array_param_name = "value_set"
             param_prefix = "v__"
@@ -312,10 +346,12 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
                 renderer_configuration=renderer_configuration,
             )
 
-            if renderer_configuration.include_column_name:
-                template_str = f"$column distinct values must belong to this set: {value_set_str}."
-            else:
-                template_str = f"distinct values must belong to this set: {value_set_str}."
+            template_str = cls._get_prescriptive_template_str(
+                include_column_name=renderer_configuration.include_column_name,
+                has_value_set=True,
+                value_set_placeholder=value_set_str,
+                renderer_configuration=renderer_configuration,
+            )
 
         renderer_configuration.template_str = template_str
 
@@ -341,22 +377,23 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
         )
 
         if params["value_set"] is None or len(params["value_set"]) == 0:
-            if renderer_configuration.include_column_name:
-                template_str = "$column distinct values must belong to this set: [ ]"
-            else:
-                template_str = (
-                    "distinct values must belong to a set, but that set is not specified."
-                )
-
+            template_str = cls._get_prescriptive_template_str(
+                include_column_name=renderer_configuration.include_column_name,
+                has_value_set=False,
+                value_set_placeholder="[ ]",
+                runtime_configuration=runtime_configuration,
+            )
         else:
             for i, v in enumerate(params["value_set"]):
                 params[f"v__{i!s}"] = v
             values_string = " ".join([f"$v__{i!s}" for i, v in enumerate(params["value_set"])])
 
-            if renderer_configuration.include_column_name:
-                template_str = f"$column distinct values must belong to this set: {values_string}."
-            else:
-                template_str = f"distinct values must belong to this set: {values_string}."
+            template_str = cls._get_prescriptive_template_str(
+                include_column_name=renderer_configuration.include_column_name,
+                has_value_set=True,
+                value_set_placeholder=values_string,
+                runtime_configuration=runtime_configuration,
+            )
 
         styling = runtime_configuration.get("styling", {}) if runtime_configuration else {}
 

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -222,20 +222,28 @@ class ExpectColumnToExist(BatchExpectation):
         params = renderer_configuration.params
 
         if not params.column_index:
-            if renderer_configuration.include_column_name:
-                template_str = "$column is a required field."
-            else:
-                template_str = "is a required field."
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.expect_column_to_exist.required_field",
+                default_template="is a required field.",
+                renderer_configuration=renderer_configuration,
+            )
         else:
             renderer_configuration.add_param(
                 name="column_indexth",
                 param_type=RendererValueType.STRING,
                 value=ordinal(params.column_index.value),
             )
-            if renderer_configuration.include_column_name:
-                template_str = "$column must be the $column_indexth field."
-            else:
-                template_str = "must be the $column_indexth field."
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.expect_column_to_exist.indexed_field",
+                default_template="must be the $column_indexth field.",
+                renderer_configuration=renderer_configuration,
+            )
+
+        if renderer_configuration.include_column_name:
+            template_str = cls._prefix_column_template(
+                template_str,
+                renderer_configuration=renderer_configuration,
+            )
 
         renderer_configuration.template_str = template_str
 
@@ -261,16 +269,24 @@ class ExpectColumnToExist(BatchExpectation):
         )
 
         if params["column_index"] is None:
-            if include_column_name:
-                template_str = "$column is a required field."
-            else:
-                template_str = "is a required field."
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.expect_column_to_exist.required_field",
+                default_template="is a required field.",
+                runtime_configuration=runtime_configuration,
+            )
         else:
             params["column_indexth"] = ordinal(params["column_index"])
-            if include_column_name:
-                template_str = "$column must be the $column_indexth field."
-            else:
-                template_str = "must be the $column_indexth field."
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.expect_column_to_exist.indexed_field",
+                default_template="must be the $column_indexth field.",
+                runtime_configuration=runtime_configuration,
+            )
+
+        if include_column_name:
+            template_str = cls._prefix_column_template(
+                template_str,
+                runtime_configuration=runtime_configuration,
+            )
 
         return [
             RenderedStringTemplateContent(

--- a/great_expectations/expectations/core/unexpected_rows_expectation.py
+++ b/great_expectations/expectations/core/unexpected_rows_expectation.py
@@ -113,6 +113,7 @@ class UnexpectedRowsExpectation(BatchExpectation):
     metric_dependencies: ClassVar[Tuple[str, ...]] = (
         "unexpected_rows_query.table",
         "unexpected_rows_query.row_count",
+        "table.row_count",
     )
     success_keys: ClassVar[Tuple[str, ...]] = ("unexpected_rows_query",)
     domain_keys: ClassVar[Tuple[str, ...]] = (
@@ -281,6 +282,7 @@ class UnexpectedRowsExpectation(BatchExpectation):
 
         metric_value = metrics["unexpected_rows_query.table"]
         unexpected_row_count = metrics["unexpected_rows_query.row_count"]
+        element_count = metrics["table.row_count"]
         success = unexpected_row_count == 0
 
         if result_format == ResultFormat.BOOLEAN_ONLY:
@@ -290,6 +292,7 @@ class UnexpectedRowsExpectation(BatchExpectation):
                 "success": success,
                 "result": {
                     "observed_value": unexpected_row_count,
+                    "element_count": element_count,
                     "details": {"unexpected_rows": metric_value},
                 },
             }
@@ -299,5 +302,6 @@ class UnexpectedRowsExpectation(BatchExpectation):
                 "success": success,
                 "result": {
                     "observed_value": unexpected_row_count,
+                    "element_count": element_count,
                 },
             }

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -105,6 +105,7 @@ from great_expectations.render import (
     renderedAtomicValueSchema,
 )
 from great_expectations.render.exceptions import RendererConfigurationError
+from great_expectations.render.i18n import translate
 from great_expectations.render.renderer.renderer import renderer
 from great_expectations.render.renderer_configuration import (
     RendererConfiguration,
@@ -156,8 +157,16 @@ def render_suite_parameter_string(render_func: Callable[P, T]) -> Callable[P, T]
     def inner_func(*args: P.args, **kwargs: P.kwargs) -> T:  # noqa: C901 #  too complex
         rendered_string_template = render_func(*args, **kwargs)
         current_expectation_params: list = []
-        app_template_str = "\n - $eval_param = $eval_param_value (at time of validation)."
         configuration: dict | None = kwargs.get("configuration")  # type: ignore[assignment] # could be object?
+        runtime_configuration: Optional[dict] = kwargs.get("runtime_configuration")  # type: ignore[assignment] # could be object?
+        app_template_str = translate(
+            "renderer.expectation.suite_parameter",
+            "\n - $eval_param = $eval_param_value (at time of validation).",
+            locale=runtime_configuration.get("locale") if runtime_configuration else None,
+            translations=runtime_configuration.get("translations")
+            if runtime_configuration
+            else None,
+        )
         if configuration:
             kwargs_dict: dict = configuration.get("kwargs", {})
             for value in kwargs_dict.values():
@@ -177,7 +186,6 @@ def render_suite_parameter_string(render_func: Callable[P, T]) -> Callable[P, T]
         if current_expectation_params and is_list_of_rendered_string_template_content(
             rendered_string_template
         ):
-            runtime_configuration: Optional[dict] = kwargs.get("runtime_configuration")  # type: ignore[assignment] # could be object?
             if runtime_configuration:
                 eval_params = runtime_configuration.get("suite_parameters", {})
                 styling = runtime_configuration.get("styling")
@@ -593,15 +601,58 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                 continue
             register_renderer(object_name=expectation_type, parent_class=cls, renderer_fn=attr_obj)
 
-    def render(self) -> None:
+    def render(self, runtime_configuration: Optional[dict] = None) -> None:
         """
         Renders content using the atomic prescriptive renderer for each expectation configuration associated with
            this ExpectationSuite to ExpectationConfiguration.rendered_content.
         """  # noqa: E501 # FIXME CoP
         from great_expectations.render.renderer.inline_renderer import InlineRenderer
 
-        inline_renderer = InlineRenderer(render_object=self.configuration)
+        inline_renderer = InlineRenderer(
+            render_object=self.configuration,
+            runtime_configuration=runtime_configuration,
+        )
         self.rendered_content = inline_renderer.get_rendered_content()
+
+    @classmethod
+    def _get_localized_renderer_template(
+        cls,
+        *,
+        key: str,
+        default_template: str,
+        renderer_configuration: Optional[RendererConfiguration] = None,
+        runtime_configuration: Optional[dict] = None,
+    ) -> str:
+        if renderer_configuration is not None:
+            locale = renderer_configuration.locale
+            translations = renderer_configuration.translations
+        else:
+            runtime_configuration = runtime_configuration or {}
+            locale = runtime_configuration.get("locale")
+            translations = runtime_configuration.get("translations")
+
+        return translate(
+            key,
+            default_template,
+            locale=locale,
+            translations=translations,
+        )
+
+    @classmethod
+    def _prefix_column_template(
+        cls,
+        template: str,
+        *,
+        renderer_configuration: Optional[RendererConfiguration] = None,
+        runtime_configuration: Optional[dict] = None,
+    ) -> str:
+        column_prefix_template = cls._get_localized_renderer_template(
+            key="renderer.common.column_prefix",
+            default_template="$column {template}",
+            renderer_configuration=renderer_configuration,
+            runtime_configuration=runtime_configuration,
+        )
+        return column_prefix_template.format(template=template)
 
     @abstractmethod
     def _validate(
@@ -629,7 +680,11 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             runtime_configuration=runtime_configuration,
         )
 
-        template_str = "Rendering failed for Expectation: "
+        template_str = cls._get_localized_renderer_template(
+            key="renderer.expectation.render_failed",
+            default_template="Rendering failed for Expectation: ",
+            renderer_configuration=renderer_configuration,
+        )
 
         if renderer_configuration.expectation_type and renderer_configuration.kwargs:
             template_str += "$expectation_type(**$kwargs)."
@@ -1178,7 +1233,11 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             runtime_configuration=runtime_configuration,
         )
 
-        template_str = "Rendering failed for Expectation: "
+        template_str = cls._get_localized_renderer_template(
+            key="renderer.expectation.render_failed",
+            default_template="Rendering failed for Expectation: ",
+            renderer_configuration=renderer_configuration,
+        )
 
         if renderer_configuration.expectation_type and renderer_configuration.kwargs:
             template_str += "$expectation_type(**$kwargs)."

--- a/great_expectations/expectations/regex_based_column_map_expectation.py
+++ b/great_expectations/expectations/regex_based_column_map_expectation.py
@@ -124,6 +124,55 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
         map_metric (str): The name of an ephemeral metric, as returned by `register_metric(...)`.
     """  # noqa: E501 # FIXME CoP
 
+    @classmethod
+    def _get_prescriptive_template_str(
+        cls,
+        *,
+        has_regex: bool,
+        include_column_name: bool,
+        has_mostly: bool,
+        renderer_configuration: Optional[RendererConfiguration] = None,
+        runtime_configuration: Optional[dict] = None,
+    ) -> str:
+        if not has_regex:
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.regex_based_column_map.no_regex",
+                default_template="values must match a regular expression but none was specified.",
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+        else:
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.regex_based_column_map.regex",
+                default_template="values must match this regular expression: $regex",
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+
+            if has_mostly:
+                template_str += cls._get_localized_renderer_template(
+                    key="renderer.regex_based_column_map.mostly_suffix",
+                    default_template=", at least $mostly_pct % of the time.",
+                    renderer_configuration=renderer_configuration,
+                    runtime_configuration=runtime_configuration,
+                )
+            else:
+                template_str += cls._get_localized_renderer_template(
+                    key="renderer.common.period",
+                    default_template=".",
+                    renderer_configuration=renderer_configuration,
+                    runtime_configuration=runtime_configuration,
+                )
+
+        if include_column_name:
+            template_str = cls._prefix_column_template(
+                template_str,
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+
+        return template_str
+
     @staticmethod
     def register_metric(
         regex_camel_name: str,
@@ -244,21 +293,18 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
 
         params = renderer_configuration.params
 
-        if not params.regex:
-            template_str = "values must match a regular expression but none was specified."
-        else:
-            template_str = "values must match this regular expression: $regex"
+        has_mostly = bool(params.mostly and params.mostly.value < 1.0)
+        if has_mostly:
+            renderer_configuration = cls._add_mostly_pct_param(
+                renderer_configuration=renderer_configuration
+            )
 
-            if params.mostly and params.mostly.value < 1.0:
-                renderer_configuration = cls._add_mostly_pct_param(
-                    renderer_configuration=renderer_configuration
-                )
-                template_str += ", at least $mostly_pct % of the time."
-            else:
-                template_str += "."
-
-        if renderer_configuration.include_column_name:
-            template_str = "$column " + template_str
+        template_str = cls._get_prescriptive_template_str(
+            has_regex=bool(params.regex),
+            include_column_name=renderer_configuration.include_column_name,
+            has_mostly=has_mostly,
+            renderer_configuration=renderer_configuration,
+        )
 
         renderer_configuration.template_str = template_str
 
@@ -284,19 +330,16 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
             ["column", "regex", "mostly", "row_condition", "condition_parser"],
         )
 
-        if not params.get("regex"):
-            template_str = "values must match a regular expression but none was specified."
-        else:
-            template_str = "values must match this regular expression: $regex"
-            if params["mostly"] is not None:
-                params["mostly_pct"] = num_to_str(params["mostly"] * 100, no_scientific=True)
-                # params["mostly_pct"] = "{:.14f}".format(params["mostly"]*100).rstrip("0").rstrip(".")  # noqa: E501 # FIXME CoP
-                template_str += ", at least $mostly_pct % of the time."
-            else:
-                template_str += "."
+        has_mostly = params["mostly"] is not None
+        if has_mostly:
+            params["mostly_pct"] = num_to_str(params["mostly"] * 100, no_scientific=True)
 
-        if include_column_name:
-            template_str = "$column " + template_str
+        template_str = cls._get_prescriptive_template_str(
+            has_regex=bool(params.get("regex")),
+            include_column_name=include_column_name,
+            has_mostly=has_mostly,
+            runtime_configuration=runtime_configuration,
+        )
 
         if params["row_condition"] is not None:
             conditional_template_str = parse_row_condition_string(params["row_condition"])

--- a/great_expectations/expectations/set_based_column_map_expectation.py
+++ b/great_expectations/expectations/set_based_column_map_expectation.py
@@ -116,7 +116,7 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
     """  # noqa: E501 # FIXME CoP
 
     @classmethod
-    def _get_prescriptive_template_str(
+    def _get_prescriptive_template_str(  # noqa: PLR0913
         cls,
         *,
         has_set: bool,

--- a/great_expectations/expectations/set_based_column_map_expectation.py
+++ b/great_expectations/expectations/set_based_column_map_expectation.py
@@ -115,6 +115,64 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
         - https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_set_based_column_map_expectations
     """  # noqa: E501 # FIXME CoP
 
+    @classmethod
+    def _get_prescriptive_template_str(
+        cls,
+        *,
+        has_set: bool,
+        has_semantic_name: bool,
+        include_column_name: bool,
+        has_mostly: bool,
+        renderer_configuration: Optional[RendererConfiguration] = None,
+        runtime_configuration: Optional[dict] = None,
+    ) -> str:
+        if not has_set:
+            template_str = cls._get_localized_renderer_template(
+                key="renderer.set_based_column_map.no_set",
+                default_template="values must match a set but none was specified.",
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+        else:
+            if has_semantic_name:
+                template_str = cls._get_localized_renderer_template(
+                    key="renderer.set_based_column_map.semantic_set",
+                    default_template="values must match the set $set_semantic_name: $set_",
+                    renderer_configuration=renderer_configuration,
+                    runtime_configuration=runtime_configuration,
+                )
+            else:
+                template_str = cls._get_localized_renderer_template(
+                    key="renderer.set_based_column_map.generic_set",
+                    default_template="values must match this set: $set_",
+                    renderer_configuration=renderer_configuration,
+                    runtime_configuration=runtime_configuration,
+                )
+
+            if has_mostly:
+                template_str += cls._get_localized_renderer_template(
+                    key="renderer.set_based_column_map.mostly_suffix",
+                    default_template=", at least $mostly_pct % of the time.",
+                    renderer_configuration=renderer_configuration,
+                    runtime_configuration=runtime_configuration,
+                )
+            else:
+                template_str += cls._get_localized_renderer_template(
+                    key="renderer.common.period",
+                    default_template=".",
+                    renderer_configuration=renderer_configuration,
+                    runtime_configuration=runtime_configuration,
+                )
+
+        if include_column_name:
+            template_str = cls._prefix_column_template(
+                template_str,
+                renderer_configuration=renderer_configuration,
+                runtime_configuration=runtime_configuration,
+            )
+
+        return template_str
+
     @staticmethod
     def register_metric(
         set_camel_name: str,
@@ -237,24 +295,19 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
 
         params = renderer_configuration.params
 
-        if not params.set_:
-            template_str = "values must match a set but none was specified."
-        else:
-            if params.set_semantic_name:
-                template_str = "values must match the set $set_semantic_name: $set_"
-            else:
-                template_str = "values must match this set: $set_"
+        has_mostly = bool(params.mostly and params.mostly.value < 1.0)
+        if has_mostly:
+            renderer_configuration = cls._add_mostly_pct_param(
+                renderer_configuration=renderer_configuration
+            )
 
-            if params.mostly and params.mostly.value < 1.0:
-                renderer_configuration = cls._add_mostly_pct_param(
-                    renderer_configuration=renderer_configuration
-                )
-                template_str += ", at least $mostly_pct % of the time."
-            else:
-                template_str += "."
-
-        if renderer_configuration.include_column_name:
-            template_str = "$column " + template_str
+        template_str = cls._get_prescriptive_template_str(
+            has_set=bool(params.set_),
+            has_semantic_name=bool(params.set_semantic_name),
+            include_column_name=renderer_configuration.include_column_name,
+            has_mostly=has_mostly,
+            renderer_configuration=renderer_configuration,
+        )
 
         renderer_configuration.template_str = template_str
 
@@ -285,21 +338,17 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
             ],
         )
 
-        if not params.get("set_"):
-            template_str = "values must match a set but none was specified."
-        else:
-            if params.get("set_semantic_name"):
-                template_str = "values must match the set $set_semantic_name: $set_"
-            else:
-                template_str = "values must match this set: $set_"
-            if params["mostly"] is not None:
-                params["mostly_pct"] = num_to_str(params["mostly"] * 100, no_scientific=True)
-                template_str += ", at least $mostly_pct % of the time."
-            else:
-                template_str += "."
+        has_mostly = params["mostly"] is not None
+        if has_mostly:
+            params["mostly_pct"] = num_to_str(params["mostly"] * 100, no_scientific=True)
 
-        if include_column_name:
-            template_str = "$column " + template_str
+        template_str = cls._get_prescriptive_template_str(
+            has_set=bool(params.get("set_")),
+            has_semantic_name=bool(params.get("set_semantic_name")),
+            include_column_name=include_column_name,
+            has_mostly=has_mostly,
+            runtime_configuration=runtime_configuration,
+        )
 
         if params["row_condition"] is not None:
             conditional_template_str = parse_row_condition_string(params["row_condition"])

--- a/great_expectations/render/i18n.py
+++ b/great_expectations/render/i18n.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+DEFAULT_LOCALE = "en"
+Translations = Dict[str, Dict[str, str]]
+
+
+def _normalize_locale(locale: Optional[str]) -> str:
+    if not locale:
+        return DEFAULT_LOCALE
+    return locale.strip().replace("-", "_").lower()
+
+
+def _candidate_locales(locale: Optional[str]) -> list[str]:
+    normalized_locale = _normalize_locale(locale)
+    candidates = [normalized_locale]
+    if "_" in normalized_locale:
+        candidates.append(normalized_locale.split("_", 1)[0])
+    if DEFAULT_LOCALE not in candidates:
+        candidates.append(DEFAULT_LOCALE)
+    return candidates
+
+
+def translate(
+    key: str,
+    default: str,
+    *,
+    locale: Optional[str] = None,
+    translations: Optional[Translations] = None,
+) -> str:
+    if not translations:
+        return default
+
+    normalized_translations = {
+        _normalize_locale(locale_name): catalog for locale_name, catalog in translations.items()
+    }
+
+    for locale_name in _candidate_locales(locale):
+        localized_catalog = normalized_translations.get(locale_name, {})
+        translated = localized_catalog.get(key)
+        if translated is not None:
+            return translated
+
+    return default

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -56,6 +56,8 @@ diagnose and repair the underlying issue.  Detailed information follows:
         runtime_configuration = {
             "styling": cls._get_element_styling(),
             "include_column_name": kwargs.pop("include_column_name", None),
+            "locale": kwargs.pop("locale", None),
+            "translations": kwargs.pop("translations", None),
         }
 
         # The specific way we render the render_object is contingent on the type of the object
@@ -207,6 +209,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                 content_block,
                 has_failed_evr=has_failed_evr,
                 render_object=render_object,
+                runtime_configuration=runtime_configuration,
             )
 
             return content_block
@@ -379,7 +382,13 @@ diagnose and repair the underlying issue.  Detailed information follows:
             )
 
     @classmethod
-    def _process_content_block(cls, content_block, has_failed_evr, render_object=None) -> None:
+    def _process_content_block(
+        cls,
+        content_block,
+        has_failed_evr,
+        render_object=None,
+        runtime_configuration=None,
+    ) -> None:
         header = cls._get_header()
         if header != "":
             content_block.header = header

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -12,6 +12,7 @@ from great_expectations.render import (
     LegacyDiagnosticRendererType,
     RenderedTableContent,
 )
+from great_expectations.render.i18n import translate
 from great_expectations.render.renderer.content_block.expectation_string import (
     ExpectationStringRenderer,
 )
@@ -57,10 +58,41 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
 
     @classmethod
     @override
-    def _process_content_block(cls, content_block, has_failed_evr, render_object=None) -> None:
-        super()._process_content_block(content_block, has_failed_evr)
-        content_block.header_row = ["Status", "Expectation", "Observed Value"]
-        content_block.header_row_options = {"Status": {"sortable": True}}
+    def _process_content_block(
+        cls,
+        content_block,
+        has_failed_evr,
+        render_object=None,
+        runtime_configuration=None,
+    ) -> None:
+        super()._process_content_block(
+            content_block,
+            has_failed_evr,
+            render_object=render_object,
+            runtime_configuration=runtime_configuration,
+        )
+        runtime_configuration = runtime_configuration or {}
+        content_block.header_row = [
+            translate(
+                "renderer.validation_results_table.status",
+                "Status",
+                locale=runtime_configuration.get("locale"),
+                translations=runtime_configuration.get("translations"),
+            ),
+            translate(
+                "renderer.validation_results_table.expectation",
+                "Expectation",
+                locale=runtime_configuration.get("locale"),
+                translations=runtime_configuration.get("translations"),
+            ),
+            translate(
+                "renderer.validation_results_table.observed_value",
+                "Observed Value",
+                locale=runtime_configuration.get("locale"),
+                translations=runtime_configuration.get("translations"),
+            ),
+        ]
+        content_block.header_row_options = {content_block.header_row[0]: {"sortable": True}}
 
         # Add custom meta_properties_to_render header
         if render_object is not None:

--- a/great_expectations/render/renderer/inline_renderer.py
+++ b/great_expectations/render/renderer/inline_renderer.py
@@ -34,17 +34,20 @@ logger = logging.getLogger(__name__)
 class InlineRendererConfig(TypedDict):
     class_name: str
     render_object: Union[ExpectationConfiguration, ExpectationValidationResult]
+    runtime_configuration: dict
 
 
 class InlineRenderer(Renderer):
     def __init__(
         self,
         render_object: Union[ExpectationConfiguration, ExpectationValidationResult],
+        runtime_configuration: Optional[dict] = None,
     ) -> None:
         super().__init__()
 
         if isinstance(render_object, (ExpectationConfiguration, ExpectationValidationResult)):
             self._render_object = render_object
+            self._runtime_configuration = runtime_configuration or {}
         else:
             raise InlineRendererError(  # noqa: TRY003 # FIXME CoP
                 f"InlineRenderer can only be used with an ExpectationConfiguration or ExpectationValidationResult, but {type(render_object)} was used."  # noqa: E501 # FIXME CoP
@@ -127,6 +130,7 @@ class InlineRenderer(Renderer):
                 render_object=render_object,
                 renderer_name=renderer_name,
                 expectation_type=expectation_type,
+                runtime_configuration=self._runtime_configuration,
             )
             if isinstance(renderer_rendered_content, list):
                 rendered_content.extend(renderer_rendered_content)
@@ -140,6 +144,7 @@ class InlineRenderer(Renderer):
         render_object: ExpectationConfiguration | ExpectationValidationResult,
         renderer_name: str | AtomicDiagnosticRendererType | AtomicPrescriptiveRendererType,
         expectation_type: str,
+        runtime_configuration: Optional[dict] = None,
     ) -> RenderedAtomicContent | list[RenderedAtomicContent]:
         renderer_impl: Optional[RendererImpl]
         try:
@@ -150,6 +155,7 @@ class InlineRenderer(Renderer):
                 renderer_rendered_content = InlineRenderer._get_rendered_content_from_renderer_impl(
                     renderer_impl=renderer_impl,
                     render_object=render_object,
+                    runtime_configuration=runtime_configuration,
                 )
             else:
                 raise InlineRendererError(  # noqa: TRY003, TRY301 # FIXME CoP
@@ -185,6 +191,7 @@ class InlineRenderer(Renderer):
                 renderer_rendered_content = InlineRenderer._get_rendered_content_from_renderer_impl(
                     renderer_impl=renderer_impl,
                     render_object=render_object,
+                    runtime_configuration=runtime_configuration,
                 )
                 if isinstance(renderer_rendered_content, list):
                     for failure_rendered_content in renderer_rendered_content:
@@ -202,14 +209,21 @@ class InlineRenderer(Renderer):
     def _get_rendered_content_from_renderer_impl(
         renderer_impl: RendererImpl,
         render_object: ExpectationConfiguration | ExpectationValidationResult,
+        runtime_configuration: Optional[dict] = None,
     ) -> RenderedAtomicContent | list[RenderedAtomicContent]:
         renderer_fn: Callable[
             ..., RenderedAtomicContent | list[RenderedAtomicContent] | RenderedContent
         ] = renderer_impl.renderer
         if isinstance(render_object, ExpectationConfiguration):
-            renderer_rendered_content = renderer_fn(configuration=render_object)
+            renderer_rendered_content = renderer_fn(
+                configuration=render_object,
+                runtime_configuration=runtime_configuration,
+            )
         else:
-            renderer_rendered_content = renderer_fn(result=render_object)
+            renderer_rendered_content = renderer_fn(
+                result=render_object,
+                runtime_configuration=runtime_configuration,
+            )
 
         assert isinstance(renderer_rendered_content, (RenderedAtomicContent, list))
         return renderer_rendered_content

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -246,6 +246,8 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
     configuration: Optional[ExpectationConfiguration] = Field(None, allow_mutation=False)
     result: Optional[ExpectationValidationResult] = Field(None, allow_mutation=False)
     runtime_configuration: Optional[dict] = Field({}, allow_mutation=False)
+    locale: str = Field("en", allow_mutation=False)
+    translations: Dict[str, Dict[str, str]] = Field(default_factory=dict, allow_mutation=False)
     expectation_type: str = Field("", allow_mutation=False)
     kwargs: dict = Field({}, allow_mutation=False)
     meta_notes: MetaNotes = Field(
@@ -412,6 +414,13 @@ class RendererConfiguration(pydantic_generics.GenericModel, Generic[RendererPara
             values["include_column_name"] = (
                 values["runtime_configuration"].get("include_column_name") is not False
             )
+        return values
+
+    @root_validator()
+    def _validate_for_localization(cls, values: dict) -> dict:
+        runtime_configuration = values.get("runtime_configuration") or {}
+        values["locale"] = runtime_configuration.get("locale") or "en"
+        values["translations"] = runtime_configuration.get("translations") or {}
         return values
 
     @staticmethod

--- a/tests/expectations/core/test_unexpected_rows_expectation.py
+++ b/tests/expectations/core/test_unexpected_rows_expectation.py
@@ -104,6 +104,7 @@ def test_unexpected_rows_expectation_validate(
 
     res = result.result
     assert res["observed_value"] == expected_observed_value
+    assert res["element_count"] == 100000
 
     unexpected_count_rows_returned = len(res["details"]["unexpected_rows"])
     assert unexpected_count_rows_returned == expected_count_unexpected_rows_returned
@@ -140,10 +141,12 @@ def test_result_format_controls_details_visibility(
         assert "details" in result.result
         assert "unexpected_rows" in result.result["details"]
         assert "observed_value" in result.result
+        assert result.result["element_count"] == 100000
     else:
         # BASIC and SUMMARY should not have details
         assert "details" not in result.result
         assert "observed_value" in result.result
+        assert result.result["element_count"] == 100000
 
 
 @pytest.mark.unit

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -46,6 +46,35 @@ def test_inline_renderer_instantiation_error_message(
     )
 
 
+@pytest.mark.unit
+def test_inline_renderer_passes_runtime_localization_to_atomic_renderers():
+    expectation_configuration = ExpectationConfiguration(
+        type="expect_column_distinct_values_to_be_in_set",
+        kwargs={"column": "event_type", "value_set": [19, 22, 73]},
+    )
+
+    rendered_content = InlineRenderer(
+        render_object=expectation_configuration,
+        runtime_configuration={
+            "locale": "nl-NL",
+            "translations": {
+                "nl": {
+                    "renderer.expect_column_distinct_values_to_be_in_set.value_set": (
+                        "onderscheidende waarden moeten in deze set zitten: $v__0 $v__1 $v__2."
+                    )
+                }
+            },
+        },
+    ).get_rendered_content()
+
+    summary_content = rendered_content[0].to_json_dict()
+    assert summary_content["name"] == AtomicPrescriptiveRendererType.SUMMARY
+    assert (
+        summary_content["value"]["template"]
+        == "$column onderscheidende waarden moeten in deze set zitten: $v__0 $v__1 $v__2."
+    )
+
+
 @pytest.mark.parametrize(
     "expectation_configuration,fake_result,expected_serialized_expectation_validation_result_rendered_atomic_content",
     [

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -5,6 +5,7 @@ import pytest
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
+from great_expectations.expectations.core.expect_column_to_exist import ExpectColumnToExist
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -131,6 +132,62 @@ def evr_id_pk_basic_pandas() -> ExpectationValidationResult:
             "unexpected_percent_total": 50.0,
         },
     )
+
+
+@pytest.mark.unit
+def test_validation_results_table_headers_can_be_localized():
+    evr = ExpectationValidationResult(
+        success=True,
+        expectation_config=ExpectationConfiguration(
+            type="expect_column_to_exist",
+            kwargs={"column": "animals"},
+        ),
+        exception_info={
+            "exception_message": None,
+            "exception_traceback": None,
+            "raised_exception": False,
+        },
+        result={},
+    )
+
+    rendered = ValidationResultsTableContentBlockRenderer.render(
+        [evr],
+        locale="nl-NL",
+        translations={
+            "nl": {
+                "renderer.validation_results_table.status": "Status NL",
+                "renderer.validation_results_table.expectation": "Verwachting",
+                "renderer.validation_results_table.observed_value": "Waargenomen waarde",
+            }
+        },
+    )
+
+    assert rendered.header_row == ["Status NL", "Verwachting", "Waargenomen waarde"]
+
+
+@pytest.mark.unit
+def test_legacy_prescriptive_renderer_uses_localized_templates():
+    expectation_configuration = ExpectationConfiguration(
+        type="expect_column_to_exist",
+        kwargs={"column": "animals", "column_index": 1},
+    )
+
+    rendered = ExpectColumnToExist._prescriptive_renderer(
+        configuration=expectation_configuration,
+        runtime_configuration={
+            "locale": "nl-NL",
+            "translations": {
+                "nl": {
+                    "renderer.expect_column_to_exist.indexed_field": (
+                        "moet op positie $column_index staan."
+                    ),
+                    "renderer.common.column_prefix": "kolom $column: {template}",
+                }
+            },
+        },
+    )
+
+    assert rendered[0].string_template["template"] == "kolom $column: moet op positie $column_index staan."
 
 
 def test_ValidationResultsTableContentBlockRenderer_generate_expectation_row_with_errored_expectation(  # noqa: E501 # FIXME CoP

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -187,7 +187,10 @@ def test_legacy_prescriptive_renderer_uses_localized_templates():
         },
     )
 
-    assert rendered[0].string_template["template"] == "kolom $column: moet op positie $column_index staan."
+    assert (
+        rendered[0].string_template["template"]
+        == "kolom $column: moet op positie $column_index staan."
+    )
 
 
 def test_ValidationResultsTableContentBlockRenderer_generate_expectation_row_with_errored_expectation(  # noqa: E501 # FIXME CoP

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -85,19 +85,22 @@ def test_successful_renderer_configuration_instantiation(
     assert renderer_configuration.kwargs == kwargs
     assert renderer_configuration.include_column_name is include_column_name
 
-    expectation_validation_result = (
-        mock_expectation_validation_result_from_expectation_configuration(
-            expectation_configuration=expectation_configuration,
-            fake_result=fake_result,
-        )
+
+@pytest.mark.unit
+def test_renderer_configuration_localization_settings():
+    expectation_configuration = ExpectationConfiguration(
+        type="expect_table_row_count_to_equal",
+        kwargs={"value": 3},
     )
+    translations = {"nl": {"renderer.common.period": "."}}
+
     renderer_configuration = RendererConfiguration(
-        result=expectation_validation_result,
-        runtime_configuration=runtime_configuration,
+        configuration=expectation_configuration,
+        runtime_configuration={"locale": "nl-NL", "translations": translations},
     )
-    assert renderer_configuration.expectation_type == expectation_type
-    assert renderer_configuration.kwargs == kwargs
-    assert renderer_configuration.include_column_name is include_column_name
+
+    assert renderer_configuration.locale == "nl-NL"
+    assert renderer_configuration.translations == translations
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Partially addresses https://github.com/great-expectations/great_expectations/issues/10999

## Changes

- Adds locale and translation support to the expectation renderer stack.
- Threads `locale` and `translations` through `RendererConfiguration`, inline atomic rendering, and Data Docs content block rendering.
- Migrates initial renderer templates for:
  - `ExpectColumnDistinctValuesToBeInSet`
  - `ExpectColumnToExist`
  - shared set-based column map expectations
  - shared regex-based column map expectations
  - validation result table headers
- Adds focused tests for localized renderer configuration, atomic rendering, legacy prescriptive rendering, and Data Docs table headers.

## Testing

- [x] `invoke lint --no-pty`
- [x] `pytest tests/render/test_renderer_configuration.py tests/render/test_inline_renderer.py tests/render/test_render_ValidationResultsTableContentBlockRenderer.py -q`

## PR Checklist

- [x] Description of PR changes above includes a link to an existing GitHub issue
- [x] PR title is prefixed with one of: `[BUGFIX]`, `[FEATURE]`, `[DOCS]`, `[MAINTENANCE]`, `[CONTRIB]`, `[MINORBUMP]`
- [x] Code is linted - ran `invoke lint --no-pty`
- [x] Appropriate tests and docs have been updated