### PR TITLE
[MAINTENANCE] Add integration-test, CI-status, and disclosure items to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,9 @@
 - [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
 - [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
 - [ ] Appropriate tests and docs have been updated
+- [ ] For any behavioral change to a data source, validation mechanic, or Expectation, at least one integration test exists in `tests/integration/data_sources_and_expectations` (see [AGENTS.md#integration-test-requirement](AGENTS.md#integration-test-requirement))
+- [ ] CI is green, including linting, mypy type-checking, and tests - this is required for merge
+- [ ] If this PR proposes adopting or recommending a particular third-party library or service, any affiliation with it (employment, financial interest, maintainership) is disclosed above for the reviewer's context
 
 For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).
 


### PR DESCRIPTION
## Summary

Adds three additive checklist items to `.github/pull_request_template.md`. No existing content was changed or reworded.

- **Integration-test coverage.** For any behavioral change to a data source, validation mechanic, or Expectation, the template now asks contributors to confirm an integration test exists under `tests/integration/data_sources_and_expectations`, linking to `AGENTS.md#integration-test-requirement`. That anchor lands in `AGENTS.md` via a separate, concurrent PR against this same base branch (`m/restructure-contribution-docs`); the path and heading are fixed, so the link is correct once that PR merges, but it will 404 until then. Ordinary cross-PR sequencing — flagging it here rather than leaving it silent.
- **CI status.** States plainly that CI (linting, mypy type-checking, and tests) must be green before merge. This isn't aspirational — mypy type-checking is part of this repository's required branch-protection status check today.
- **Conflict-of-interest disclosure.** Asks contributors to disclose any affiliation (employment, financial interest, maintainership) when a PR proposes adopting or recommending a particular third-party library or service. Framed as context for the reviewer, not a disqualifier.

No changelog-related prompt was added or touched; changelog entries are generated from merged-PR metadata by an automated process, not something contributor-facing docs should ask about.

## Test plan

- [x] Diffed against the base branch to confirm every prior line is unchanged and only new lines were added
- [x] Manually reviewed the rendered checklist for wording and link correctness
- [ ] Confirm the `AGENTS.md#integration-test-requirement` link resolves once the concurrent PR adding `AGENTS.md` merges