### PR TITLE
[MAINTENANCE] Replace broken Wistia embed with YouTube on GX Core intro page

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -47,10 +47,6 @@ module.exports = {
       async: true,
       defer: true
     },
-    {
-      src: 'https://fast.wistia.net/assets/external/E-v1.js',
-      async: true
-    }
   ],
 
   themeConfig: {

--- a/docs/docusaurus/src/components/Videos/GXCoreVideoSnippet.js
+++ b/docs/docusaurus/src/components/Videos/GXCoreVideoSnippet.js
@@ -1,15 +1,15 @@
 import React from 'react'
 
 const GXCoreVideoSnippet = () =>
-  <div className='wistia_responsive_padding' style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+  <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
     <div
-      className='wistia_responsive_wrapper'
       style={{ height: '100%', left: '0', position: 'absolute', top: '0', width: '100%' }}
     >
       <iframe
-        src='https://fast.wistia.net/embed/iframe/8d4jvi21ev?seo=false&videoFoam=true'
-        title='GX Core 1.0 demo Video' allow='autoplay; fullscreen' allowTransparency='true'
-        frameBorder='0' scrolling='no' className='wistia_embed' name='wistia_embed' msallowfullscreen
+        src='https://www.youtube.com/embed/5S0lNuHLIPk'
+        title='GX Core 1.0 demo Video'
+        allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+        frameBorder='0' allowFullScreen
         width='100%' height='100%'
       />
     </div>


### PR DESCRIPTION
## Summary

- The Wistia video (`8d4jvi21ev`) embedded on the [GX Core introduction page](https://docs.greatexpectations.io/docs/core/introduction/) returns "Video not found" — it became inaccessible after the org migration to Fivetran.
- Replaces the Wistia `<iframe>` with the equivalent YouTube embed (`https://www.youtube.com/watch?v=5S0lNuHLIPk`), which is the same "GX Core 1.0 demo" video.
- Removes the now-unused Wistia external script (`fast.wistia.net/assets/external/E-v1.js`) from `docusaurus.config.js`.

## Files changed

- `docs/docusaurus/src/components/Videos/GXCoreVideoSnippet.js` — swap Wistia iframe for YouTube embed; drop Wistia-specific class names and attributes
- `docs/docusaurus/docusaurus.config.js` — remove Wistia script loader

## Test plan

- [x] Verify the YouTube embed loads on the introduction page in a deploy preview
- [x] Confirm no console errors related to Wistia on any docs page