### PR TITLE
[MAINTENANCE] Deprecate GX Cloud entry points (CloudDataContext + get_context cloud branch)

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
 import uuid
@@ -121,6 +122,15 @@ class CloudUserInfo:
     workspaces: list[Workspace]
 
 
+# Dedupe guard (Req 1.5): set by get_context() around its cloud-branch delegation so that
+# CloudDataContext.__init__ does not double-fire the deprecation warning for a single
+# user-initiated construction. ContextVar is thread- and async-safe; this is private state,
+# not a new constructor parameter (Req 6.1).
+_SUPPRESS_CONSTRUCTION_DEPRECATION: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_SUPPRESS_CONSTRUCTION_DEPRECATION", default=False
+)
+
+
 @public_api
 class CloudDataContext(SerializableDataContext):
     """Subclass of AbstractDataContext that contains functionality necessary to work in a GX Cloud-backed environment."""  # noqa: E501 # FIXME CoP
@@ -146,6 +156,14 @@ class CloudDataContext(SerializableDataContext):
                 config_variables.yml and the environment
             cloud_config (GXCloudConfig): GXCloudConfig corresponding to current CloudDataContext
         """  # noqa: E501 # FIXME CoP
+        if not _SUPPRESS_CONSTRUCTION_DEPRECATION.get():
+            warnings.warn(
+                "CloudDataContext is deprecated and will be removed in great_expectations v2.0. "
+                'Use get_context() with cloud parameters (mode="cloud" or cloud_* arguments) as '
+                "the equivalent entry point during the deprecation period.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )  # deprecated-v1.17.2
         self._check_if_latest_version()
         self._cloud_user_info: CloudUserInfo | None = None
 

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -22,7 +22,10 @@ from requests import HTTPError, Response
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations import __version__
-from great_expectations._docs_decorators import public_api
+from great_expectations._docs_decorators import (
+    deprecated_method_or_class,
+    public_api,
+)
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.config_provider import (
@@ -131,6 +134,12 @@ _SUPPRESS_CONSTRUCTION_DEPRECATION: contextvars.ContextVar[bool] = contextvars.C
 )
 
 
+@deprecated_method_or_class(
+    version="1.17.2",
+    message="Scheduled for removal in great_expectations v2.0. Use ``get_context()`` with "
+    'cloud parameters (``mode="cloud"`` or ``cloud_*`` arguments) as the equivalent entry '
+    "point during the deprecation period.",
+)
 @public_api
 class CloudDataContext(SerializableDataContext):
     """Subclass of AbstractDataContext that contains functionality necessary to work in a GX Cloud-backed environment."""  # noqa: E501 # FIXME CoP

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -138,9 +138,8 @@ _SUPPRESS_CONSTRUCTION_DEPRECATION: contextvars.ContextVar[bool] = contextvars.C
 
 @deprecated_method_or_class(
     version="1.17.2",
-    message="Scheduled for removal in great_expectations v2.0. Use ``get_context()`` with "
-    'cloud parameters (``mode="cloud"`` or ``cloud_*`` arguments) as the equivalent entry '
-    "point during the deprecation period.",
+    message="GX Cloud has been shut down, so this no longer functions and will be "
+    "removed in great_expectations 2.0.",
 )
 @public_api
 class CloudDataContext(SerializableDataContext):
@@ -169,9 +168,8 @@ class CloudDataContext(SerializableDataContext):
         """  # noqa: E501 # FIXME CoP
         if not _SUPPRESS_CONSTRUCTION_DEPRECATION.get():
             warnings.warn(
-                "CloudDataContext is deprecated and will be removed in great_expectations v2.0. "
-                'Use get_context() with cloud parameters (mode="cloud" or cloud_* arguments) as '
-                "the equivalent entry point during the deprecation period.",
+                "GX Cloud has been shut down, so this no longer functions and will be "
+                "removed in great_expectations 2.0.",
                 category=DeprecationWarning,
                 stacklevel=2,
             )  # deprecated-v1.17.2

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -125,10 +125,12 @@ class CloudUserInfo:
     workspaces: list[Workspace]
 
 
-# Dedupe guard (Req 1.5): set by get_context() around its cloud-branch delegation so that
+# Dedupe guard: set by get_context() around its cloud-branch delegation so that
 # CloudDataContext.__init__ does not double-fire the deprecation warning for a single
-# user-initiated construction. ContextVar is thread- and async-safe; this is private state,
-# not a new constructor parameter (Req 6.1).
+# user-initiated construction (exactly one warning per construction, whether the user
+# calls CloudDataContext(...) directly or reaches it via get_context()). ContextVar is
+# thread- and async-safe; this is private state, not a new constructor parameter, so the
+# public signature is unchanged.
 _SUPPRESS_CONSTRUCTION_DEPRECATION: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "_SUPPRESS_CONSTRUCTION_DEPRECATION", default=False
 )

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -438,7 +438,9 @@ def _get_context_resolves_to_cloud(  # noqa: PLR0913 # FIXME CoP
     """Return True iff a ``get_context`` call with these arguments would resolve to a CloudDataContext.
 
     Mirrors ``ProjectManager._build_context`` / ``_get_cloud_context`` so the
-    ``get_context`` deprecation warning cannot drift from the actual delegation (Req 2.5).
+    ``get_context`` deprecation warning cannot drift from the actual delegation: the
+    warning must fire if and only if the call really builds a CloudDataContext, otherwise
+    callers would see spurious warnings (or miss real ones) as the resolution logic evolves.
     """  # noqa: E501 # FIXME CoP
     if mode in ("file", "ephemeral"):
         return False

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
+from great_expectations._docs_decorators import deprecated_argument, public_api
 from great_expectations.exceptions import (
     GXCloudConfigurationError,
 )
@@ -554,6 +554,13 @@ def get_context(
 ) -> EphemeralDataContext | FileDataContext | CloudDataContext: ...
 
 
+@deprecated_argument(
+    argument_name="cloud_mode",
+    version="1.17.2",
+    message="The GX Cloud branch of ``get_context()`` (``mode=\"cloud\"`` and the "
+    "``cloud_*`` arguments) is scheduled for removal in great_expectations v2.0. "
+    "``get_context()`` itself is not deprecated.",
+)
 @public_api
 def get_context(  # noqa: PLR0913 # FIXME CoP
     project_config: DataContextConfig | Mapping | None = None,

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -557,7 +557,7 @@ def get_context(
 @deprecated_argument(
     argument_name="cloud_mode",
     version="1.17.2",
-    message="The GX Cloud branch of ``get_context()`` (``mode=\"cloud\"`` and the "
+    message='The GX Cloud branch of ``get_context()`` (``mode="cloud"`` and the '
     "``cloud_*`` arguments) is scheduled for removal in great_expectations v2.0. "
     "``get_context()`` itself is not deprecated.",
 )

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -427,7 +427,7 @@ class ProjectManager:
 project_manager = ProjectManager()
 
 
-def _get_context_resolves_to_cloud(
+def _get_context_resolves_to_cloud(  # noqa: PLR0913 # FIXME CoP
     mode: ContextModes | None,
     cloud_mode: bool | None,
     cloud_base_url: str | None,

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -426,6 +427,38 @@ class ProjectManager:
 project_manager = ProjectManager()
 
 
+def _get_context_resolves_to_cloud(
+    mode: ContextModes | None,
+    cloud_mode: bool | None,
+    cloud_base_url: str | None,
+    cloud_access_token: str | None,
+    cloud_organization_id: str | None,
+    cloud_workspace_id: str | None,
+) -> bool:
+    """Return True iff a ``get_context`` call with these arguments would resolve to a CloudDataContext.
+
+    Mirrors ``ProjectManager._build_context`` / ``_get_cloud_context`` so the
+    ``get_context`` deprecation warning cannot drift from the actual delegation (Req 2.5).
+    """  # noqa: E501 # FIXME CoP
+    if mode in ("file", "ephemeral"):
+        return False
+    if mode == "cloud":
+        return True
+    # mode is None: mirror ProjectManager._get_cloud_context
+    if cloud_mode is False:
+        return False
+    if cloud_mode is True:
+        return True
+    from great_expectations.data_context.data_context import CloudDataContext
+
+    return CloudDataContext.is_cloud_config_available(
+        cloud_base_url=cloud_base_url,
+        cloud_access_token=cloud_access_token,
+        cloud_organization_id=cloud_organization_id,
+        cloud_workspace_id=cloud_workspace_id,
+    )
+
+
 @overload
 def get_context(
     project_config: DataContextConfig | Mapping | None = ...,
@@ -607,6 +640,43 @@ def get_context(  # noqa: PLR0913 # FIXME CoP
     Raises:
         GXCloudConfigurationError: Cloud mode enabled, but missing configuration.
     """  # noqa: E501 # FIXME CoP
+    if _get_context_resolves_to_cloud(
+        mode=mode,
+        cloud_mode=cloud_mode,
+        cloud_base_url=cloud_base_url,
+        cloud_access_token=cloud_access_token,
+        cloud_organization_id=cloud_organization_id,
+        cloud_workspace_id=cloud_workspace_id,
+    ):
+        warnings.warn(
+            'The GX Cloud branch of get_context() (mode="cloud", the cloud_* parameters, '
+            "and the equivalent GX_CLOUD_* environment configuration) is deprecated and will "
+            "be removed in great_expectations v2.0. get_context() itself is not deprecated.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )  # deprecated-v1.17.2
+        from great_expectations.data_context.data_context.cloud_data_context import (
+            _SUPPRESS_CONSTRUCTION_DEPRECATION,
+        )
+
+        token = _SUPPRESS_CONSTRUCTION_DEPRECATION.set(True)
+        try:
+            return project_manager.get_project(
+                project_config=project_config,
+                context_root_dir=context_root_dir,
+                project_root_dir=project_root_dir,
+                runtime_environment=runtime_environment,
+                cloud_base_url=cloud_base_url,
+                cloud_access_token=cloud_access_token,
+                cloud_organization_id=cloud_organization_id,
+                cloud_workspace_id=cloud_workspace_id,
+                cloud_mode=cloud_mode,
+                user_agent_str=user_agent_str,
+                mode=mode,
+            )
+        finally:
+            _SUPPRESS_CONSTRUCTION_DEPRECATION.reset(token)
+
     return project_manager.get_project(
         project_config=project_config,
         context_root_dir=context_root_dir,

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -559,9 +559,8 @@ def get_context(
 @deprecated_argument(
     argument_name="cloud_mode",
     version="1.17.2",
-    message='The GX Cloud branch of ``get_context()`` (``mode="cloud"`` and the '
-    "``cloud_*`` arguments) is scheduled for removal in great_expectations v2.0. "
-    "``get_context()`` itself is not deprecated.",
+    message="GX Cloud has been shut down, so this no longer functions and will be "
+    "removed in great_expectations 2.0.",
 )
 @public_api
 def get_context(  # noqa: PLR0913 # FIXME CoP
@@ -658,9 +657,8 @@ def get_context(  # noqa: PLR0913 # FIXME CoP
         cloud_workspace_id=cloud_workspace_id,
     ):
         warnings.warn(
-            'The GX Cloud branch of get_context() (mode="cloud", the cloud_* parameters, '
-            "and the equivalent GX_CLOUD_* environment configuration) is deprecated and will "
-            "be removed in great_expectations v2.0. get_context() itself is not deprecated.",
+            "GX Cloud has been shut down, so this no longer functions and will be "
+            "removed in great_expectations 2.0.",
             category=DeprecationWarning,
             stacklevel=2,
         )  # deprecated-v1.17.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1844,14 +1844,25 @@ def empty_base_data_context_in_cloud_mode(
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir(exist_ok=True)
 
-    context = CloudDataContext(
-        project_config=empty_ge_cloud_data_context_config,
-        context_root_dir=project_path,
-        cloud_base_url=ge_cloud_config.base_url,
-        cloud_access_token=ge_cloud_config.access_token,
-        cloud_organization_id=ge_cloud_config.organization_id,
-        cloud_workspace_id=ge_cloud_config.workspace_id,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="The GX Cloud branch of get_context",
+            category=DeprecationWarning,
+        )
+        context = CloudDataContext(
+            project_config=empty_ge_cloud_data_context_config,
+            context_root_dir=project_path,
+            cloud_base_url=ge_cloud_config.base_url,
+            cloud_access_token=ge_cloud_config.access_token,
+            cloud_organization_id=ge_cloud_config.organization_id,
+            cloud_workspace_id=ge_cloud_config.workspace_id,
+        )
     set_context(context)
     return context
 
@@ -1886,7 +1897,18 @@ def empty_data_context_in_cloud_mode(
             autospec=True,
             side_effect=mocked_get_cloud_config,
         ),
+        warnings.catch_warnings(),
     ):
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="The GX Cloud branch of get_context",
+            category=DeprecationWarning,
+        )
         context = CloudDataContext(context_root_dir=project_path)
 
     context._datasources = {}  # type: ignore[assignment] # Basic in-memory mock for DatasourceDict to avoid HTTP calls
@@ -1904,14 +1926,25 @@ def empty_cloud_data_context(
     project_path.mkdir()
     project_path_name: str = str(project_path)
 
-    context = CloudDataContext(
-        project_config=empty_ge_cloud_data_context_config,
-        context_root_dir=project_path_name,
-        cloud_base_url=ge_cloud_config.base_url,
-        cloud_access_token=ge_cloud_config.access_token,
-        cloud_organization_id=ge_cloud_config.organization_id,
-        cloud_workspace_id=ge_cloud_config.workspace_id,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="The GX Cloud branch of get_context",
+            category=DeprecationWarning,
+        )
+        context = CloudDataContext(
+            project_config=empty_ge_cloud_data_context_config,
+            context_root_dir=project_path_name,
+            cloud_base_url=ge_cloud_config.base_url,
+            cloud_access_token=ge_cloud_config.access_token,
+            cloud_organization_id=ge_cloud_config.organization_id,
+            cloud_workspace_id=ge_cloud_config.workspace_id,
+        )
     set_context(context)
     return context
 
@@ -1939,13 +1972,24 @@ def cloud_api_fake(cloud_details: CloudDetails):
 
 @pytest.fixture
 def empty_cloud_context_fluent(cloud_api_fake, cloud_details: CloudDetails) -> CloudDataContext:
-    context = gx.get_context(
-        cloud_access_token=cloud_details.access_token,
-        cloud_organization_id=cloud_details.org_id,
-        cloud_workspace_id=cloud_details.workspace_id,
-        cloud_base_url=cloud_details.base_url,
-        cloud_mode=True,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="The GX Cloud branch of get_context",
+            category=DeprecationWarning,
+        )
+        context = gx.get_context(
+            cloud_access_token=cloud_details.access_token,
+            cloud_organization_id=cloud_details.org_id,
+            cloud_workspace_id=cloud_details.workspace_id,
+            cloud_base_url=cloud_details.base_url,
+            cloud_mode=True,
+        )
     set_context(context)
     return context
 
@@ -1969,14 +2013,25 @@ def empty_base_data_context_in_cloud_mode_custom_base_url(
     custom_ge_cloud_config = copy.deepcopy(ge_cloud_config)
     custom_ge_cloud_config.base_url = custom_base_url
 
-    context = CloudDataContext(
-        project_config=empty_ge_cloud_data_context_config,
-        context_root_dir=project_path,
-        cloud_base_url=custom_ge_cloud_config.base_url,
-        cloud_access_token=custom_ge_cloud_config.access_token,
-        cloud_organization_id=custom_ge_cloud_config.organization_id,
-        cloud_workspace_id=custom_ge_cloud_config.workspace_id,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="The GX Cloud branch of get_context",
+            category=DeprecationWarning,
+        )
+        context = CloudDataContext(
+            project_config=empty_ge_cloud_data_context_config,
+            context_root_dir=project_path,
+            cloud_base_url=custom_ge_cloud_config.base_url,
+            cloud_access_token=custom_ge_cloud_config.access_token,
+            cloud_organization_id=custom_ge_cloud_config.organization_id,
+            cloud_workspace_id=custom_ge_cloud_config.workspace_id,
+        )
     assert context.list_datasources() == []
     assert context.ge_cloud_config.base_url != ge_cloud_config.base_url
     assert context.ge_cloud_config.base_url == custom_base_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1847,12 +1847,7 @@ def empty_base_data_context_in_cloud_mode(
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
-            category=DeprecationWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="The GX Cloud branch of get_context",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         context = CloudDataContext(
@@ -1901,12 +1896,7 @@ def empty_data_context_in_cloud_mode(
     ):
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
-            category=DeprecationWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="The GX Cloud branch of get_context",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         context = CloudDataContext(context_root_dir=project_path)
@@ -1929,12 +1919,7 @@ def empty_cloud_data_context(
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
-            category=DeprecationWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="The GX Cloud branch of get_context",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         context = CloudDataContext(
@@ -1975,12 +1960,7 @@ def empty_cloud_context_fluent(cloud_api_fake, cloud_details: CloudDetails) -> C
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
-            category=DeprecationWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="The GX Cloud branch of get_context",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         context = gx.get_context(
@@ -2016,12 +1996,7 @@ def empty_base_data_context_in_cloud_mode_custom_base_url(
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
-            category=DeprecationWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="The GX Cloud branch of get_context",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         context = CloudDataContext(

--- a/tests/data_context/cloud_data_context/conftest.py
+++ b/tests/data_context/cloud_data_context/conftest.py
@@ -1,0 +1,19 @@
+import warnings
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _suppress_cloud_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="The GX Cloud branch of get_context",
+            category=DeprecationWarning,
+        )
+        yield

--- a/tests/data_context/cloud_data_context/conftest.py
+++ b/tests/data_context/cloud_data_context/conftest.py
@@ -8,12 +8,7 @@ def _suppress_cloud_deprecation_warnings():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
-            category=DeprecationWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="The GX Cloud branch of get_context",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         yield

--- a/tests/data_context/cloud_data_context/test_cloud_deprecation.py
+++ b/tests/data_context/cloud_data_context/test_cloud_deprecation.py
@@ -1,8 +1,9 @@
 """Tests for the direct-construction DeprecationWarning on ``CloudDataContext``.
 
 Verifies that constructing a ``CloudDataContext`` directly emits exactly one
-``DeprecationWarning`` naming the class and the v2.0 removal target, that the
-warning surfaces the caller's frame, and that it is purely additive -- the
+``DeprecationWarning`` stating that GX Cloud has been shut down and naming the
+2.0 removal target, that the warning surfaces the caller's frame, and that it is
+purely additive -- the
 constructor's signature, return shape, observable behavior, and cloud-specific
 public-API surface are all unchanged when the warning is suppressed.
 
@@ -32,8 +33,8 @@ if TYPE_CHECKING:
 # module level markers
 pytestmark = pytest.mark.cloud
 
-# The substring that uniquely identifies the CloudDataContext construction warning.
-_CLOUD_DEPRECATION_SUBSTR = "CloudDataContext is deprecated"
+# The substring that uniquely identifies the cloud-deprecation warning.
+_CLOUD_DEPRECATION_SUBSTR = "GX Cloud has been shut down"
 
 
 def _construct_cloud_data_context(
@@ -70,8 +71,8 @@ def test_direct_construction_emits_exactly_one_deprecation_warning(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
 ):
-    """Direct construction emits exactly one CloudDataContext DeprecationWarning
-    whose message names ``CloudDataContext`` and states v2.0.
+    """Direct construction emits exactly one DeprecationWarning whose message
+    states that GX Cloud has been shut down and names 2.0 as the removal target.
 
     ``pytest.warns(DeprecationWarning)`` overrides the autouse suppression so the
     warning is observable. The count assertion filters to the cloud-deprecation
@@ -95,9 +96,9 @@ def test_direct_construction_emits_exactly_one_deprecation_warning(
     )
 
     message = str(cloud_warnings[0].message)
-    # Names CloudDataContext explicitly and states the v2.0 removal target.
-    assert "CloudDataContext" in message
-    assert "v2.0" in message
+    # States that GX Cloud no longer functions and names the 2.0 removal target.
+    assert _CLOUD_DEPRECATION_SUBSTR in message
+    assert "2.0" in message
     assert cloud_warnings[0].category is DeprecationWarning
 
 

--- a/tests/data_context/cloud_data_context/test_cloud_deprecation.py
+++ b/tests/data_context/cloud_data_context/test_cloud_deprecation.py
@@ -1,7 +1,10 @@
 """Tests for the direct-construction DeprecationWarning on ``CloudDataContext``.
 
-Covers Req 1.1, 1.2, 1.3, 1.4, 6.1, 6.3, 6.6 (deprecate-gx-cloud spec) and the
-design's Testing Strategy -> Unit/behavior items 1, 5 (direct path), and 7.
+Verifies that constructing a ``CloudDataContext`` directly emits exactly one
+``DeprecationWarning`` naming the class and the v2.0 removal target, that the
+warning surfaces the caller's frame, and that it is purely additive -- the
+constructor's signature, return shape, observable behavior, and cloud-specific
+public-API surface are all unchanged when the warning is suppressed.
 
 The autouse ``_suppress_cloud_deprecation_warnings`` fixture in this directory's
 ``conftest.py`` ignores the cloud-deprecation warnings by message prefix.
@@ -29,8 +32,7 @@ if TYPE_CHECKING:
 # module level markers
 pytestmark = pytest.mark.cloud
 
-# The substring that uniquely identifies the CloudDataContext construction warning
-# introduced by this spec (Req 1.2 wording).
+# The substring that uniquely identifies the CloudDataContext construction warning.
 _CLOUD_DEPRECATION_SUBSTR = "CloudDataContext is deprecated"
 
 
@@ -68,8 +70,8 @@ def test_direct_construction_emits_exactly_one_deprecation_warning(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
 ):
-    """Req 1.1, 1.2: direct construction emits exactly one CloudDataContext
-    DeprecationWarning whose message names ``CloudDataContext`` and states v2.0.
+    """Direct construction emits exactly one CloudDataContext DeprecationWarning
+    whose message names ``CloudDataContext`` and states v2.0.
 
     ``pytest.warns(DeprecationWarning)`` overrides the autouse suppression so the
     warning is observable. The count assertion filters to the cloud-deprecation
@@ -85,15 +87,15 @@ def test_direct_construction_emits_exactly_one_deprecation_warning(
     assert isinstance(context, CloudDataContext)
 
     cloud_warnings = [w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)]
-    # Req 1.1: exactly one per instance (the dedupe guard must not let it double-fire,
-    # and the warning must actually be emitted).
+    # Exactly one per instance: the dedupe guard must not let it double-fire, and the
+    # warning must actually be emitted.
     assert len(cloud_warnings) == 1, (
         "Expected exactly one CloudDataContext deprecation warning, got "
         f"{[str(w.message) for w in cloud_warnings]}"
     )
 
     message = str(cloud_warnings[0].message)
-    # Req 1.2: names CloudDataContext explicitly and states v2.0 removal.
+    # Names CloudDataContext explicitly and states the v2.0 removal target.
     assert "CloudDataContext" in message
     assert "v2.0" in message
     assert cloud_warnings[0].category is DeprecationWarning
@@ -105,7 +107,7 @@ def test_warning_surfaces_caller_frame_not_internal_frame(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
 ):
-    """Req 1.3: the warning is emitted with a stacklevel that surfaces the caller's
+    """The warning is emitted with a stacklevel that surfaces the caller's
     frame (this test module), not an internal great_expectations frame.
 
     With ``stacklevel=2`` the recorded warning's ``filename`` must be THIS test
@@ -139,8 +141,8 @@ def test_suppressed_warning_yields_identical_observable_behavior(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
 ):
-    """Req 1.4, 6.1, 6.6: the warning is additive only. With the warning suppressed,
-    construction yields the same observable result (same type, same key attributes,
+    """The warning is additive only. With the warning suppressed, construction
+    yields the same observable result (same type, same key attributes,
     ``mode == "cloud"``) as without the warning -- the warning changes nothing but
     emission.
     """
@@ -171,10 +173,9 @@ def test_cloud_public_api_surface_intact(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
 ):
-    """Req 6.3: the cloud-specific ``@public_api`` surface is unchanged by the
-    deprecation. ``cloud_user_info``, ``ge_cloud_config``, ``mode`` and
-    ``prepare_checkpoint_run`` must all still be present, and ``mode`` returns
-    ``"cloud"``.
+    """The cloud-specific ``@public_api`` surface is unchanged by the deprecation.
+    ``cloud_user_info``, ``ge_cloud_config``, ``mode`` and ``prepare_checkpoint_run``
+    must all still be present, and ``mode`` returns ``"cloud"``.
     """
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/tests/data_context/cloud_data_context/test_cloud_deprecation.py
+++ b/tests/data_context/cloud_data_context/test_cloud_deprecation.py
@@ -1,0 +1,202 @@
+"""Tests for the direct-construction DeprecationWarning on ``CloudDataContext``.
+
+Covers Req 1.1, 1.2, 1.3, 1.4, 6.1, 6.3, 6.6 (deprecate-gx-cloud spec) and the
+design's Testing Strategy -> Unit/behavior items 1, 5 (direct path), and 7.
+
+The autouse ``_suppress_cloud_deprecation_warnings`` fixture in this directory's
+``conftest.py`` ignores the cloud-deprecation warnings by message prefix.
+``pytest.warns(...)`` overrides that suppression for its assertion block, which
+is exactly what these tests rely on to observe the warning.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+import pytest
+
+from great_expectations.data_context import CloudDataContext
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from great_expectations.data_context.types.base import (
+        DataContextConfig,
+        GXCloudConfig,
+    )
+
+# module level markers
+pytestmark = pytest.mark.cloud
+
+# The substring that uniquely identifies the CloudDataContext construction warning
+# introduced by this spec (Req 1.2 wording).
+_CLOUD_DEPRECATION_SUBSTR = "CloudDataContext is deprecated"
+
+
+def _construct_cloud_data_context(
+    *,
+    tmp_path: pathlib.Path,
+    project_config: DataContextConfig,
+    cloud_config: GXCloudConfig,
+) -> CloudDataContext:
+    """Directly construct a ``CloudDataContext`` using the standard test mocks.
+
+    ``cloud_api_fake`` (mocked HTTP backend) plus an explicit ``project_config`` and
+    explicit ``cloud_*`` arguments make direct construction succeed without real
+    network access. The caller is responsible for warning capture/suppression.
+
+    Note: ``CloudDataContext.__init__`` does NOT accept ``cloud_mode`` (that is a
+    ``get_context()`` parameter); we pass ``cloud_base_url`` / ``cloud_access_token`` /
+    ``cloud_organization_id`` / ``cloud_workspace_id`` instead.
+    """
+    project_path = tmp_path / "empty_data_context"
+    project_path.mkdir()
+    return CloudDataContext(
+        project_config=project_config,
+        context_root_dir=str(project_path),
+        cloud_base_url=cloud_config.base_url,
+        cloud_access_token=cloud_config.access_token,
+        cloud_organization_id=cloud_config.organization_id,
+        cloud_workspace_id=cloud_config.workspace_id,
+    )
+
+
+def test_direct_construction_emits_exactly_one_deprecation_warning(
+    cloud_api_fake,
+    tmp_path: pathlib.Path,
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GXCloudConfig,
+):
+    """Req 1.1, 1.2: direct construction emits exactly one CloudDataContext
+    DeprecationWarning whose message names ``CloudDataContext`` and states v2.0.
+
+    ``pytest.warns(DeprecationWarning)`` overrides the autouse suppression so the
+    warning is observable. The count assertion filters to the cloud-deprecation
+    warning specifically so unrelated DeprecationWarnings cannot mask a regression.
+    """
+    with pytest.warns(DeprecationWarning) as record:
+        context = _construct_cloud_data_context(
+            tmp_path=tmp_path,
+            project_config=empty_ge_cloud_data_context_config,
+            cloud_config=ge_cloud_config,
+        )
+
+    assert isinstance(context, CloudDataContext)
+
+    cloud_warnings = [
+        w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)
+    ]
+    # Req 1.1: exactly one per instance (the dedupe guard must not let it double-fire,
+    # and the warning must actually be emitted).
+    assert len(cloud_warnings) == 1, (
+        "Expected exactly one CloudDataContext deprecation warning, got "
+        f"{[str(w.message) for w in cloud_warnings]}"
+    )
+
+    message = str(cloud_warnings[0].message)
+    # Req 1.2: names CloudDataContext explicitly and states v2.0 removal.
+    assert "CloudDataContext" in message
+    assert "v2.0" in message
+    assert cloud_warnings[0].category is DeprecationWarning
+
+
+def test_warning_surfaces_caller_frame_not_internal_frame(
+    cloud_api_fake,
+    tmp_path: pathlib.Path,
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GXCloudConfig,
+):
+    """Req 1.3: the warning is emitted with a stacklevel that surfaces the caller's
+    frame (this test module), not an internal great_expectations frame.
+
+    With ``stacklevel=2`` the recorded warning's ``filename`` must be THIS test
+    module and must NOT be ``cloud_data_context.py``. This fails if the stacklevel
+    is dropped/wrong (warning would then point at the gx-internal frame).
+    """
+    with pytest.warns(DeprecationWarning) as record:
+        _construct_cloud_data_context(
+            tmp_path=tmp_path,
+            project_config=empty_ge_cloud_data_context_config,
+            cloud_config=ge_cloud_config,
+        )
+
+    cloud_warnings = [
+        w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)
+    ]
+    assert len(cloud_warnings) == 1
+    filename = cloud_warnings[0].filename
+
+    # Caller frame == this test module (the CloudDataContext(...) invocation site).
+    assert filename.endswith("test_cloud_deprecation.py"), (
+        f"Warning should surface the caller frame, got filename={filename!r}"
+    )
+    # Must NOT point at the internal definition site.
+    assert "cloud_data_context.py" not in filename, (
+        f"Warning surfaced an internal great_expectations frame: {filename!r}"
+    )
+
+
+def test_suppressed_warning_yields_identical_observable_behavior(
+    cloud_api_fake,
+    tmp_path: pathlib.Path,
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GXCloudConfig,
+):
+    """Req 1.4, 6.1, 6.6: the warning is additive only. With the warning suppressed,
+    construction yields the same observable result (same type, same key attributes,
+    ``mode == "cloud"``) as without the warning -- the warning changes nothing but
+    emission.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=_CLOUD_DEPRECATION_SUBSTR,
+            category=DeprecationWarning,
+        )
+        context = _construct_cloud_data_context(
+            tmp_path=tmp_path,
+            project_config=empty_ge_cloud_data_context_config,
+            cloud_config=ge_cloud_config,
+        )
+
+    # Observable behavior unchanged by the (suppressed) warning.
+    assert isinstance(context, CloudDataContext)
+    assert context.mode == "cloud"
+    # Cloud config is wired through exactly as the inputs specified (return shape intact).
+    assert context.ge_cloud_config.base_url == ge_cloud_config.base_url
+    assert context.ge_cloud_config.organization_id == ge_cloud_config.organization_id
+    assert context.ge_cloud_config.access_token == ge_cloud_config.access_token
+
+
+def test_cloud_public_api_surface_intact(
+    cloud_api_fake,
+    tmp_path: pathlib.Path,
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GXCloudConfig,
+):
+    """Req 6.3: the cloud-specific ``@public_api`` surface is unchanged by the
+    deprecation. ``cloud_user_info``, ``ge_cloud_config``, ``mode`` and
+    ``prepare_checkpoint_run`` must all still be present, and ``mode`` returns
+    ``"cloud"``.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=_CLOUD_DEPRECATION_SUBSTR,
+            category=DeprecationWarning,
+        )
+        context = _construct_cloud_data_context(
+            tmp_path=tmp_path,
+            project_config=empty_ge_cloud_data_context_config,
+            cloud_config=ge_cloud_config,
+        )
+
+    for attr in ("cloud_user_info", "ge_cloud_config", "mode", "prepare_checkpoint_run"):
+        assert hasattr(context, attr), f"Cloud public-API surface lost attribute: {attr}"
+
+    # cloud_user_info / prepare_checkpoint_run remain callable methods.
+    assert callable(context.cloud_user_info)
+    assert callable(context.prepare_checkpoint_run)
+    # mode is the cloud literal (cheap to check, no network).
+    assert context.mode == "cloud"

--- a/tests/data_context/cloud_data_context/test_cloud_deprecation.py
+++ b/tests/data_context/cloud_data_context/test_cloud_deprecation.py
@@ -84,9 +84,7 @@ def test_direct_construction_emits_exactly_one_deprecation_warning(
 
     assert isinstance(context, CloudDataContext)
 
-    cloud_warnings = [
-        w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)
-    ]
+    cloud_warnings = [w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)]
     # Req 1.1: exactly one per instance (the dedupe guard must not let it double-fire,
     # and the warning must actually be emitted).
     assert len(cloud_warnings) == 1, (
@@ -121,9 +119,7 @@ def test_warning_surfaces_caller_frame_not_internal_frame(
             cloud_config=ge_cloud_config,
         )
 
-    cloud_warnings = [
-        w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)
-    ]
+    cloud_warnings = [w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)]
     assert len(cloud_warnings) == 1
     filename = cloud_warnings[0].filename
 

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -15,12 +15,8 @@ from great_expectations.core.validation_definition import ValidationDefinition
 from great_expectations.data_context.data_context.cloud_data_context import CloudDataContext
 
 pytestmark = [
-    pytest.mark.filterwarnings(
-        "ignore:CloudDataContext is deprecated:DeprecationWarning"
-    ),
-    pytest.mark.filterwarnings(
-        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
-    ),
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
 ]
 
 CLOUD_BASE_URL = "https://api.greatexpectations.io/fake"

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import warnings
 from typing import Any, Dict, List, Tuple
 from urllib.parse import parse_qs, urlparse
 
@@ -12,6 +13,15 @@ from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.validation_definition import ValidationDefinition
 from great_expectations.data_context.data_context.cloud_data_context import CloudDataContext
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:CloudDataContext is deprecated:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
+    ),
+]
 
 CLOUD_BASE_URL = "https://api.greatexpectations.io/fake"
 ACCESS_TOKEN = "my-secret-access-token"
@@ -177,8 +187,16 @@ def test_warns_when_workspace_id_env_var_unset(unset_gx_env_variables: None):
         status=200,
     )
 
-    # Capture warnings and instantiate CloudDataContext
+    # Capture warnings and instantiate CloudDataContext. The cloud-deprecation
+    # DeprecationWarning is suppressed locally so this assertion stays focused
+    # on the workspace-id UserWarning under test (the deprecation warning is
+    # exercised by the dedicated behavior tests).
     with pytest.warns(UserWarning) as warning_info:
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
         CloudDataContext(
             cloud_base_url=CLOUD_BASE_URL,
             cloud_access_token=ACCESS_TOKEN,

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -15,8 +15,7 @@ from great_expectations.core.validation_definition import ValidationDefinition
 from great_expectations.data_context.data_context.cloud_data_context import CloudDataContext
 
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 CLOUD_BASE_URL = "https://api.greatexpectations.io/fake"
@@ -190,7 +189,7 @@ def test_warns_when_workspace_id_env_var_unset(unset_gx_env_variables: None):
     with pytest.warns(UserWarning) as warning_info:
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         CloudDataContext(

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -21,8 +21,7 @@ if TYPE_CHECKING:
     )
 
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -20,6 +20,15 @@ if TYPE_CHECKING:
         GXCloudConfig,
     )
 
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:CloudDataContext is deprecated:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
+    ),
+]
+
 
 @pytest.fixture
 def pandas_enabled_datasource_config() -> dict:

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -21,12 +21,8 @@ if TYPE_CHECKING:
     )
 
 pytestmark = [
-    pytest.mark.filterwarnings(
-        "ignore:CloudDataContext is deprecated:DeprecationWarning"
-    ),
-    pytest.mark.filterwarnings(
-        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
-    ),
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
 ]
 
 

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -13,12 +13,8 @@ from great_expectations.exceptions import GXCloudError
 from great_expectations.exceptions.exceptions import GXCloudConfigurationError
 
 pytestmark = [
-    pytest.mark.filterwarnings(
-        "ignore:CloudDataContext is deprecated:DeprecationWarning"
-    ),
-    pytest.mark.filterwarnings(
-        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
-    ),
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
 ]
 
 

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -13,8 +13,7 @@ from great_expectations.exceptions import GXCloudError
 from great_expectations.exceptions.exceptions import GXCloudConfigurationError
 
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -12,6 +12,15 @@ from great_expectations.data_context.data_context.cloud_data_context import (
 from great_expectations.exceptions import GXCloudError
 from great_expectations.exceptions.exceptions import GXCloudConfigurationError
 
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:CloudDataContext is deprecated:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
+    ),
+]
+
 
 @pytest.mark.cloud
 def test_data_context_ge_cloud_mode_with_incomplete_cloud_config_should_throw_error():

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -43,6 +43,15 @@ if TYPE_CHECKING:
         ConfigurationIdentifier,
     )
 
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:CloudDataContext is deprecated:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
+    ),
+]
+
 yaml = YAMLHandler()
 
 

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -44,8 +44,7 @@ if TYPE_CHECKING:
     )
 
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 yaml = YAMLHandler()

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -44,12 +44,8 @@ if TYPE_CHECKING:
     )
 
 pytestmark = [
-    pytest.mark.filterwarnings(
-        "ignore:CloudDataContext is deprecated:DeprecationWarning"
-    ),
-    pytest.mark.filterwarnings(
-        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
-    ),
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
 ]
 
 yaml = YAMLHandler()

--- a/tests/data_context/test_get_context_cloud_deprecation.py
+++ b/tests/data_context/test_get_context_cloud_deprecation.py
@@ -1,9 +1,12 @@
 """Tests for the cloud-branch DeprecationWarning emitted by ``get_context()``.
 
-Covers Req 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 1.5, 6.2 (deprecate-gx-cloud spec) and the
-design's Testing Strategy -> Unit/behavior items 2 (factory cloud-branch warning),
-3 (env-var-only path), 4 (no spurious warning), 5 (exactly-one-per-construction on
-the factory path) and 6 (guard reset on error).
+Verifies that ``get_context()`` warns when (and only when) the call resolves to a
+``CloudDataContext`` -- across the ``mode="cloud"``, ``cloud_mode=True``, ``cloud_*``
+kwargs, and env-var-only trigger forms -- that it does NOT warn on non-cloud calls,
+that the warning surfaces the caller's frame, that exactly one cloud-deprecation
+warning fires per construction (the dedupe guard prevents the ``__init__`` warning
+from also firing on the factory path), and that the guard is reset even when cloud
+delegation raises.
 
 This module lives OUTSIDE the ``tests/data_context/cloud_data_context/`` directory,
 so the autouse ``_suppress_cloud_deprecation_warnings`` conftest fixture does NOT
@@ -35,7 +38,7 @@ if TYPE_CHECKING:
         GXCloudConfig,
     )
 
-# Substrings that uniquely identify the two cloud-deprecation warnings this spec adds.
+# Substrings that uniquely identify the two cloud-deprecation warnings.
 _FACTORY_DEPRECATION_SUBSTR = "The GX Cloud branch of get_context"
 _INIT_DEPRECATION_SUBSTR = "CloudDataContext is deprecated"
 
@@ -68,10 +71,10 @@ def _init_warnings(record) -> list:
 
 
 # ---------------------------------------------------------------------------
-# Item 2: factory cloud-branch warning on the three trigger forms
-# (Req 2.1, 2.3, 2.4). Each form emits the warning BEFORE the cloud context is
-# built; with no real cloud config the call raises AFTER the warning, so we
-# capture the warning and assert it fired even though construction failed.
+# Factory cloud-branch warning on the three trigger forms. Each form emits the
+# warning BEFORE the cloud context is built; with no real cloud config the call
+# raises AFTER the warning, so we capture the warning and assert it fired even
+# though construction failed.
 # ---------------------------------------------------------------------------
 
 
@@ -88,9 +91,9 @@ def test_cloud_trigger_forms_emit_branch_deprecation_warning(
     _no_cloud_env: None,
     call_kwargs: dict,
 ):
-    """Req 2.1/2.3: each of the three cloud trigger forms emits a
-    ``DeprecationWarning`` identifying the GX Cloud *branch* of ``get_context()``
-    (not ``get_context`` itself) and naming v2.0 as the removal target.
+    """Each of the three cloud trigger forms emits a ``DeprecationWarning``
+    identifying the GX Cloud *branch* of ``get_context()`` (not ``get_context``
+    itself) and naming v2.0 as the removal target.
 
     The warning fires BEFORE delegation, so even though the call ultimately
     raises (no real cloud backend), the warning is recorded. This test fails if
@@ -108,7 +111,7 @@ def test_cloud_trigger_forms_emit_branch_deprecation_warning(
     )
     message = str(cloud_warnings[0].message)
     assert cloud_warnings[0].category is DeprecationWarning
-    # Req 2.3: identifies the branch, names v2.0, and explicitly disclaims that
+    # Identifies the branch, names v2.0, and explicitly disclaims that
     # get_context() itself is deprecated.
     assert _FACTORY_DEPRECATION_SUBSTR in message
     assert "v2.0" in message
@@ -119,7 +122,7 @@ def test_cloud_trigger_forms_emit_branch_deprecation_warning(
 def test_branch_warning_surfaces_caller_frame_not_internal_frame(
     _no_cloud_env: None,
 ):
-    """Req 2.4 (stacklevel=2): the recorded warning's ``filename`` is THIS test
+    """With ``stacklevel=2`` the recorded warning's ``filename`` is THIS test
     module (the caller's ``get_context(...)`` site), not ``context_factory.py``.
 
     Fails if the stacklevel is dropped/wrong -- the warning would then point at
@@ -142,9 +145,9 @@ def test_branch_warning_surfaces_caller_frame_not_internal_frame(
 
 
 # ---------------------------------------------------------------------------
-# Item 3: env-var-only path still warns (Req 2.5). Proves the gate reuses the
-# same resolution predicate (is_cloud_config_available) as delegation -- a
-# kwarg-only gate would miss this path.
+# Env-var-only path still warns. Proves the gate reuses the same resolution
+# predicate (is_cloud_config_available) as delegation -- a kwarg-only gate would
+# miss this path.
 # ---------------------------------------------------------------------------
 
 
@@ -152,8 +155,8 @@ def test_branch_warning_surfaces_caller_frame_not_internal_frame(
 def test_env_var_only_path_emits_branch_deprecation_warning(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Req 2.5: with ``GX_CLOUD_*`` env vars set and NO cloud kwargs,
-    ``get_context()`` still resolves to cloud and emits the branch warning.
+    """With ``GX_CLOUD_*`` env vars set and NO cloud kwargs, ``get_context()``
+    still resolves to cloud and emits the branch warning.
 
     This fails if the gate were re-derived from kwargs alone instead of reusing
     the factory's ``is_cloud_config_available`` predicate.
@@ -179,7 +182,7 @@ def test_env_var_only_path_emits_branch_deprecation_warning(
 
 
 # ---------------------------------------------------------------------------
-# Item 4: no spurious warning (Req 2.2).
+# No spurious warning: non-cloud calls must stay silent.
 # ---------------------------------------------------------------------------
 
 
@@ -187,9 +190,9 @@ def test_env_var_only_path_emits_branch_deprecation_warning(
 def test_ephemeral_mode_emits_no_cloud_warning_even_with_env_set(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Req 2.2: ``mode="ephemeral"`` resolves non-cloud even WITH ``GX_CLOUD_*``
-    env vars set, so NO cloud deprecation warning fires (mode short-circuits
-    before the env-based predicate). Returns an ``EphemeralDataContext``.
+    """``mode="ephemeral"`` resolves non-cloud even WITH ``GX_CLOUD_*`` env vars
+    set, so NO cloud deprecation warning fires (mode short-circuits before the
+    env-based predicate). Returns an ``EphemeralDataContext``.
 
     Fails if the gate fired on the env config regardless of the explicit
     non-cloud mode.
@@ -219,8 +222,8 @@ def test_plain_get_context_with_no_cloud_config_emits_no_cloud_warning(
     _no_cloud_env: None,
     tmp_path: pathlib.Path,
 ):
-    """Req 2.2: a plain ``get_context()`` with no cloud kwargs and no cloud env
-    config emits no cloud deprecation warning and returns a non-cloud context.
+    """A plain ``get_context()`` with no cloud kwargs and no cloud env config
+    emits no cloud deprecation warning and returns a non-cloud context.
     """
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
@@ -238,10 +241,9 @@ def test_plain_get_context_with_no_cloud_config_emits_no_cloud_warning(
 
 
 # ---------------------------------------------------------------------------
-# Item 5: exactly-one-per-construction on the FACTORY cloud path (Req 1.5).
-# Uses the mocked cloud backend so construction SUCCEEDS, then asserts exactly
-# one branch warning and ZERO __init__ warnings (the guard suppressed the
-# latter).
+# Exactly-one-per-construction on the FACTORY cloud path. Uses the mocked cloud
+# backend so construction SUCCEEDS, then asserts exactly one branch warning and
+# ZERO __init__ warnings (the guard suppressed the latter).
 # ---------------------------------------------------------------------------
 
 
@@ -251,8 +253,8 @@ def test_factory_cloud_path_emits_exactly_one_cloud_warning(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
 ):
-    """Req 1.5: a single factory-path cloud construction emits EXACTLY ONE
-    cloud-deprecation warning -- the ``get_context()`` branch warning -- and the
+    """A single factory-path cloud construction emits EXACTLY ONE cloud-deprecation
+    warning -- the ``get_context()`` branch warning -- and the
     ``CloudDataContext.__init__`` warning does NOT also fire (the dedupe guard
     suppressed it).
 
@@ -287,9 +289,9 @@ def test_factory_cloud_path_emits_exactly_one_cloud_warning(
 
 
 # ---------------------------------------------------------------------------
-# Item 6: guard reset on error (Req 1.5 / Error Handling). After a cloud-branch
-# get_context() that RAISES inside delegation, the try/finally must have reset
-# the guard so a subsequent DIRECT CloudDataContext(...) still warns.
+# Guard reset on error. After a cloud-branch get_context() that RAISES inside
+# delegation, the try/finally must have reset the guard so a subsequent DIRECT
+# CloudDataContext(...) still warns.
 # ---------------------------------------------------------------------------
 
 
@@ -301,10 +303,10 @@ def test_guard_is_reset_after_factory_cloud_path_raises(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
 ):
-    """Req 1.5 / Error Handling: a ``get_context(mode="cloud")`` that raises
-    inside the cloud branch must reset the dedupe guard (set in a try/finally),
-    so a subsequent DIRECT ``CloudDataContext(...)`` STILL emits its own
-    ``CloudDataContext is deprecated`` warning.
+    """A ``get_context(mode="cloud")`` that raises inside the cloud branch must
+    reset the dedupe guard (set in a try/finally), so a subsequent DIRECT
+    ``CloudDataContext(...)`` STILL emits its own ``CloudDataContext is deprecated``
+    warning.
 
     Fails if the guard reset were dropped from the ``finally`` -- the leaked
     ``True`` guard would silently suppress the direct-construction warning.

--- a/tests/data_context/test_get_context_cloud_deprecation.py
+++ b/tests/data_context/test_get_context_cloud_deprecation.py
@@ -38,9 +38,10 @@ if TYPE_CHECKING:
         GXCloudConfig,
     )
 
-# Substrings that uniquely identify the two cloud-deprecation warnings.
-_FACTORY_DEPRECATION_SUBSTR = "The GX Cloud branch of get_context"
-_INIT_DEPRECATION_SUBSTR = "CloudDataContext is deprecated"
+# The substring that uniquely identifies the cloud-deprecation warning. Both the
+# get_context() cloud branch and CloudDataContext.__init__ emit the same message, so
+# a single substring matches whichever site fired.
+_CLOUD_DEPRECATION_SUBSTR = "GX Cloud has been shut down"
 
 # Realistic dummy cloud kwargs (no real backend) used to trigger the kwargs branch.
 _CLOUD_KWARGS = {
@@ -63,11 +64,7 @@ def _no_cloud_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _cloud_warnings(record) -> list:
-    return [w for w in record if _FACTORY_DEPRECATION_SUBSTR in str(w.message)]
-
-
-def _init_warnings(record) -> list:
-    return [w for w in record if _INIT_DEPRECATION_SUBSTR in str(w.message)]
+    return [w for w in record if _CLOUD_DEPRECATION_SUBSTR in str(w.message)]
 
 
 # ---------------------------------------------------------------------------
@@ -92,12 +89,11 @@ def test_cloud_trigger_forms_emit_branch_deprecation_warning(
     call_kwargs: dict,
 ):
     """Each of the three cloud trigger forms emits a ``DeprecationWarning``
-    identifying the GX Cloud *branch* of ``get_context()`` (not ``get_context``
-    itself) and naming v2.0 as the removal target.
+    stating that GX Cloud has been shut down and naming 2.0 as the removal target.
 
     The warning fires BEFORE delegation, so even though the call ultimately
     raises (no real cloud backend), the warning is recorded. This test fails if
-    the gate is removed (no warning) or the message stops naming the branch/v2.0.
+    the gate is removed (no warning) or the message stops naming the 2.0 target.
     """
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
@@ -111,11 +107,9 @@ def test_cloud_trigger_forms_emit_branch_deprecation_warning(
     )
     message = str(cloud_warnings[0].message)
     assert cloud_warnings[0].category is DeprecationWarning
-    # Identifies the branch, names v2.0, and explicitly disclaims that
-    # get_context() itself is deprecated.
-    assert _FACTORY_DEPRECATION_SUBSTR in message
-    assert "v2.0" in message
-    assert "get_context() itself is not deprecated" in message
+    # States that GX Cloud no longer functions and names the 2.0 removal target.
+    assert _CLOUD_DEPRECATION_SUBSTR in message
+    assert "2.0" in message
 
 
 @pytest.mark.cloud
@@ -178,7 +172,7 @@ def test_env_var_only_path_emits_branch_deprecation_warning(
         "Env-var-only cloud config should still trigger the branch warning; got "
         f"{[str(w.message) for w in record]}"
     )
-    assert "v2.0" in str(cloud_warnings[0].message)
+    assert "2.0" in str(cloud_warnings[0].message)
 
 
 # ---------------------------------------------------------------------------
@@ -213,8 +207,6 @@ def test_ephemeral_mode_emits_no_cloud_warning_even_with_env_set(
         "mode='ephemeral' must not emit a cloud deprecation warning even with "
         f"GX_CLOUD_* env vars set; got {[str(w.message) for w in record]}"
     )
-    # Belt and suspenders: the __init__ warning must not fire either.
-    assert _init_warnings(record) == []
 
 
 @pytest.mark.unit
@@ -237,13 +229,12 @@ def test_plain_get_context_with_no_cloud_config_emits_no_cloud_warning(
         "Non-cloud get_context() must not emit a cloud deprecation warning; got "
         f"{[str(w.message) for w in record]}"
     )
-    assert _init_warnings(record) == []
 
 
 # ---------------------------------------------------------------------------
 # Exactly-one-per-construction on the FACTORY cloud path. Uses the mocked cloud
-# backend so construction SUCCEEDS, then asserts exactly one branch warning and
-# ZERO __init__ warnings (the guard suppressed the latter).
+# backend so construction SUCCEEDS, then asserts exactly one cloud-deprecation
+# warning total (the guard prevents the __init__ warning from also firing).
 # ---------------------------------------------------------------------------
 
 
@@ -254,12 +245,11 @@ def test_factory_cloud_path_emits_exactly_one_cloud_warning(
     ge_cloud_config: GXCloudConfig,
 ):
     """A single factory-path cloud construction emits EXACTLY ONE cloud-deprecation
-    warning -- the ``get_context()`` branch warning -- and the
-    ``CloudDataContext.__init__`` warning does NOT also fire (the dedupe guard
-    suppressed it).
+    warning -- ``get_context()`` emits it and the dedupe guard suppresses the
+    ``CloudDataContext.__init__`` warning that would otherwise also fire.
 
-    Fails if the guard were removed (then BOTH warnings would fire) or if the
-    branch warning were removed (then zero -- or only the __init__ one -- fire).
+    Fails if the guard were removed (then BOTH sites would fire -- two warnings)
+    or if the warning were removed entirely (then zero).
     """
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
@@ -274,17 +264,13 @@ def test_factory_cloud_path_emits_exactly_one_cloud_warning(
 
     assert isinstance(context, CloudDataContext)
 
-    branch_warnings = _cloud_warnings(record)
-    init_warnings = _init_warnings(record)
-    # Exactly one branch warning fired...
-    assert len(branch_warnings) == 1, (
-        "Expected exactly one get_context() cloud-branch deprecation warning, got "
-        f"{[str(w.message) for w in branch_warnings]}"
-    )
-    # ...and the CloudDataContext.__init__ warning was suppressed by the guard.
-    assert init_warnings == [], (
-        "The CloudDataContext.__init__ warning must not fire on the factory path "
-        f"(guard should have suppressed it); got {[str(w.message) for w in init_warnings]}"
+    cloud_warnings = _cloud_warnings(record)
+    # Exactly one cloud-deprecation warning total: get_context() emits it and the
+    # dedupe guard suppresses the CloudDataContext.__init__ warning. Without the
+    # guard, both sites would fire (two warnings).
+    assert len(cloud_warnings) == 1, (
+        "Expected exactly one cloud-deprecation warning on the factory path, got "
+        f"{[str(w.message) for w in cloud_warnings]}"
     )
 
 
@@ -305,8 +291,7 @@ def test_guard_is_reset_after_factory_cloud_path_raises(
 ):
     """A ``get_context(mode="cloud")`` that raises inside the cloud branch must
     reset the dedupe guard (set in a try/finally), so a subsequent DIRECT
-    ``CloudDataContext(...)`` STILL emits its own ``CloudDataContext is deprecated``
-    warning.
+    ``CloudDataContext(...)`` STILL emits its own cloud-deprecation warning.
 
     Fails if the guard reset were dropped from the ``finally`` -- the leaked
     ``True`` guard would silently suppress the direct-construction warning.
@@ -335,10 +320,10 @@ def test_guard_is_reset_after_factory_cloud_path_raises(
         )
 
     assert isinstance(context, CloudDataContext)
-    init_warnings = _init_warnings(record)
-    assert len(init_warnings) == 1, (
+    direct_warnings = _cloud_warnings(record)
+    assert len(direct_warnings) == 1, (
         "Direct construction after a raised factory cloud call must still warn "
         "(guard must have been reset in the finally); got "
-        f"{[str(w.message) for w in init_warnings]}"
+        f"{[str(w.message) for w in direct_warnings]}"
     )
-    assert "v2.0" in str(init_warnings[0].message)
+    assert "2.0" in str(direct_warnings[0].message)

--- a/tests/data_context/test_get_context_cloud_deprecation.py
+++ b/tests/data_context/test_get_context_cloud_deprecation.py
@@ -1,0 +1,346 @@
+"""Tests for the cloud-branch DeprecationWarning emitted by ``get_context()``.
+
+Covers Req 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 1.5, 6.2 (deprecate-gx-cloud spec) and the
+design's Testing Strategy -> Unit/behavior items 2 (factory cloud-branch warning),
+3 (env-var-only path), 4 (no spurious warning), 5 (exactly-one-per-construction on
+the factory path) and 6 (guard reset on error).
+
+This module lives OUTSIDE the ``tests/data_context/cloud_data_context/`` directory,
+so the autouse ``_suppress_cloud_deprecation_warnings`` conftest fixture does NOT
+apply here. Each test therefore manages warnings explicitly (``pytest.warns`` /
+``warnings.catch_warnings(record=True)``). There is deliberately NO module-level
+``filterwarnings`` ignore -- a module-wide ignore would weaken the
+"no spurious warning" assertions.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+import pytest
+
+import great_expectations as gx
+from great_expectations.data_context import (
+    CloudDataContext,
+    EphemeralDataContext,
+)
+from great_expectations.data_context.cloud_constants import GXCloudEnvironmentVariable
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from great_expectations.data_context.types.base import (
+        DataContextConfig,
+        GXCloudConfig,
+    )
+
+# Substrings that uniquely identify the two cloud-deprecation warnings this spec adds.
+_FACTORY_DEPRECATION_SUBSTR = "The GX Cloud branch of get_context"
+_INIT_DEPRECATION_SUBSTR = "CloudDataContext is deprecated"
+
+# Realistic dummy cloud kwargs (no real backend) used to trigger the kwargs branch.
+_CLOUD_KWARGS = {
+    "cloud_base_url": "https://app.greatexpectations.io/",
+    "cloud_access_token": "i_am_a_token",
+    "cloud_organization_id": "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
+}
+
+
+@pytest.fixture
+def _no_cloud_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no ``GX_CLOUD_*`` env config leaks in from the host environment.
+
+    The cloud-resolution predicate consults ``GX_CLOUD_*`` env vars; clearing them
+    makes the explicit kwargs / ``mode`` / ``cloud_mode`` the ONLY trigger, so the
+    trigger-form tests are not contaminated by ambient cloud config.
+    """
+    for var in GXCloudEnvironmentVariable:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _cloud_warnings(record) -> list:
+    return [w for w in record if _FACTORY_DEPRECATION_SUBSTR in str(w.message)]
+
+
+def _init_warnings(record) -> list:
+    return [w for w in record if _INIT_DEPRECATION_SUBSTR in str(w.message)]
+
+
+# ---------------------------------------------------------------------------
+# Item 2: factory cloud-branch warning on the three trigger forms
+# (Req 2.1, 2.3, 2.4). Each form emits the warning BEFORE the cloud context is
+# built; with no real cloud config the call raises AFTER the warning, so we
+# capture the warning and assert it fired even though construction failed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+@pytest.mark.parametrize(
+    "call_kwargs",
+    [
+        pytest.param({"mode": "cloud"}, id="mode-cloud"),
+        pytest.param({"cloud_mode": True}, id="cloud-mode-true"),
+        pytest.param(dict(_CLOUD_KWARGS), id="cloud-star-kwargs"),
+    ],
+)
+def test_cloud_trigger_forms_emit_branch_deprecation_warning(
+    _no_cloud_env: None,
+    call_kwargs: dict,
+):
+    """Req 2.1/2.3: each of the three cloud trigger forms emits a
+    ``DeprecationWarning`` identifying the GX Cloud *branch* of ``get_context()``
+    (not ``get_context`` itself) and naming v2.0 as the removal target.
+
+    The warning fires BEFORE delegation, so even though the call ultimately
+    raises (no real cloud backend), the warning is recorded. This test fails if
+    the gate is removed (no warning) or the message stops naming the branch/v2.0.
+    """
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        with pytest.raises(Exception):  # noqa: B017 -- raise origin varies (config vs connection); the warning, not the raise, is under test
+            gx.get_context(**call_kwargs)
+
+    cloud_warnings = _cloud_warnings(record)
+    assert len(cloud_warnings) >= 1, (
+        "Expected the cloud-branch DeprecationWarning to fire before the cloud "
+        f"build failed; got {[str(w.message) for w in record]}"
+    )
+    message = str(cloud_warnings[0].message)
+    assert cloud_warnings[0].category is DeprecationWarning
+    # Req 2.3: identifies the branch, names v2.0, and explicitly disclaims that
+    # get_context() itself is deprecated.
+    assert _FACTORY_DEPRECATION_SUBSTR in message
+    assert "v2.0" in message
+    assert "get_context() itself is not deprecated" in message
+
+
+@pytest.mark.cloud
+def test_branch_warning_surfaces_caller_frame_not_internal_frame(
+    _no_cloud_env: None,
+):
+    """Req 2.4 (stacklevel=2): the recorded warning's ``filename`` is THIS test
+    module (the caller's ``get_context(...)`` site), not ``context_factory.py``.
+
+    Fails if the stacklevel is dropped/wrong -- the warning would then point at
+    the gx-internal emission frame.
+    """
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        with pytest.raises(Exception):  # noqa: B017
+            gx.get_context(mode="cloud")
+
+    cloud_warnings = _cloud_warnings(record)
+    assert len(cloud_warnings) >= 1
+    filename = cloud_warnings[0].filename
+    assert filename.endswith("test_get_context_cloud_deprecation.py"), (
+        f"Warning should surface the caller frame, got filename={filename!r}"
+    )
+    assert "context_factory.py" not in filename, (
+        f"Warning surfaced an internal great_expectations frame: {filename!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 3: env-var-only path still warns (Req 2.5). Proves the gate reuses the
+# same resolution predicate (is_cloud_config_available) as delegation -- a
+# kwarg-only gate would miss this path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+def test_env_var_only_path_emits_branch_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Req 2.5: with ``GX_CLOUD_*`` env vars set and NO cloud kwargs,
+    ``get_context()`` still resolves to cloud and emits the branch warning.
+
+    This fails if the gate were re-derived from kwargs alone instead of reusing
+    the factory's ``is_cloud_config_available`` predicate.
+    """
+    monkeypatch.setenv(GXCloudEnvironmentVariable.ACCESS_TOKEN, "i_am_a_token")
+    monkeypatch.setenv(
+        GXCloudEnvironmentVariable.ORGANIZATION_ID,
+        "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
+    )
+    monkeypatch.setenv(
+        GXCloudEnvironmentVariable.BASE_URL, "https://app.greatexpectations.io/"
+    )
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        with pytest.raises(Exception):  # noqa: B017
+            gx.get_context()  # no kwargs -- env config is the sole trigger
+
+    cloud_warnings = _cloud_warnings(record)
+    assert len(cloud_warnings) >= 1, (
+        "Env-var-only cloud config should still trigger the branch warning; got "
+        f"{[str(w.message) for w in record]}"
+    )
+    assert "v2.0" in str(cloud_warnings[0].message)
+
+
+# ---------------------------------------------------------------------------
+# Item 4: no spurious warning (Req 2.2).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_ephemeral_mode_emits_no_cloud_warning_even_with_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Req 2.2: ``mode="ephemeral"`` resolves non-cloud even WITH ``GX_CLOUD_*``
+    env vars set, so NO cloud deprecation warning fires (mode short-circuits
+    before the env-based predicate). Returns an ``EphemeralDataContext``.
+
+    Fails if the gate fired on the env config regardless of the explicit
+    non-cloud mode.
+    """
+    monkeypatch.setenv(GXCloudEnvironmentVariable.ACCESS_TOKEN, "i_am_a_token")
+    monkeypatch.setenv(
+        GXCloudEnvironmentVariable.ORGANIZATION_ID,
+        "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
+    )
+    monkeypatch.setenv(
+        GXCloudEnvironmentVariable.BASE_URL, "https://app.greatexpectations.io/"
+    )
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        context = gx.get_context(mode="ephemeral")
+
+    assert isinstance(context, EphemeralDataContext)
+    assert _cloud_warnings(record) == [], (
+        "mode='ephemeral' must not emit a cloud deprecation warning even with "
+        f"GX_CLOUD_* env vars set; got {[str(w.message) for w in record]}"
+    )
+    # Belt and suspenders: the __init__ warning must not fire either.
+    assert _init_warnings(record) == []
+
+
+@pytest.mark.unit
+def test_plain_get_context_with_no_cloud_config_emits_no_cloud_warning(
+    _no_cloud_env: None,
+    tmp_path: pathlib.Path,
+):
+    """Req 2.2: a plain ``get_context()`` with no cloud kwargs and no cloud env
+    config emits no cloud deprecation warning and returns a non-cloud context.
+    """
+    project_path = tmp_path / "empty_data_context"
+    project_path.mkdir()
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        context = gx.get_context(context_root_dir=str(project_path))
+
+    assert not isinstance(context, CloudDataContext)
+    assert _cloud_warnings(record) == [], (
+        "Non-cloud get_context() must not emit a cloud deprecation warning; got "
+        f"{[str(w.message) for w in record]}"
+    )
+    assert _init_warnings(record) == []
+
+
+# ---------------------------------------------------------------------------
+# Item 5: exactly-one-per-construction on the FACTORY cloud path (Req 1.5).
+# Uses the mocked cloud backend so construction SUCCEEDS, then asserts exactly
+# one branch warning and ZERO __init__ warnings (the guard suppressed the
+# latter).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+def test_factory_cloud_path_emits_exactly_one_cloud_warning(
+    cloud_api_fake,
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GXCloudConfig,
+):
+    """Req 1.5: a single factory-path cloud construction emits EXACTLY ONE
+    cloud-deprecation warning -- the ``get_context()`` branch warning -- and the
+    ``CloudDataContext.__init__`` warning does NOT also fire (the dedupe guard
+    suppressed it).
+
+    Fails if the guard were removed (then BOTH warnings would fire) or if the
+    branch warning were removed (then zero -- or only the __init__ one -- fire).
+    """
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        context = gx.get_context(
+            project_config=empty_ge_cloud_data_context_config,
+            cloud_base_url=ge_cloud_config.base_url,
+            cloud_access_token=ge_cloud_config.access_token,
+            cloud_organization_id=ge_cloud_config.organization_id,
+            cloud_workspace_id=ge_cloud_config.workspace_id,
+            cloud_mode=True,
+        )
+
+    assert isinstance(context, CloudDataContext)
+
+    branch_warnings = _cloud_warnings(record)
+    init_warnings = _init_warnings(record)
+    # Exactly one branch warning fired...
+    assert len(branch_warnings) == 1, (
+        "Expected exactly one get_context() cloud-branch deprecation warning, got "
+        f"{[str(w.message) for w in branch_warnings]}"
+    )
+    # ...and the CloudDataContext.__init__ warning was suppressed by the guard.
+    assert init_warnings == [], (
+        "The CloudDataContext.__init__ warning must not fire on the factory path "
+        f"(guard should have suppressed it); got {[str(w.message) for w in init_warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 6: guard reset on error (Req 1.5 / Error Handling). After a cloud-branch
+# get_context() that RAISES inside delegation, the try/finally must have reset
+# the guard so a subsequent DIRECT CloudDataContext(...) still warns.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cloud
+def test_guard_is_reset_after_factory_cloud_path_raises(
+    _no_cloud_env: None,
+    cloud_api_fake,
+    tmp_path: pathlib.Path,
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GXCloudConfig,
+):
+    """Req 1.5 / Error Handling: a ``get_context(mode="cloud")`` that raises
+    inside the cloud branch must reset the dedupe guard (set in a try/finally),
+    so a subsequent DIRECT ``CloudDataContext(...)`` STILL emits its own
+    ``CloudDataContext is deprecated`` warning.
+
+    Fails if the guard reset were dropped from the ``finally`` -- the leaked
+    ``True`` guard would silently suppress the direct-construction warning.
+    """
+    # First: a factory cloud call that raises (no real cloud config -> the guard
+    # is set True before delegation and must be reset in the finally when the
+    # build fails).
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        with pytest.raises(Exception):  # noqa: B017
+            gx.get_context(mode="cloud")
+
+    # Now a direct construction (mocked backend so it succeeds). If the guard had
+    # leaked True, this warning would be suppressed.
+    project_path = tmp_path / "empty_data_context"
+    project_path.mkdir()
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        context = CloudDataContext(
+            project_config=empty_ge_cloud_data_context_config,
+            context_root_dir=str(project_path),
+            cloud_base_url=ge_cloud_config.base_url,
+            cloud_access_token=ge_cloud_config.access_token,
+            cloud_organization_id=ge_cloud_config.organization_id,
+            cloud_workspace_id=ge_cloud_config.workspace_id,
+        )
+
+    assert isinstance(context, CloudDataContext)
+    init_warnings = _init_warnings(record)
+    assert len(init_warnings) == 1, (
+        "Direct construction after a raised factory cloud call must still warn "
+        "(guard must have been reset in the finally); got "
+        f"{[str(w.message) for w in init_warnings]}"
+    )
+    assert "v2.0" in str(init_warnings[0].message)

--- a/tests/data_context/test_get_context_cloud_deprecation.py
+++ b/tests/data_context/test_get_context_cloud_deprecation.py
@@ -98,7 +98,7 @@ def test_cloud_trigger_forms_emit_branch_deprecation_warning(
     """
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
-        with pytest.raises(Exception):  # noqa: B017 -- raise origin varies (config vs connection); the warning, not the raise, is under test
+        with pytest.raises(Exception):  # noqa: B017 # post-warning failure type varies (config vs connection); the warning, not the raise, is under test
             gx.get_context(**call_kwargs)
 
     cloud_warnings = _cloud_warnings(record)
@@ -127,7 +127,7 @@ def test_branch_warning_surfaces_caller_frame_not_internal_frame(
     """
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(Exception):  # noqa: B017 # post-warning failure type varies; the warning, not the raise, is under test
             gx.get_context(mode="cloud")
 
     cloud_warnings = _cloud_warnings(record)
@@ -167,7 +167,7 @@ def test_env_var_only_path_emits_branch_deprecation_warning(
 
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(Exception):  # noqa: B017 # post-warning failure type varies; the warning, not the raise, is under test
             gx.get_context()  # no kwargs -- env config is the sole trigger
 
     cloud_warnings = _cloud_warnings(record)
@@ -314,7 +314,7 @@ def test_guard_is_reset_after_factory_cloud_path_raises(
     # build fails).
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(Exception):  # noqa: B017 # post-warning failure type varies; the warning, not the raise, is under test
             gx.get_context(mode="cloud")
 
     # Now a direct construction (mocked backend so it succeeds). If the guard had

--- a/tests/data_context/test_get_context_cloud_deprecation.py
+++ b/tests/data_context/test_get_context_cloud_deprecation.py
@@ -163,9 +163,7 @@ def test_env_var_only_path_emits_branch_deprecation_warning(
         GXCloudEnvironmentVariable.ORGANIZATION_ID,
         "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
     )
-    monkeypatch.setenv(
-        GXCloudEnvironmentVariable.BASE_URL, "https://app.greatexpectations.io/"
-    )
+    monkeypatch.setenv(GXCloudEnvironmentVariable.BASE_URL, "https://app.greatexpectations.io/")
 
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
@@ -201,9 +199,7 @@ def test_ephemeral_mode_emits_no_cloud_warning_even_with_env_set(
         GXCloudEnvironmentVariable.ORGANIZATION_ID,
         "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
     )
-    monkeypatch.setenv(
-        GXCloudEnvironmentVariable.BASE_URL, "https://app.greatexpectations.io/"
-    )
+    monkeypatch.setenv(GXCloudEnvironmentVariable.BASE_URL, "https://app.greatexpectations.io/")
 
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -27,12 +27,8 @@ from great_expectations.exceptions.exceptions import (
 from tests.test_utils import working_directory
 
 pytestmark = [
-    pytest.mark.filterwarnings(
-        "ignore:CloudDataContext is deprecated:DeprecationWarning"
-    ),
-    pytest.mark.filterwarnings(
-        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
-    ),
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
 ]
 
 GX_CLOUD_PARAMS_ALL = {

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -27,8 +27,7 @@ from great_expectations.exceptions.exceptions import (
 from tests.test_utils import working_directory
 
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 GX_CLOUD_PARAMS_ALL = {

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -26,6 +26,15 @@ from great_expectations.exceptions.exceptions import (
 )
 from tests.test_utils import working_directory
 
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:CloudDataContext is deprecated:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
+    ),
+]
+
 GX_CLOUD_PARAMS_ALL = {
     "cloud_base_url": "localhost:7000",
     "cloud_organization_id": "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -334,9 +334,9 @@ def test_errors_if_context_root_dir_and_project_root_dir_are_both_provided_for_f
 
     with pytest.raises(
         TypeError,
-        match="'project_root_dir' and 'context_root_dir' are conflicting args; please only provide one",  # noqa: E501
+        match="'project_root_dir' and 'context_root_dir' are conflicting args; please only provide one",  # noqa: E501 # long expected-error-message match string
     ):
-        gx.get_context(  # type: ignore[call-overload]
+        gx.get_context(  # type: ignore[call-overload] # intentionally passing conflicting args to exercise the error path
             mode="file",
             context_root_dir=context_root_dir,
             project_root_dir=context_root_dir.parent,

--- a/tests/data_context/test_workspace_aware_context.py
+++ b/tests/data_context/test_workspace_aware_context.py
@@ -23,6 +23,15 @@ from great_expectations.data_context.data_context.cloud_data_context import (
     WorkspaceNotSetError,
 )
 
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:CloudDataContext is deprecated:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
+    ),
+]
+
 
 @pytest.fixture
 def mock_cloud_config_params() -> dict[str, Any]:

--- a/tests/data_context/test_workspace_aware_context.py
+++ b/tests/data_context/test_workspace_aware_context.py
@@ -24,12 +24,8 @@ from great_expectations.data_context.data_context.cloud_data_context import (
 )
 
 pytestmark = [
-    pytest.mark.filterwarnings(
-        "ignore:CloudDataContext is deprecated:DeprecationWarning"
-    ),
-    pytest.mark.filterwarnings(
-        "ignore:The GX Cloud branch of get_context:DeprecationWarning"
-    ),
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
 ]
 
 

--- a/tests/data_context/test_workspace_aware_context.py
+++ b/tests/data_context/test_workspace_aware_context.py
@@ -24,8 +24,7 @@ from great_expectations.data_context.data_context.cloud_data_context import (
 )
 
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 

--- a/tests/data_context/test_workspace_aware_context.py
+++ b/tests/data_context/test_workspace_aware_context.py
@@ -209,7 +209,7 @@ class TestCloudDataContextDirectInstantiationWithoutWorkspaceId:
         sample_user_with_one_workspace: CloudUserInfo,
         mock_project_config: dict[str, Any],
     ):
-        """Test that CloudDataContext succeeds and auto-sets workspace_id when user has 1 workspace."""  # noqa: E501
+        """Test that CloudDataContext succeeds and auto-sets workspace_id when user has 1 workspace."""  # noqa: E501 # long descriptive test docstring
         with (
             patch(
                 "great_expectations.data_context.data_context.cloud_data_context.CloudDataContext._get_cloud_user_info",

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -55,8 +55,7 @@ LOGGER = logging.getLogger(__name__)
 # warnings-as-errors test posture doesn't fail otherwise-passing cloud tests. The filters are
 # message-scoped and narrow, so unrelated DeprecationWarnings still surface as failures.
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -51,9 +51,9 @@ yaml = YAMLHandler()
 LOGGER = logging.getLogger(__name__)
 
 # This module's cloud tests construct cloud contexts directly (e.g. get_context(cloud_*=...)),
-# which emit the GX Cloud deprecation warnings added by the deprecate-gx-cloud spec. Suppress only
-# those two messages so the warnings-as-errors posture doesn't fail otherwise-passing cloud tests
-# (Req 4.5; narrow, message-scoped — unrelated DeprecationWarnings still surface).
+# which emit the GX Cloud deprecation warnings. Suppress only those two messages so the
+# warnings-as-errors test posture doesn't fail otherwise-passing cloud tests. The filters are
+# message-scoped and narrow, so unrelated DeprecationWarnings still surface as failures.
 pytestmark = [
     pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
     pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -50,6 +50,15 @@ yaml = YAMLHandler()
 
 LOGGER = logging.getLogger(__name__)
 
+# This module's cloud tests construct cloud contexts directly (e.g. get_context(cloud_*=...)),
+# which emit the GX Cloud deprecation warnings added by the deprecate-gx-cloud spec. Suppress only
+# those two messages so the warnings-as-errors posture doesn't fail otherwise-passing cloud tests
+# (Req 4.5; narrow, message-scoped — unrelated DeprecationWarnings still surface).
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+]
+
 
 @pytest.fixture
 def taxi_data_samples_dir() -> pathlib.Path:

--- a/tests/integration/cloud/conftest.py
+++ b/tests/integration/cloud/conftest.py
@@ -1,0 +1,19 @@
+import warnings
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _suppress_cloud_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="CloudDataContext is deprecated",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="The GX Cloud branch of get_context",
+            category=DeprecationWarning,
+        )
+        yield

--- a/tests/integration/cloud/conftest.py
+++ b/tests/integration/cloud/conftest.py
@@ -8,12 +8,7 @@ def _suppress_cloud_deprecation_warnings():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="CloudDataContext is deprecated",
-            category=DeprecationWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="The GX Cloud branch of get_context",
+            message="GX Cloud has been shut down",
             category=DeprecationWarning,
         )
         yield

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -80,8 +80,7 @@ from tests.integration.test_definitions.trino.integration_tests import (
 # content. Unrelated DeprecationWarnings still surface as failures.
 pytestmark = [
     pytest.mark.docs,
-    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
-    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:GX Cloud has been shut down:DeprecationWarning"),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -74,10 +74,10 @@ from tests.integration.test_definitions.trino.integration_tests import (
 )
 
 # Cloud doc-snippet scripts call the get_context() cloud branch / construct CloudDataContext,
-# which emit the GX Cloud deprecation warnings added by the deprecate-gx-cloud spec. The runner
-# execs snippets in-process, so under the warnings-as-errors posture those warnings would fail the
-# run. Suppress only those two messages (narrow, message-scoped; Req 4.5) without touching the
-# docs/docusaurus snippet content itself (Req 5.3). Unrelated DeprecationWarnings still surface.
+# which emit the GX Cloud deprecation warnings. The runner execs snippets in-process, so under
+# the warnings-as-errors test posture those warnings would fail the run. Suppress only those two
+# messages (narrow, message-scoped) here in the harness rather than editing the published snippet
+# content. Unrelated DeprecationWarnings still surface as failures.
 pytestmark = [
     pytest.mark.docs,
     pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -73,7 +73,16 @@ from tests.integration.test_definitions.trino.integration_tests import (
     trino_integration_tests,
 )
 
-pytestmark = pytest.mark.docs
+# Cloud doc-snippet scripts call the get_context() cloud branch / construct CloudDataContext,
+# which emit the GX Cloud deprecation warnings added by the deprecate-gx-cloud spec. The runner
+# execs snippets in-process, so under the warnings-as-errors posture those warnings would fail the
+# run. Suppress only those two messages (narrow, message-scoped; Req 4.5) without touching the
+# docs/docusaurus snippet content itself (Req 5.3). Unrelated DeprecationWarnings still surface.
+pytestmark = [
+    pytest.mark.docs,
+    pytest.mark.filterwarnings("ignore:CloudDataContext is deprecated:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:The GX Cloud branch of get_context:DeprecationWarning"),
+]
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
## What changed

**Source (`great_expectations/data_context/data_context/`):**
- `cloud_data_context.py` — a private module-level `contextvars.ContextVar` dedupe guard, plus a gated `DeprecationWarning` at the top of `CloudDataContext.__init__` (`stacklevel=2`, `# deprecated-v1.17.2`). Class docstring note via the existing `@deprecated_method_or_class` decorator.
- `context_factory.py` — a `DeprecationWarning` on the `get_context()` cloud branch, emitted before delegating, gated by a predicate (`_get_context_resolves_to_cloud`) that **mirrors the actual delegation** (`_build_context`/`_get_cloud_context`) so it can't drift (covers `mode="cloud"`, `cloud_mode=True`, `cloud_*` kwargs, and the env-var-only `GX_CLOUD_*` path; never warns for `file`/`ephemeral`). The guard is set/reset around delegation in a `try/finally` so a single construction emits **exactly one** warning and the guard can't leak on error. Arg docstring note via the existing `@deprecated_argument` decorator.

Both entry points emit the same `DeprecationWarning`: "GX Cloud has been shut down, so this no longer functions and will be removed in great_expectations 2.0." It follows the `# deprecated-v<version>` convention. The dedupe guard guarantees exactly one warning per construction even though both sites now share identical text.

**Test hygiene (no global suppression):**
- New message-scoped autouse suppression conftests for `tests/data_context/cloud_data_context/` and `tests/integration/cloud/` (covers `rest_contracts/` by inheritance).
- Incidental cloud-construction sites outside the cloud dirs handled narrowly: fixture-local `catch_warnings()` wraps in the root `tests/conftest.py` and module-level `pytestmark` filters on the affected `tests/data_context/` modules. Nothing added to `pyproject.toml` or any global scope.

**New behavior tests:** direct-construction warning (count, caller-frame, additive-only, surface intact) and factory cloud-branch warning (all trigger forms, env-var-only, no-spurious, exactly-one dedupe, guard-reset-on-error).

## Validation

- `tests/test_deprecation.py` passes unmodified (version-comment convention).
- Version stamp `1.17.2` matches `great_expectations/deployment_version`.
- Under the project's `filterwarnings=["error", ...]` posture with `--cloud`: cloud unit tree (11 passed), cloud integration tree incl. `rest_contracts/` (37 passed), incidental modules (70 passed), new behavior modules (13 passed).
- Scope-boundary diff audit confirms additive-only: no cloud symbol removed/renamed, no warnings on non-`@public_api` internals, no new deprecation infrastructure, no changelog/docusaurus changes.


