### PR TITLE
[MAINTENANCE] Skip Microsoft Teams webhook integration tests during CI transition

### DIFF
--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -447,7 +447,8 @@ class TestMicrosoftTeamsNotificationAction:
         mock_send_notification.assert_called_once_with(url=MS_TEAMS_WEBHOOK_VALUE, json=mock.ANY)
 
     @pytest.mark.skip(
-        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; live endpoint returns 403 Forbidden.",
+        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; "
+        "live endpoint returns 403 Forbidden.",
     )
     @pytest.mark.integration
     @pytest.mark.parametrize(
@@ -491,7 +492,8 @@ class TestMicrosoftTeamsNotificationAction:
             assert result == {"microsoft_teams_notification_result": None}
 
     @pytest.mark.skip(
-        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; live endpoint returns 403 Forbidden.",
+        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; "
+        "live endpoint returns 403 Forbidden.",
     )
     @pytest.mark.integration
     @pytest.mark.parametrize(

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -446,10 +446,7 @@ class TestMicrosoftTeamsNotificationAction:
 
         mock_send_notification.assert_called_once_with(url=MS_TEAMS_WEBHOOK_VALUE, json=mock.ANY)
 
-    @pytest.mark.skip(
-        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; "
-        "live endpoint returns 403 Forbidden.",
-    )
+    @pytest.mark.skip(reason="CI TRANSITION")
     @pytest.mark.integration
     @pytest.mark.parametrize(
         "notify_on, expected_notification",
@@ -491,10 +488,7 @@ class TestMicrosoftTeamsNotificationAction:
         else:
             assert result == {"microsoft_teams_notification_result": None}
 
-    @pytest.mark.skip(
-        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; "
-        "live endpoint returns 403 Forbidden.",
-    )
+    @pytest.mark.skip(reason="CI TRANSITION")
     @pytest.mark.integration
     @pytest.mark.parametrize(
         "notify_on, expected_notification",

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -446,6 +446,9 @@ class TestMicrosoftTeamsNotificationAction:
 
         mock_send_notification.assert_called_once_with(url=MS_TEAMS_WEBHOOK_VALUE, json=mock.ANY)
 
+    @pytest.mark.skip(
+        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; live endpoint returns 403 Forbidden.",
+    )
     @pytest.mark.integration
     @pytest.mark.parametrize(
         "notify_on, expected_notification",
@@ -487,6 +490,9 @@ class TestMicrosoftTeamsNotificationAction:
         else:
             assert result == {"microsoft_teams_notification_result": None}
 
+    @pytest.mark.skip(
+        reason="gx->fivetran CI transition: Microsoft Teams webhook decommissioned; live endpoint returns 403 Forbidden.",
+    )
     @pytest.mark.integration
     @pytest.mark.parametrize(
         "notify_on, expected_notification",


### PR DESCRIPTION
## Summary

The Microsoft Teams notification integration tests in `tests/actions/test_core_actions.py` POST to a live Microsoft Teams webhook to assert that notifications are delivered. That webhook endpoint has been decommissioned (Office 365 connector webhooks are being retired) and now returns `403 Forbidden` on every request, even after retries.

As a result, these two tests fail on every scheduled CI run:

- `TestMicrosoftTeamsNotificationAction::test_run_integration_success_with_severity_filtering`
- `TestMicrosoftTeamsNotificationAction::test_run_integration_failure_with_severity_filtering`

These failures reflect a dead external dependency, not a defect in GX code.

## Change

Skip both tests with `@pytest.mark.skip` and a greppable reason so they can be easily found and revisited once a replacement notification target is available. No production code is affected.

The remaining tests in the class (including the mocked unit tests and the fake-webhook failure test) are unchanged.