### PR TITLE
[MAINTENANCE] Fix pytest parametrize non-Collection iterable deprecation breaking scheduled CI

### DIFF
--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -132,38 +132,40 @@ def test_multicolumn_expectation_has_default_mostly(fake_expectation_cls, config
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "fake_expectation_cls, config",
-    itertools.chain(
-        *[
-            [
-                (
-                    FakeMulticolumnExpectation,
-                    fake_expectation_config(
-                        "fake_multicolumn_expectation",
-                        {"column_list": ["column_1", "column_2"], "mostly": x},
-                    ),
-                )
-                for x in [0, 0.5, 1]
-            ],
-            [
-                (
-                    FakeColumnMapExpectation,
-                    fake_expectation_config(
-                        "fake_column_map_expectation", {"column": "col", "mostly": x}
-                    ),
-                )
-                for x in [0, 0.5, 1]
-            ],
-            [
-                (
-                    FakeColumnPairMapExpectation,
-                    fake_expectation_config(
-                        "fake_column_pair_map_expectation",
-                        {"column_A": "colA", "column_B": "colB", "mostly": x},
-                    ),
-                )
-                for x in [0, 0.5, 1]
-            ],
-        ]
+    list(
+        itertools.chain(
+            *[
+                [
+                    (
+                        FakeMulticolumnExpectation,
+                        fake_expectation_config(
+                            "fake_multicolumn_expectation",
+                            {"column_list": ["column_1", "column_2"], "mostly": x},
+                        ),
+                    )
+                    for x in [0, 0.5, 1]
+                ],
+                [
+                    (
+                        FakeColumnMapExpectation,
+                        fake_expectation_config(
+                            "fake_column_map_expectation", {"column": "col", "mostly": x}
+                        ),
+                    )
+                    for x in [0, 0.5, 1]
+                ],
+                [
+                    (
+                        FakeColumnPairMapExpectation,
+                        fake_expectation_config(
+                            "fake_column_pair_map_expectation",
+                            {"column_A": "colA", "column_B": "colB", "mostly": x},
+                        ),
+                    )
+                    for x in [0, 0.5, 1]
+                ],
+            ]
+        )
     ),
 )
 def test_expectation_succeeds_with_valid_mostly(fake_expectation_cls, config):


### PR DESCRIPTION
## Summary

Scheduled CI (`ci` workflow, `unit-tests` jobs) has been failing on `develop` across **all** Python versions (3.10–3.13). Root cause is a **pytest version bump** picked up by the unpinned dev dependency, not a code change.

## Root cause

- `reqs/requirements-dev-lite.txt` pins `pytest>=8.2.1` (no upper bound), so scheduled CI installs the latest pytest on each run.
- A recent pytest release raises `PytestRemovedIn10Warning` when a **non-Collection iterable** (here `itertools.chain(...)`) is passed to `@pytest.mark.parametrize`.
- The suite runs with `filterwarnings = ["error", ...]` (`pyproject.toml`), so the warning becomes a hard **collection error**:

```
ERROR tests/expectations/test_expectation.py - pytest.PytestRemovedIn10Warning:
Passing a non-Collection iterable to parametrize is deprecated.
Test: ...::test_expectation_succeeds_with_valid_mostly, argvalues type: chain
Please convert to a list or tuple.
```

`tests/expectations/test_expectation.py` is the only test file that passes an iterator (`itertools.chain`) to `parametrize`, so it's the only one affected.

## Fix

Wrap the `itertools.chain(...)` argvalues in `list(...)`, per the [pytest deprecation guidance](https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators). Backward-compatible with older pytest versions.