### PR TITLE
[MAINTENANCE] Document the full label taxonomy in .github/LABELS.md

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,9 +1,8 @@
-# Label taxonomy
+# Labels 
 
-This document is the single source of truth for what each label on this repository means, who applies it,
-and when. Other contribution docs (for example, `CONTRIBUTING.md` and the issue forms under
-`.github/ISSUE_TEMPLATE/`) link here rather than redefining label meanings themselves. If you're deciding
-which label to apply, or wondering why an issue carries the labels it does, this is the page to check.
+We use GitHub labels to organize issues, surface available work for contributors, and track RFC status.
+If you're deciding which label to apply, or wondering why an issue carries the labels it does, this is 
+the page to check.
 
 Labels are organized into axes. An issue carries exactly one type label. Status labels track lifecycle
 position; most issues carry one, but some compose deliberately — for example, `pinned` sits alongside
@@ -15,12 +14,12 @@ Discussions, not issues.
 
 Exactly one type label per issue, applied at triage.
 
-| Label | Represents | Notes |
-|---|---|---|
-| `bug` | Actual behavior diverges from documented/intended behavior | Existing label, kept |
-| `feature-request` | New capability or additive API | Absorbs the older `enhancement`, `feature`, and `expectation-request` labels. A new Expectation that conforms to the existing Expectation interface is a feature request, not an RFC. |
-| `documentation` | Docs defects and gaps | Existing label, kept |
-| `maintenance` | Internal chores: refactors, CI, dependency hygiene, test infra | Deliberately matches the `[MAINTENANCE]` pull-request title tag |
+| Label | Represents | 
+|---|---|
+| `bug` | Actual behavior diverges from documented/intended behavior | 
+| `feature-request` | New capability or additive API |
+| `documentation` | Docs defects and gaps |
+| `maintenance` | Internal chores: refactors, CI, dependency hygiene, test infra | 
 
 ## Status axis
 
@@ -33,16 +32,14 @@ expected — most notably `pinned` alongside `claimed` (see "Claim staleness" be
 | `needs-info` | Blocked on the reporter (repro, versions, clarification) | Maintainer |
 | `ready-for-work` | Triaged, accepted, and defined well enough to start today — the claiming gate | Maintainer |
 | `claimed` | Contributor assigned and actively working | The claim-bot workflow (applied on a successful claim, removed on unassignment, including deadline lapse) |
-| `pinned` | Exempt from the claim staleness deadline (legitimately long-running work) | Maintainer only |
+| `pinned` | Exempt from the claim staleness deadline (legitimately long-running work) | Maintainer |
 | `blocked` | Blocked on something other than the reporter: an RFC decision, an upstream fix, or an architectural dependency | Maintainer |
 
 ### Claim staleness
 
-A claim goes stale after **~1 week of inactivity on the issue itself** — not one week from the moment of
-claiming. Commenting or otherwise engaging with the issue resets that inactivity clock. Because a reminder
-comment is posted before the deadline, and that reminder itself counts as activity, the effective
-end-to-end window before an unanswered claim lapses is **~10–11 days**, not exactly 7. `pinned` exempts an
-issue from this staleness handling entirely.
+A claim goes stale after about a week of inactivity. Commenting or otherwise engaging with the issue 
+resets that inactivity clock.  If a maintainer applies the `pinned` label, it exempts an issue from this 
+staleness handling entirely.
 
 ## Invitation axis
 
@@ -80,22 +77,3 @@ The following labels are machine-owned. Don't apply them by hand:
 - `agent-review-requested`
 - `claimed`
 - `🔔 reminder-sent` (the claim-bot's reminder marker)
-
-## Retired labels
-
-The following labels were retired (removed from the repository) as part of this taxonomy's introduction
-and are no longer valid:
-
-- The team-routing family: `core`, `community`, `devrel`, `dx`, `cloud`, `analytics`
-- The `feature:*` family
-- The `stack:*` family
-- `fluent-datasources`
-- `bounty-board`
-- `community-supported`
-- `not-supported`
-- `discussion`
-- Vendor one-offs: `azure`, `aws`, `databricks-sql`, `redshift`
-- Superseded resolution labels: `wontfix`, `as-designed`, `fix-in-prog`, `pending`, `in-progress`,
-  `pr:in_review` (GitHub's native close reasons now cover this)
-- `backlog`
-- `performance`

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,101 @@
+# Label taxonomy
+
+This document is the single source of truth for what each label on this repository means, who applies it,
+and when. Other contribution docs (for example, `CONTRIBUTING.md` and the issue forms under
+`.github/ISSUE_TEMPLATE/`) link here rather than redefining label meanings themselves. If you're deciding
+which label to apply, or wondering why an issue carries the labels it does, this is the page to check.
+
+Labels are organized into axes. An issue carries exactly one type label. Status labels track lifecycle
+position; most issues carry one, but some compose deliberately — for example, `pinned` sits alongside
+`claimed` to exempt an actively claimed issue from staleness handling. The invitation axis adds zero or
+more labels on top, subject to the composability rule below. The RFC-status axis applies to GitHub
+Discussions, not issues.
+
+## Type axis
+
+Exactly one type label per issue, applied at triage.
+
+| Label | Represents | Notes |
+|---|---|---|
+| `bug` | Actual behavior diverges from documented/intended behavior | Existing label, kept |
+| `feature-request` | New capability or additive API | Absorbs the older `enhancement`, `feature`, and `expectation-request` labels. A new Expectation that conforms to the existing Expectation interface is a feature request, not an RFC. |
+| `documentation` | Docs defects and gaps | Existing label, kept |
+| `maintenance` | Internal chores: refactors, CI, dependency hygiene, test infra | Deliberately matches the `[MAINTENANCE]` pull-request title tag |
+
+## Status axis
+
+Tracks an issue's lifecycle position. Most issues carry a single status label, but some combinations are
+expected — most notably `pinned` alongside `claimed` (see "Claim staleness" below).
+
+| Label | Represents | Applied by |
+|---|---|---|
+| `triage` | Awaiting maintainer triage | Automatically, by the issue forms' `labels:` key on submission; removed by a maintainer at triage |
+| `needs-info` | Blocked on the reporter (repro, versions, clarification) | Maintainer |
+| `ready-for-work` | Triaged, accepted, and defined well enough to start today — the claiming gate | Maintainer |
+| `claimed` | Contributor assigned and actively working | The claim-bot workflow (applied on a successful claim, removed on unassignment, including deadline lapse) |
+| `pinned` | Exempt from the claim staleness deadline (legitimately long-running work) | Maintainer only |
+| `blocked` | Blocked on something other than the reporter: an RFC decision, an upstream fix, or an architectural dependency | Maintainer |
+
+### Claim staleness
+
+A claim goes stale after **~1 week of inactivity on the issue itself** — not one week from the moment of
+claiming. Commenting or otherwise engaging with the issue resets that inactivity clock. Because a reminder
+comment is posted before the deadline, and that reminder itself counts as activity, the effective
+end-to-end window before an unanswered claim lapses is **~10–11 days**, not exactly 7. `pinned` exempts an
+issue from this staleness handling entirely.
+
+## Invitation axis
+
+Composable only with `ready-for-work`. These two labels may only appear on an issue that also carries
+`ready-for-work`; they are never applied alone.
+
+| Label | Represents |
+|---|---|
+| `good first issue` | Ready for work and scoped for a first-time contributor: a clear reproduction and description, a pointer to the relevant module, no architectural judgment required |
+| `help wanted` | Ready for work and the maintainer is explicitly not planning to do it themselves — community contribution is the expected path |
+
+## RFC-status axis
+
+Applies to GitHub Discussions, not issues.
+
+| Label | Represents |
+|---|---|
+| `rfc:proposed` | Open, within the comment window |
+| `rfc:final-comment` | Comment window closed; the maintainer decision-SLA clock is running |
+| `rfc:accepted` | Approved |
+| `rfc:declined` | Denied, with written rationale |
+| `rfc:withdrawn` | Withdrawn by its author |
+
+## Reserved / bot-owned labels
+
+The following labels are machine-owned. Don't apply them by hand:
+
+- `stale`
+- `cla-signed`
+- `cla-not-signed`
+- `dependencies`
+- `python`
+- `javascript`
+- `github_actions`
+- `agent-review-requested`
+- `claimed`
+- `🔔 reminder-sent` (the claim-bot's reminder marker)
+
+## Retired labels
+
+The following labels were retired (removed from the repository) as part of this taxonomy's introduction
+and are no longer valid:
+
+- The team-routing family: `core`, `community`, `devrel`, `dx`, `cloud`, `analytics`
+- The `feature:*` family
+- The `stack:*` family
+- `fluent-datasources`
+- `bounty-board`
+- `community-supported`
+- `not-supported`
+- `discussion`
+- Vendor one-offs: `azure`, `aws`, `databricks-sql`, `redshift`
+- Superseded resolution labels: `wontfix`, `as-designed`, `fix-in-prog`, `pending`, `in-progress`,
+  `pr:in_review` (GitHub's native close reasons now cover this)
+- `backlog`
+- `performance`

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,59 +1,60 @@
-# Labels 
+# Labels
 
 We use GitHub labels to organize issues, surface available work for contributors, and track RFC status.
-If you're deciding which label to apply, or wondering why an issue carries the labels it does, this is 
+If you're deciding which label to apply, or wondering why an issue carries the labels it does, this is
 the page to check.
 
-Labels are organized into axes. An issue carries exactly one type label. Status labels track lifecycle
-position; most issues carry one, but some compose deliberately — for example, `pinned` sits alongside
-`claimed` to exempt an actively claimed issue from staleness handling. The invitation axis adds zero or
-more labels on top, subject to the composability rule below. The RFC-status axis applies to GitHub
-Discussions, not issues.
+Labels fall into a few groups, and each group answers one question about an issue:
 
-## Type axis
+- **Type** — what kind of work is it? Every issue carries exactly one type label.
+- **Status** — where is it in its lifecycle? Most issues carry one status label, though a few combine
+  deliberately (for example, `pinned` alongside `claimed`).
+- **Invitation** — is it open for community contribution, and how welcoming? These sit on top of a status
+  and never appear on their own.
+- **RFC status** — for design proposals, which live in GitHub Discussions rather than as issues.
 
-Exactly one type label per issue, applied at triage.
+If you're here to contribute, start with the next section: it covers the labels that tell you which
+issues are open and how claiming works. Everything after it is reference.
 
-| Label | Represents | 
-|---|---|
-| `bug` | Actual behavior diverges from documented/intended behavior | 
-| `feature-request` | New capability or additive API |
-| `documentation` | Docs defects and gaps |
-| `maintenance` | Internal chores: refactors, CI, dependency hygiene, test infra | 
+## Finding and claiming work
 
-## Status axis
-
-Tracks an issue's lifecycle position. Most issues carry a single status label, but some combinations are
-expected — most notably `pinned` alongside `claimed` (see "Claim staleness" below).
+Most contributions start from an issue labeled `ready-for-work`: it has been triaged, accepted, and
+scoped well enough to begin today. `ready-for-work` is the gate for claiming — an issue without it isn't
+open yet. The two invitation labels point you toward especially good starting points, and once you claim
+an issue the claim bot tracks it with `claimed`. For how to claim an issue, see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 | Label | Represents | Applied by |
 |---|---|---|
-| `triage` | Awaiting maintainer triage | Automatically, by the issue forms' `labels:` key on submission; removed by a maintainer at triage |
-| `needs-info` | Blocked on the reporter (repro, versions, clarification) | Maintainer |
 | `ready-for-work` | Triaged, accepted, and defined well enough to start today — the claiming gate | Maintainer |
-| `claimed` | Contributor assigned and actively working | The claim-bot workflow (applied on a successful claim, removed on unassignment, including deadline lapse) |
+| `good first issue` | Ready for work and scoped for a first-time contributor: a clear reproduction and description, a pointer to the relevant module, no architectural judgment required | Maintainer |
+| `help wanted` | Ready for work and the maintainer is explicitly not planning to do it themselves — community contribution is the expected path | Maintainer |
+| `claimed` | Contributor assigned and actively working | The claim bot (on a successful claim; removed on unassignment, including deadline lapse) |
 | `pinned` | Exempt from the claim staleness deadline (legitimately long-running work) | Maintainer |
-| `blocked` | Blocked on something other than the reporter: an RFC decision, an upstream fix, or an architectural dependency | Maintainer |
+
+`good first issue` and `help wanted` are the invitation group: they only ever appear on an issue that
+already carries `ready-for-work`, never on their own.
 
 ### Claim staleness
 
-A claim goes stale after about a week of inactivity. Commenting or otherwise engaging with the issue 
-resets that inactivity clock.  If a maintainer applies the `pinned` label, it exempts an issue from this 
+A claim goes stale after about a week of inactivity. Commenting or otherwise engaging with the issue
+resets that inactivity clock. If a maintainer applies the `pinned` label, it exempts an issue from this
 staleness handling entirely.
 
-## Invitation axis
+## Issue types
 
-Composable only with `ready-for-work`. These two labels may only appear on an issue that also carries
-`ready-for-work`; they are never applied alone.
+Exactly one type label per issue, applied by a maintainer at triage.
 
 | Label | Represents |
 |---|---|
-| `good first issue` | Ready for work and scoped for a first-time contributor: a clear reproduction and description, a pointer to the relevant module, no architectural judgment required |
-| `help wanted` | Ready for work and the maintainer is explicitly not planning to do it themselves — community contribution is the expected path |
+| `bug` | Actual behavior diverges from documented/intended behavior |
+| `feature-request` | New capability or additive API |
+| `documentation` | Docs defects and gaps |
+| `maintenance` | Internal chores: refactors, CI, dependency hygiene, test infra |
 
-## RFC-status axis
+## RFC labels
 
-Applies to GitHub Discussions, not issues.
+RFCs (design proposals) live in GitHub Discussions, not issues, and carry their own status labels:
 
 | Label | Represents |
 |---|---|
@@ -62,6 +63,17 @@ Applies to GitHub Discussions, not issues.
 | `rfc:accepted` | Approved |
 | `rfc:declined` | Denied, with written rationale |
 | `rfc:withdrawn` | Withdrawn by its author |
+
+## Other issue statuses
+
+These statuses track where an issue sits before or outside the claiming flow. You generally won't apply
+them yourself, but they explain why an issue may not be available to pick up.
+
+| Label | Represents | Applied by |
+|---|---|---|
+| `triage` | Awaiting maintainer triage | Automatically, by the issue forms' `labels:` key on submission; removed by a maintainer at triage |
+| `needs-info` | Blocked on the reporter (repro, versions, clarification) | Maintainer |
+| `blocked` | Blocked on something other than the reporter: an RFC decision, an upstream fix, or an architectural dependency | Maintainer |
 
 ## Reserved / bot-owned labels
 


### PR DESCRIPTION
## Summary

Adds `.github/LABELS.md` as the single source of truth for this repository's label taxonomy: the type,
status, and invitation axes for issues, the RFC-status axis for Discussions, the reserved bot-owned label
set, and the list of labels retired as part of this cleanup.

Other contribution docs (`CONTRIBUTING.md`, the issue forms under `.github/ISSUE_TEMPLATE/`) will link to
this file rather than redefining label meanings inline, so label semantics live in exactly one place.

## Test plan

- [ ] Confirm the file renders correctly on GitHub (tables, headings, anchors)
- [ ] Confirm no other doc in this PR chain duplicates label definitions once this lands