### PR TITLE
[DOCS] Enumerate ephemeral Data Context use cases

### DIFF
--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_ephemeral_data_context.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_create_a_data_context/_ephemeral_data_context.md
@@ -11,6 +11,12 @@ import PrereqGxInstallation from '../../_core_components/prerequisites/_gx_insta
 
 ## Create an Ephemeral Data Context
 
+An Ephemeral Data Context keeps its configuration in memory and writes nothing to a persistent store, so it is a good fit whenever you don't need to keep your GX configuration between runs. Common use cases include:
+
+- Experimenting with GX or exploring data without creating a `gx/` project directory.
+- Running validations in CI, where the environment is recreated on each run and no project directory is committed to your repository.
+- Working in disposable or read-only compute&mdash;such as ephemeral containers or hosted notebooks&mdash;where there is no persistent filesystem to write to.
+
 <Tabs 
    queryString="procedure"
    defaultValue="instructions"


### PR DESCRIPTION
## Description

Per the discussion in #11923, this adds a short, provider-agnostic enumeration of when an **Ephemeral Data Context** is a good fit — running in CI, disposable/read-only compute, and quick experimentation — to the Ephemeral section of the *Create a Data Context* page.

As @joshua-stauffer suggested there, the code snippet is left **DataContext-focused** (unchanged); this only adds prose listing the additional use cases. No vendor names.

Documentation-only change.

---

- [ ] Description of PR changes above includes a link to an existing GitHub issue — see discussion #11923
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` — n/a, documentation-only change (no Python touched)
- [x] Appropriate tests and docs have been updated
