### PR TITLE
[MAINTENANCE] Fix BigQuery Python 3.13 collection error from NumPy 'generic' unit DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -653,6 +653,11 @@ filterwarnings = [
     # Example Actual Warning:
     # FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.* once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates past that date.
     "ignore: You are using a Python version \\(3\\.10.*\\) which Google will stop supporting in new releases of google:FutureWarning",
+    # db_dtypes (google-cloud-bigquery dependency) calls numpy.datetime64("NaT") at class-definition
+    # time; NumPy 2.x emits a DeprecationWarning about the 'generic' unit in Python 3.13+ environments.
+    # This crashes pytest collection (exit 4) before test-skip shims can fire.
+    # Remove when db_dtypes is updated to pass an explicit unit (e.g. numpy.datetime64("NaT", "ns")).
+    "ignore:The 'generic' unit for NumPy:DeprecationWarning",
     # sqlalchemy
     # Example Actual Warning:
     # sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)


### PR DESCRIPTION
## Summary

- `db_dtypes` (a transitive dependency of `google-cloud-bigquery`) calls `numpy.datetime64("NaT")` at class-definition time in `db_dtypes/core.py`. NumPy 2.x in Python 3.13 environments emits a `DeprecationWarning` about using the `'generic'` unit without an explicit unit specifier (e.g. `"ns"`).
- Because `pyproject.toml` has `filterwarnings = ["error", ...]`, this import-time warning is converted to a fatal error during pytest collection — before any tests run. The job exits with code 4 (collection error), which means even the existing backend-skip shim in `tests/conftest.py` never fires.
- Fix: add a `filterwarnings` ignore for `DeprecationWarning` messages matching `"The 'generic' unit for NumPy"` so collection can complete successfully. This follows the established pattern for suppressing third-party import-time warnings in this repo.

**Note:** BigQuery tests remain skipped by the existing `skipped_backend_marks` shim in `tests/conftest.py`; this PR only stops the collection crash. The `filterwarnings` entry should be removed once `db_dtypes` is updated to pass an explicit unit to `numpy.datetime64`/`numpy.timedelta64`.

## Test plan

- [ ] Scheduled CI `marker-tests (bigquery, 3.13)` job should go from exit-4 collection error → green (tests collected and skipped)
- [ ] No other `filterwarnings` entries are removed or loosened
- [ ] Diff is only `pyproject.toml` (+5 lines)