### PR TITLE
[BUGFIX] Fix crash rendering results with unexpected_index_column_names and no domain column

### DIFF
--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -445,9 +445,17 @@ def _convert_unexpected_indices_to_df(
     def _agg_func(y: pd.Series[T]) -> list[T]:  # type: ignore[type-var]  # not yet supported by pandas-stubs
         return list(y)
 
-    all_unexpected_indices: pd.DataFrame = unexpected_index_df.groupby(domain_column_name_list).agg(
-        _agg_func
-    )
+    all_unexpected_indices: pd.DataFrame
+    if domain_column_name_list:
+        all_unexpected_indices = unexpected_index_df.groupby(domain_column_name_list).agg(_agg_func)
+    else:
+        # No domain column is present to group by (every key in each
+        # `unexpected_index_list` entry is itself one of
+        # `unexpected_index_column_names`), so there is nothing to aggregate across
+        # rows -- `.groupby([])` raises `ValueError: No group keys passed!` here.
+        # Each row already stands on its own; wrap its values in a single-item list
+        # to match the shape `.groupby().agg(_agg_func)` would otherwise produce.
+        all_unexpected_indices = unexpected_index_df.map(lambda x: [x])
 
     # 2. add count
     col_to_count: str = unexpected_index_column_names[0]

--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -157,6 +157,31 @@ def test_convert_unexpected_indices_to_df():
     assert res.iloc[2].tolist() == ["5", "five", 1]
 
 
+def test_convert_unexpected_indices_to_df_no_domain_column():
+    # Regression test: when every key in each `unexpected_index_list` entry is
+    # itself one of `unexpected_index_column_names` (i.e. no separate domain/value
+    # column is present), there is nothing to group by. This previously raised
+    # `ValueError: No group keys passed!` from `.groupby([])`. See GH#11933.
+    unexpected_index_list = [{"pk_1": 3}, {"pk_1": 4}, {"pk_1": 5}]
+    unexpected_index_column_names = ["pk_1"]
+
+    partial_unexpected_counts = [
+        {"count": 1, "value": None},
+        {"count": 1, "value": None},
+        {"count": 1, "value": None},
+    ]
+
+    res = _convert_unexpected_indices_to_df(
+        unexpected_index_list=unexpected_index_list,
+        unexpected_index_column_names=unexpected_index_column_names,
+        partial_unexpected_counts=partial_unexpected_counts,
+    )
+    assert list(res) == ["pk_1", "Count"]
+    assert res.iloc[0].tolist() == ["3", 1]
+    assert res.iloc[1].tolist() == ["4", 1]
+    assert res.iloc[2].tolist() == ["5", 1]
+
+
 def test_convert_unexpected_indices_to_df_multiple():
     result = [
         {"animals": "giraffe", "pk_1": 3},


### PR DESCRIPTION
- [x] Description of PR changes above includes a link to an existing GitHub issue
- [x] PR title is prefixed with `[BUGFIX]`
- [x] Code is linted - ran `ruff format` + `ruff check` on the changed files (clean)
- [x] Appropriate tests and docs have been updated

Closes #11933.

## Problem

When `result_format=COMPLETE` and `unexpected_index_column_names` is specified, but no separate domain/value column is tracked alongside the ID/PK columns, rendering the validation result for Data Docs crashes:

```
ValueError: No group keys passed!
```

## Root cause

`_convert_unexpected_indices_to_df` (`great_expectations/render/util.py`) computes `domain_column_name_list` as whatever keys of an `unexpected_index_list` entry are *not* in `unexpected_index_column_names`. When every key in the dict *is* an ID/PK column -- i.e. there's no separate domain column present -- that list ends up empty, and `pandas.DataFrame.groupby([])` raises.

## Fix

Branch on whether there's actually a domain column to group by:

```python
if domain_column_name_list:
    all_unexpected_indices = unexpected_index_df.groupby(domain_column_name_list).agg(_agg_func)
else:
    # No domain column to group by -- each row already stands on its own;
    # wrap its values in a single-item list to match the shape
    # .groupby().agg(_agg_func) would otherwise produce.
    all_unexpected_indices = unexpected_index_df.map(lambda x: [x])
```

With no domain column, every unexpected row is already its own group of one -- there's nothing to merge across rows, so this skips straight to the equivalent output shape instead of crashing. The existing grouped path (domain column present) is untouched.

## Test

Added `test_convert_unexpected_indices_to_df_no_domain_column` in `tests/render/test_util.py`, directly exercising the previously-crashing input shape (matches the existing test style in that file).

Confirmed as a true regression guard: reverting the fix reproduces the exact original `ValueError: No group keys passed!`; restoring it passes.

## Verification

- Reproduced the original crash directly against `_convert_unexpected_indices_to_df`
- Confirmed the fix resolves it with correct output, and the existing grouped (domain-column-present) path is unaffected
- `tests/render/test_util.py`: 22 passed
- Broader `tests/render/`: 168 passed, 2 xfailed (pre-existing, unrelated)
- `ruff check` / `ruff format --check`: clean