### PR TITLE
[MAINTENANCE] Pull CI Docker images directly from Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ name: ci
 #   2. Every 3 hours
 #   3. When we push a tag with a semver pattern x.y.z (for example 0.0.1) which is the pattern we use for releases.
 
-env:
-  ECR_PULL_THROUGH_REPOSITORY_URL: 258143015559.dkr.ecr.us-east-1.amazonaws.com/docker-hub/
-
 on:
   merge_group:
   pull_request_target:
@@ -294,12 +291,6 @@ jobs:
         run: |
           yarn install
           python ci/checks/validate_docs_snippets.py
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registries: "258143015559"
 
       - name: Start services
         if: ${{ matrix.start_services }}
@@ -643,16 +634,6 @@ jobs:
         if: matrix.markers == 'sql_server'
         run: ./scripts/install_sql_server_odbc_driver.sh
 
-      - name: Configure ECR AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::258143015559:role/github-amazonec2containerregistryreadonly
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Run the tests
         run: |
           FLAGS=""
@@ -742,16 +723,6 @@ jobs:
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
           invoke deps --gx-install -m snowflake -r test
 
-      - name: Configure ECR AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::258143015559:role/github-amazonec2containerregistryreadonly
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Run the tests
         run: |
           GROUP="${SHARD%/*}"
@@ -822,16 +793,6 @@ jobs:
         run: |
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
           invoke deps --gx-install -m '${{ matrix.markers }}' -r test
-
-      - name: Configure ECR AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::258143015559:role/github-amazonec2containerregistryreadonly
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run the tests
         run: invoke ci-tests '${{ matrix.markers }}' --up-services --verbose  --reports

--- a/assets/docker/clickhouse/docker-compose.yml
+++ b/assets/docker/clickhouse/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}library/yandex/clickhouse-server
+    image: yandex/clickhouse-server
     ports:
       - "9000:9000"
 

--- a/assets/docker/databricks/docker-compose.yml
+++ b/assets/docker/databricks/docker-compose.yml
@@ -1,3 +1,3 @@
 services:
   databricks:
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}databricksruntime/python
+    image: databricksruntime/python

--- a/assets/docker/linkchecker/docker-compose.yml
+++ b/assets/docker/linkchecker/docker-compose.yml
@@ -1,4 +1,4 @@
 services:
   linkchecker:
     build: ./
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}library/linkchecker:1.0
+    image: linkchecker:1.0

--- a/assets/docker/mysql/docker-compose.yml
+++ b/assets/docker/mysql/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   mysql_db:
     platform: linux/amd64
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}library/mysql:8.0.20
+    image: mysql:8.0.20
     volumes:
       - ./conf.d:/etc/mysql/conf.d
     environment:

--- a/assets/docker/postgresql/docker-compose.yml
+++ b/assets/docker/postgresql/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres_db:
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}library/postgres:15.1
+    image: postgres:15.1
     command:
       - postgres
       - "-c"

--- a/assets/docker/readthedocs/docker-compose.yml
+++ b/assets/docker/readthedocs/docker-compose.yml
@@ -1,3 +1,3 @@
 services:
   rtd:
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}readthedocs/build:6.0
+    image: readthedocs/build:6.0

--- a/assets/docker/spark/docker-compose.yml
+++ b/assets/docker/spark/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   spark-connect:
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}apache/spark:latest@sha256:fb5c5e61e7bb1be94b7f3a31afe1f73c5b4d20b6008f4ffa7278fc085da08a9e
+    image: apache/spark:latest@sha256:fb5c5e61e7bb1be94b7f3a31afe1f73c5b4d20b6008f4ffa7278fc085da08a9e
     ports:
       - "15002:15002" # Spark Connect port
     environment:

--- a/assets/docker/trino/docker-compose.yml
+++ b/assets/docker/trino/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
   trino_db:
-    image: ${ECR_PULL_THROUGH_REPOSITORY_URL}trinodb/trino:latest
+    image: trinodb/trino:latest
     ports:
       - "8088:8080"


### PR DESCRIPTION
## Summary

CI service containers (Spark, Postgres, MySQL, Trino, etc.) were pulled through an ECR pull-through cache that fronted Docker Hub. That cache is being torn down as part of the CI infrastructure transition, so the **ECR login steps now fail** — including in jobs that have nothing to do with the (already-removed) Cloud server, e.g. `marker-tests`, `marker-tests-snowflake`, and `redshift`.

This repoints every CI service image at its canonical Docker Hub coordinate and removes the ECR machinery entirely.

## Changes

- **`.github/workflows/ci.yml`**
  - Removed the `ECR_PULL_THROUGH_REPOSITORY_URL` workflow env var.
  - Removed all four `Login to Amazon ECR` steps (and the `Configure ECR AWS Credentials` OIDC steps) from `docs-snippets`, `marker-tests`, `marker-tests-snowflake`, and `redshift`. No private images remain in the registry, so authenticated pulls are no longer needed anywhere in CI.
- **`assets/docker/*/docker-compose.yml`** (8 files: clickhouse, databricks, linkchecker, mysql, postgresql, readthedocs, spark, trino) — image refs now point directly at Docker Hub (e.g. `postgres:15.1`, `apache/spark:...`, `trinodb/trino:latest`) instead of `${ECR_PULL_THROUGH_REPOSITORY_URL}…`.

## Why this shape

- **No remaining authenticated dependency.** The only images that genuinely required the registry were the Cloud server images, which were already removed. Every remaining service image is a public Docker Hub image, so the cache was acting purely as a Docker Hub proxy.
- **Reversible.** If Docker Hub rate limits become a problem and a pull-through cache is available on the other side of the transition, the prefix can be reintroduced.

## Verification

- `ci.yml` and all 8 compose files parse as valid YAML.
- Repo-wide grep confirms **zero** remaining references to the ECR account, the pull-through env var, `amazon-ecr-login`, or `configure-aws-credentials`.
- Of the 8 repointed compose files, only `spark`, `postgresql`, `mysql`, and `trino` are actually started in CI (`clickhouse`/`databricks` markers declare no service; `linkchecker`/`readthedocs` are unused — the lychee link checker is commented out). The remaining four are repointed for consistency but are not exercised by CI.

## Follow-up (not in this PR)

`marker-tests`, `marker-tests-snowflake`, and `redshift` still declare `permissions: id-token: write`, which was only needed for the OIDC-based ECR credential step. With that step gone the grant is unused and could be dropped in a follow-up; left untouched here to keep this change scoped to the cache removal.
