### PR TITLE
[BUGFIX] Preserve date-like strings in SQL distinct value sets

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_distinct_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_distinct_values.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -41,6 +42,7 @@ if TYPE_CHECKING:
 _SQLALCHEMY_1_4_OR_GREATER = SQLALCHEMY_VERSION is not None and is_version_greater_or_equal(
     SQLALCHEMY_VERSION, "1.4.0"
 )
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 # Type alias for scalar values that can appear in columns or value sets
@@ -103,7 +105,7 @@ def _coerce_value_set_to_column_type(
 
 
 def _coerce_value_set_for_sql(value_set: List[ScalarValue]) -> List[ScalarValue]:
-    """Coerce value_set string values that look like dates to datetime.date objects.
+    """Coerce ISO date string values to datetime.date objects.
 
     This is needed for databases like BigQuery that require exact type matching.
     For SQLAlchemy metrics where we don't have access to actual column values.
@@ -119,10 +121,9 @@ def _coerce_value_set_for_sql(value_set: List[ScalarValue]) -> List[ScalarValue]
 
     coerced: List[ScalarValue] = []
     for v in value_set:
-        if isinstance(v, str):
-            # Try to parse as date (common format: YYYY-MM-DD)
+        if isinstance(v, str) and _ISO_DATE_RE.fullmatch(v):
             try:
-                coerced.append(parse(v).date())
+                coerced.append(datetime.date.fromisoformat(v))
             except (ValueError, TypeError):
                 coerced.append(v)
         else:

--- a/tests/expectations/metrics/column_aggregate_metrics/test_column_distinct_values.py
+++ b/tests/expectations/metrics/column_aggregate_metrics/test_column_distinct_values.py
@@ -1,0 +1,29 @@
+import datetime
+
+import pytest
+
+from great_expectations.expectations.metrics.column_aggregate_metrics import (
+    column_distinct_values,
+)
+
+
+@pytest.mark.unit
+def test_coerce_value_set_for_sql_preserves_non_iso_date_like_strings() -> None:
+    assert column_distinct_values._coerce_value_set_for_sql(["0-10", "10-20", "20-30"]) == [
+        "0-10",
+        "10-20",
+        "20-30",
+    ]
+
+
+@pytest.mark.unit
+def test_coerce_value_set_for_sql_coerces_iso_date_strings() -> None:
+    assert column_distinct_values._coerce_value_set_for_sql(["2024-11-19", "2024-11-20"]) == [
+        datetime.date(2024, 11, 19),
+        datetime.date(2024, 11, 20),
+    ]
+
+
+@pytest.mark.unit
+def test_coerce_value_set_for_sql_preserves_invalid_iso_date_strings() -> None:
+    assert column_distinct_values._coerce_value_set_for_sql(["2024-13-19"]) == ["2024-13-19"]

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py
@@ -49,6 +49,18 @@ def test_strings(batch_for_datasource: Batch) -> None:
 
 
 @parameterize_batch_for_data_sources(
+    data_source_configs=ALL_DATA_SOURCES,
+    data=pd.DataFrame({COL_NAME: ["0-10", "10-20", "20-30"]}),
+)
+def test_date_like_strings(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnDistinctValuesToBeInSet(
+        column=COL_NAME, value_set=["0-10", "10-20", "20-30"]
+    )
+    result = batch_for_datasource.validate(expectation)
+    assert result.success
+
+
+@parameterize_batch_for_data_sources(
     data_source_configs=DATA_SOURCES_THAT_SUPPORT_DATE_COMPARISONS,
     data=pd.DataFrame({COL_NAME: [datetime(2024, 11, 19).date(), datetime(2024, 11, 20).date()]}),  # noqa: DTZ001 # FIXME CoP
 )


### PR DESCRIPTION
Fixes #11946.

## Summary

This updates SQL value-set coercion for distinct-value expectations so non-ISO date-like strings such as `"10-20"` remain strings instead of being parsed into `datetime.date` objects by `dateutil`.

## Details

`_coerce_value_set_for_sql` previously attempted to parse every string in `value_set`. Because `dateutil.parser.parse` is permissive, text bins like `"10-20"` could become a date, which can produce type-mismatched SQL comparisons against text columns.

The helper now only converts strict ISO date strings in `YYYY-MM-DD` format with `datetime.date.fromisoformat`. Invalid ISO-looking strings and other date-like text values are preserved as strings.

## Checklist

- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Description includes a link to an existing GitHub issue
- [x] Code is linted
- [x] Appropriate tests have been updated

## Tests

- `.venv/bin/python -m pytest tests/expectations/metrics/column_aggregate_metrics/test_column_distinct_values.py -q`
- `.venv/bin/python -m pytest 'tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py::test_date_like_strings[sqlite]' 'tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py::test_date_like_strings[pandas-data-frame]' -q`
- `.venv/bin/python -m pytest 'tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py::test_strings[sqlite]' 'tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py::test_dates_with_str_value_set[pandas-data-frame]' 'tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py::test_success_complete_results[sqlite]' -q`
- `.venv/bin/python -m pytest 'tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_equal_set.py::test_dates_with_str_value_set[pandas-data-frame]' 'tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_contain_set.py::test_dates_with_str_value_set[pandas-data-frame]' -q`
- `.venv/bin/python -m pytest tests/expectations/metrics/test_core.py::test_distinct_metric_sa -q`
- `.venv/bin/ruff check great_expectations/expectations/metrics/column_aggregate_metrics/column_distinct_values.py tests/expectations/metrics/column_aggregate_metrics/test_column_distinct_values.py tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_be_in_set.py`
