### PR TITLE
[DOCS] Sync docs version label to released 1.18.0

### DIFF
--- a/docs/docusaurus/docs/components/_data.jsx
+++ b/docs/docusaurus/docs/components/_data.jsx
@@ -1,5 +1,5 @@
 export default {
-  release_version: "great_expectations, version 1.16.1",
+  release_version: "great_expectations, version 1.18.0",
   min_python: "3.10",
   max_python: "3.13",
 };

--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -318,7 +318,7 @@ module.exports = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '1.16.1',
+              label: '1.18.0',
             },
             ['0.18']: {
               label: '0.18.21',


### PR DESCRIPTION
## Summary

The docs site version dropdown on https://docs.greatexpectations.io was displaying `1.16.1` as the latest version even though the current published release is `1.18.0`.

Two version strings in the docs config had drifted and were never updated during the 1.17.x and 1.18.0 releases:

- `docs/docusaurus/docusaurus.config.js` — the Docusaurus `current` version **label** (drives the version dropdown). Was `1.16.1`.
- `docs/docusaurus/docs/components/_data.jsx` — the `release_version` string surfaced in docs content. Was `1.16.1`.

Both are now set to `1.18.0` to match the latest release.

## Why this happened

These two values are not derived from `deployment_version` at build time — they are literal strings that must be bumped per release. They had not tracked the last few releases, so the published docs lagged the actual release by two minor versions.

## Verification

- [ ] Docs site build (CI) passes.
- [ ] After deploy, the version dropdown shows `1.18.0`.