### PR TITLE
[DOCS] Fix typos in the Run a Validation Definition guide

### DIFF
--- a/docs/docusaurus/docs/core/run_validations/run_a_validation_definition.md
+++ b/docs/docusaurus/docs/core/run_validations/run_a_validation_definition.md
@@ -62,7 +62,7 @@ import PrereqValidationDefinition from '../_core_components/prerequisites/_valid
    ```python title="Python" name="docs/docusaurus/docs/core/run_validations/_examples/run_a_validation_definition.py - review Validation Results"
    ```
    
-   When you print the returned Validation Result object you will recieve a json representation of the results.  By default this will include a `"results"` list that includes each Expectation in your Validation Definition's Expectation Suite, whether the Expectation was successfully met or failed to pass, and some sumarized information explaining the why the Expectation succeeded or failed.
+   When you print the returned Validation Result object you will receive a json representation of the results.  By default this will include a `"results"` list that includes each Expectation in your Validation Definition's Expectation Suite, whether the Expectation was successfully met or failed to pass, and some summarized information explaining why the Expectation succeeded or failed.
 
 </TabItem>
 


### PR DESCRIPTION
## Description

Fixes three small typos in the **Run a Validation Definition** page of the GX Core docs (`docs/docusaurus/docs/core/run_validations/run_a_validation_definition.md`):

- `recieve` → `receive`
- `sumarized` → `summarized`
- `explaining the why the Expectation` → `explaining why the Expectation`

Documentation-only change; no code or behavior is affected.

---

- [x] Description of PR changes above includes a link to an existing GitHub issue — n/a, trivial documentation typo fix
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` — n/a, documentation-only change (no Python touched)
- [x] Appropriate tests and docs have been updated
