### PR TITLE
[DOCS] Enumerate Ephemeral Data Context use cases in type overview

### DIFF
--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/create_a_data_context.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/create_a_data_context.md
@@ -19,7 +19,7 @@ The following are the available Data Context types:
 
 - **File Data Context:** A persistent Data Context that stores metadata and configuration information as YAML files within a file system. File Data Contexts allow you to re-use previously configured Expectation Suites, Data Sources, and Checkpoints.
 
-- **Ephemeral Data Context:** A temporary Data Context that stores metadata and configuration information in memory. This Data Context will not persist beyond the current Python session. Ephemeral Data Contexts are useful when you don’t have write permissions to a file system or if you are going to engage in data exploration without needing to save your results.
+- **Ephemeral Data Context:** A temporary Data Context that stores metadata and configuration information in memory. This Data Context will not persist beyond the current Python session. Ephemeral Data Contexts are a good fit when you don’t need GX configuration to persist between runs—for example, when exploring data without saving results, running validations in CI where the environment is recreated on each run, or working in disposable or read-only compute (such as ephemeral containers or hosted notebooks) where there is no persistent filesystem.
 
 <Tabs queryString="context_type" groupId="context_type" defaultValue='quick' values={[{label: 'Quick Start', value:'quick'}, {label: 'File', value:'file'}, {label: 'Ephemeral', value:'ephemeral'}]}>
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/create_a_data_context.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/create_a_data_context.md
@@ -19,7 +19,10 @@ The following are the available Data Context types:
 
 - **File Data Context:** A persistent Data Context that stores metadata and configuration information as YAML files within a file system. File Data Contexts allow you to re-use previously configured Expectation Suites, Data Sources, and Checkpoints.
 
-- **Ephemeral Data Context:** A temporary Data Context that stores metadata and configuration information in memory. This Data Context will not persist beyond the current Python session. Ephemeral Data Contexts are a good fit when you don’t need GX configuration to persist between runs—for example, when exploring data without saving results, running validations in CI where the environment is recreated on each run, or working in disposable or read-only compute (such as ephemeral containers or hosted notebooks) where there is no persistent filesystem.
+- **Ephemeral Data Context:** A temporary Data Context that stores metadata and configuration in memory and does not persist beyond the current Python session. Ephemeral Data Contexts are a good fit when you don't need your GX configuration to persist between runs, such as:
+  - Exploring data without saving results
+  - Running validations in CI where the environment is recreated each run
+  - Working in read-only or disposable compute (such as containers or hosted notebooks) with no persistent file system
 
 <Tabs queryString="context_type" groupId="context_type" defaultValue='quick' values={[{label: 'Quick Start', value:'quick'}, {label: 'File', value:'file'}, {label: 'Ephemeral', value:'ephemeral'}]}>
 


### PR DESCRIPTION
## Summary

- Adds CI pipeline and disposable/read-only compute use cases to the **Ephemeral Data Context** type description on the *Create a Data Context* overview page — the natural location for this information, since it appears before the QuickStart/File/Ephemeral tab selection.
- The description already mentioned data exploration as a use case; this extends it with environments where there is no persistent filesystem (CI, ephemeral containers, hosted notebooks).
- Documentation-only change; no Python touched.

## Context

Community contribution by @zozo123 in #11928 identified the right information but placed it inside the Ephemeral tab content (after the tab is already selected). Moving it up to the type overview bullet gives readers the signal before they choose a context type, which is where it does the most good.

## Test plan

- [x] Visual review of the rendered doc page: Ephemeral Data Context bullet reads naturally with the added use cases.
- [x] No other files changed.

Co-authored-by: Yossi Eliaz <yossi.eliaz@incredibuild.com>