### PR TITLE
[DOCS] Fix parameter name mismatches in docstrings

### DIFF
--- a/great_expectations/experimental/metric_repository/batch_inspector.py
+++ b/great_expectations/experimental/metric_repository/batch_inspector.py
@@ -38,7 +38,7 @@ class BatchInspector:
         Args:
             data_asset_id (uuid.UUID): current data asset id.
             batch_request (BatchRequest): BatchRequest for current batch.
-            metrics_list (Optional[List[MetricTypes]]): List of metrics to compute.
+            metric_list (Optional[List[MetricTypes]]): List of metrics to compute.
         Returns:
             MetricRun: _description_
         """

--- a/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/metric_list_metric_retriever.py
@@ -211,7 +211,7 @@ class MetricListMetricRetriever(MetricRetriever):
         """Calculate table metrics, which include row_count, column names and types.
 
         Args:
-            metrics_list (List[MetricTypes]): list of metrics sent from Agent.
+            metric_list (List[MetricTypes]): list of metrics sent from Agent.
             batch_request (BatchRequest): for current batch.
 
         Returns:

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -130,7 +130,7 @@ def substitute_none_for_missing(
 
     Args:
         kwargs: A dictionary of keyword arguments.
-        kwargs_list: A list or sequence of strings representing all possible keyword parameters to a function.
+        kwarg_list: A list or sequence of strings representing all possible keyword parameters to a function.
 
     Returns:
         A copy of the original `kwargs` with missing keys from `kwarg_list` defaulted to `None`.


### PR DESCRIPTION
Fixes three docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `great_expectations/render/util.py` | `substitute_none_for_missing` | `kwargs_list` | `kwarg_list` |
| `great_expectations/experimental/metric_repository/batch_inspector.py` | `compute_metric_list_run` | `metrics_list` | `metric_list` |
| `great_expectations/experimental/metric_repository/metric_list_metric_retriever.py` | `_calculate_table_metrics` | `metrics_list` | `metric_list` |

The sibling methods in `metric_list_metric_retriever.py` that genuinely take `metrics_list` are left unchanged.

Doc-only change; no behavior modified.

- [x] Description of PR changes above includes a link to an [existing GitHub issue](https://github.com/great-expectations/great_expectations/issues) (n/a - trivial doc fix)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted (doc-only change)
- [x] Appropriate tests and docs have been updated (n/a - docstring-only)