### PR TITLE
[MAINTENANCE] Accept Snowflake parameterized BINARY observed type in type-list expectation test

### DIFF
--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_type_list.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_in_type_list.py
@@ -204,7 +204,7 @@ def test_failure(
         ),
         pytest.param(
             gxe.ExpectColumnValuesToBeInTypeList(
-                column="VARBINARY", type_list=["VARBINARY", "BINARY"]
+                column="VARBINARY", type_list=["VARBINARY", "BINARY", "BINARY(8388608)"]
             ),
             id="VARBINARY",
         ),


### PR DESCRIPTION
## Summary

Snowflake's connector now reports a `VARBINARY` column's type as the length-parameterized string `BINARY(8388608)` (where 8388608 is Snowflake's 8 MiB maximum binary size) rather than the bare `BINARY`. The `expect_column_values_to_be_in_type_list` test asserts that the observed type is an exact member of the configured `type_list`, so this upstream type-naming change broke the `VARBINARY` case.

This adds the parameterized form to the accepted `type_list` for that case, consistent with how the existing `STRING`, `TEXT`, and `CHARACTER` cases already accept their length-parameterized observed types (e.g. `VARCHAR(16777216)`, `VARCHAR(1)`).

## Change

```diff
-                column="VARBINARY", type_list=["VARBINARY", "BINARY"]
+                column="VARBINARY", type_list=["VARBINARY", "BINARY", "BINARY(8388608)"]
```

## Testing

The affected test (`test_success_complete_snowflake[snowflake-VARBINARY]`) requires Snowflake credentials and the `snowflake` marker, so it only executes in CI. The Snowflake assertion itself can only be validated by CI.