### PR TITLE
[MAINTENANCE] Add Request For Comment discussion category form

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/request-for-comment.yml
+++ b/.github/DISCUSSION_TEMPLATE/request-for-comment.yml
@@ -1,0 +1,42 @@
+labels: ["rfc:proposed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to propose a change that needs discussion before implementation — for example,
+        a new public API, a change to existing public behavior, or an architectural shift that affects
+        more than one component. The project's contribution guide documents the comment window and
+        decision SLA that apply once an RFC discussion is opened; this template only covers the content
+        of the proposal itself.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Include context on who is affected and why the status quo is insufficient.
+      placeholder: Describe the problem this RFC addresses.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the change you're proposing in enough detail for reviewers to evaluate it. Include relevant code sketches, interfaces, or examples if helpful.
+      placeholder: Describe the proposed change.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact on public API or architecture
+      description: Does this change any public API, existing behavior, or the architecture of a component? Note any backward-compatibility or migration concerns.
+      placeholder: Describe the impact on the public API or architecture, or explain why there is none.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider, and why did you choose this one instead?
+      placeholder: Describe alternative approaches and why they were not chosen.
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

- Adds `.github/DISCUSSION_TEMPLATE/request-for-comment.yml`, a discussion category form scoped to the existing "Request For Comment" discussion category (slug `request-for-comment`).
- GitHub matches a discussion category form to a category by filename, so the file is named after the category slug rather than an abbreviation.
- The form asks four questions up front: the problem being solved, the proposed change, its impact on the public API or architecture, and alternatives considered. All four are required fields.
- The form sets `labels: ["rfc:proposed"]` so a new discussion opened from this template is labeled correctly from the start.
- A short markdown intro block points contributors to the contribution guide for process details (comment window, decision timeline) rather than duplicating them here.

## Notes

- The `rfc:proposed` label does not yet exist on this repository — it needs to be created before this label assignment will take effect on new discussions.

## Test plan

- [x] Validated the YAML parses and matches GitHub's discussion category form schema (at least one non-markdown field present, required textareas with labels).
- [ ] Open a test discussion under the "Request For Comment" category after merge to confirm the form renders as expected and the `rfc:proposed` label is available to apply.
