### PR TITLE
[BUGFIX] Fix crash rendering results with unexpected_index_column_names and no domain column

### DIFF
--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -445,9 +445,17 @@ def _convert_unexpected_indices_to_df(
     def _agg_func(y: pd.Series[T]) -> list[T]:  # type: ignore[type-var]  # not yet supported by pandas-stubs
         return list(y)
 
-    all_unexpected_indices: pd.DataFrame = unexpected_index_df.groupby(domain_column_name_list).agg(
-        _agg_func
-    )
+    all_unexpected_indices: pd.DataFrame
+    if domain_column_name_list:
+        all_unexpected_indices = unexpected_index_df.groupby(domain_column_name_list).agg(_agg_func)
+    else:
+        # No domain column is present to group by (every key in each
+        # `unexpected_index_list` entry is itself one of
+        # `unexpected_index_column_names`), so there is nothing to aggregate across
+        # rows -- `.groupby([])` raises `ValueError: No group keys passed!` here.
+        # Each row already stands on its own; wrap its values in a single-item list
+        # to match the shape `.groupby().agg(_agg_func)` would otherwise produce.
+        all_unexpected_indices = unexpected_index_df.map(lambda x: [x])
 
     # 2. add count
     col_to_count: str = unexpected_index_column_names[0]

--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -157,6 +157,31 @@ def test_convert_unexpected_indices_to_df():
     assert res.iloc[2].tolist() == ["5", "five", 1]
 
 
+def test_convert_unexpected_indices_to_df_no_domain_column():
+    # Regression test: when every key in each `unexpected_index_list` entry is
+    # itself one of `unexpected_index_column_names` (i.e. no separate domain/value
+    # column is present), there is nothing to group by. This previously raised
+    # `ValueError: No group keys passed!` from `.groupby([])`. See GH#11933.
+    unexpected_index_list = [{"pk_1": 3}, {"pk_1": 4}, {"pk_1": 5}]
+    unexpected_index_column_names = ["pk_1"]
+
+    partial_unexpected_counts = [
+        {"count": 1, "value": None},
+        {"count": 1, "value": None},
+        {"count": 1, "value": None},
+    ]
+
+    res = _convert_unexpected_indices_to_df(
+        unexpected_index_list=unexpected_index_list,
+        unexpected_index_column_names=unexpected_index_column_names,
+        partial_unexpected_counts=partial_unexpected_counts,
+    )
+    assert list(res) == ["pk_1", "Count"]
+    assert res.iloc[0].tolist() == ["3", 1]
+    assert res.iloc[1].tolist() == ["4", 1]
+    assert res.iloc[2].tolist() == ["5", 1]
+
+
 def test_convert_unexpected_indices_to_df_multiple():
     result = [
         {"animals": "giraffe", "pk_1": 3},


### PR DESCRIPTION
Closes #11933.

## Problem

When rendering a validation result for Data Docs with `result_format` `COMPLETE` and `unexpected_index_column_names` set to the *entire* set of keys present in each `unexpected_index_list` entry (i.e. no separate domain/value column is tracked alongside the ID/PK columns), rendering crashes:

```
ValueError: No group keys passed!
```

## Root cause

In `great_expectations/render/util.py`, `_convert_unexpected_indices_to_df` computes:

```python
domain_column_name_list = list(
    set(first_unexpected_index.keys()).difference(set(unexpected_index_column_names))
)
```

When every key in `first_unexpected_index` is itself one of `unexpected_index_column_names`, this set difference is empty. The function then calls:

```python
unexpected_index_df.groupby(domain_column_name_list).agg(_agg_func)
```

`.groupby([])` raises `ValueError: No group keys passed!` since pandas requires at least one group key.

## Fix

When there is no domain column to group by, there is nothing to aggregate across rows -- each row already stands on its own. Skip the groupby/agg and instead wrap each cell's own value in a single-item list, matching the same per-cell shape `.groupby().agg(_agg_func)` would otherwise produce (a list of values per cell), just with each list containing exactly one element instead of being merged across rows.

## Test

Added `test_convert_unexpected_indices_to_df_no_domain_column` in `tests/render/test_util.py`, covering the exact scenario from the issue (dict keys == `unexpected_index_column_names`).

Verified as a true regression guard: fails with the original `ValueError` when the fix is reverted, passes with it restored. Also verified the existing grouped (domain-column-present) test cases are unaffected.