### PR TITLE
[MAINTENANCE] Point doc-site references at CONTRIBUTING.md/DEVELOPMENT.md directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@ They are listed in the order in which GX is prioritizing the support issues:
 ## Contribute
 We truly value the contributions of our community and always welcome pull requests. PRs are encouraged for both bug fixes and new features. For feature requests, we ask that you first open an issue for discussion to ensure the feature fits within the vision for GX Core and to align on the approach so that your time and effort are well spent. Thank you for being a crucial part of GX Core!
 
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to propose a change, claim an issue, and submit a pull request.
+
 ## Code of conduct
 Everyone interacting in GX Core project codebases, Discourse forums, Slack channels, and email communications is expected to adhere to the [GX Community Code of Conduct](https://discourse.greatexpectations.io/t/gx-community-code-of-conduct/1199).

--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -11,7 +11,7 @@ https://docusaurus.io/docs/installation#requirements
 
 ## Installation
 
-Follow the [CONTRIBUTING_CODE](https://github.com/great-expectations/great_expectations/blob/develop/CONTRIBUTING_CODE.md) guide in the `great_expectations` repository to install dev dependencies.
+Follow the [DEVELOPMENT](https://github.com/great-expectations/great_expectations/blob/develop/DEVELOPMENT.md) guide in the `great_expectations` repository to install dev dependencies.
 
 Then run the following command from the repository root to install the rest of the dependencies and build documentation locally (including prior versions) and start a development server:
 

--- a/docs/docusaurus/docs/core/introduction/community_resources.md
+++ b/docs/docusaurus/docs/core/introduction/community_resources.md
@@ -26,7 +26,7 @@ To contribute to GX documentation or code, see one of the following resources:
 
 - To request a documentation change, or a change that doesn't require local testing, see the [README](https://github.com/great-expectations/great_expectations/tree/develop/docs) in the `docs` repository.
 
-- To submit a code change to GX for consideration, see [CONTRIBUTING_CODE](https://github.com/great-expectations/great_expectations/blob/develop/CONTRIBUTING_CODE.md) in the `great_expectations` repository.
+- To submit a code change to GX for consideration, see [CONTRIBUTING](https://github.com/great-expectations/great_expectations/blob/develop/CONTRIBUTING.md) in the `great_expectations` repository.
 
 If you're not sure where to start, or you want to learn what other contributors are doing, check out the [community-supported tab in the GX Issues board](https://github.com/orgs/great-expectations/projects/2/views/1?pane=info) and/or check out the [GX Slack community](https://greatexpectations.io/slack) and introduce yourself in the [#contributing channel](https://greatexpectationstalk.slack.com/archives/CV828B2UX).
 


### PR DESCRIPTION
## Summary
- Repoints `docs/docusaurus/README.md`'s dev-dependency-install link from `CONTRIBUTING_CODE.md` to `DEVELOPMENT.md`.
- Repoints `docs/docusaurus/docs/core/introduction/community_resources.md`'s "submit a code change" link from `CONTRIBUTING_CODE.md` to `CONTRIBUTING.md`.
- Adds a link to `CONTRIBUTING.md` in the root `README.md`'s existing "Contribute" section (purely additive — no existing prose changed).

## Notes for reviewers
- This PR targets the `m/restructure-contribution-docs` integration branch, not `develop`.
- **Depends on the companion `CONTRIBUTING.md` and `DEVELOPMENT.md` PRs landing on the same integration branch first** — as reviewed in isolation here, both new link targets don't exist yet, so this PR alone would introduce dead links. It's meant to merge alongside or after those two, not standalone.

## Test plan
- [x] Confirmed both `CONTRIBUTING_CODE.md` references in the docs site are gone (`grep`)
- [x] Confirmed `README.md`'s diff is purely additive
- [ ] Docusaurus production build — pending Component D's sibling PRs landing so link targets resolve; will re-run once `CONTRIBUTING.md`/`DEVELOPMENT.md` exist on this branch