### PR TITLE
[MAINTENANCE] Add structured GitHub issue forms for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,121 @@
+name: Bug report
+description: Report a problem with Great Expectations
+title: "[BUG] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. The more detail you provide here, the faster
+        we can reproduce and fix the issue — ideally the reproduction below is complete enough that we
+        can turn it directly into a regression test.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is and what you expected to happen instead.
+      placeholder: |
+        What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: gx-version
+    attributes:
+      label: Great Expectations version
+      description: Output of `great_expectations --version` or `pip show great_expectations`.
+      placeholder: "e.g. 1.3.5"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "e.g. 3.11.8"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: execution-engine
+    attributes:
+      label: Execution engine / data source
+      description: Which backend were you using when the issue occurred?
+      multiple: false
+      options:
+        - Pandas
+        - Spark
+        - SQLite
+        - PostgreSQL
+        - MySQL
+        - Snowflake
+        - BigQuery
+        - Redshift
+        - Databricks (SQL)
+        - Databricks (Spark)
+        - Trino
+        - Other SQLAlchemy-compatible database
+        - Not applicable / not data-backend related
+        - Other (please name it below)
+    validations:
+      required: true
+
+  - type: input
+    id: execution-engine-other
+    attributes:
+      label: If "Other", name the execution engine or data source
+      placeholder: "e.g. ClickHouse, DuckDB"
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: |
+        Steps to reproduce the behavior, detailed enough for a maintainer to turn into an integration
+        test. Please include:
+        - The minimal `great_expectations` code (or CLI commands) that trigger the issue
+        - Sample data or a schema that reproduces it (a small inline CSV/JSON snippet or a synthetic
+          example is ideal — avoid attaching proprietary data)
+        - Any relevant configuration (e.g. `great_expectations.yml`, Data Source / Expectation Suite
+          definitions)
+        - The full stack trace of any error(s)
+      placeholder: |
+        1. Configure a Data Source with...
+        2. Create an Expectation Suite with...
+        3. Run validation with...
+        4. Observe the following error / incorrect result...
+
+        ```python
+        # minimal code sample
+        ```
+
+        ```
+        # sample data or schema
+        ```
+
+        ```
+        # full stack trace
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Additional environment details
+      description: Operating system, cloud/orchestration environment, and any other packages or versions that may be relevant.
+      placeholder: "e.g. macOS 14, running inside Airflow 2.9 on AWS MWAA"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that would help us understand or prioritize this issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Share an early-stage idea
+    url: https://github.com/great-expectations/great_expectations/discussions/categories/ideas
+    about: Have a half-baked idea that isn't ready for a formal feature request yet? Start a discussion in the Ideas category first.
+  - name: Propose a change requiring an RFC
+    url: https://github.com/great-expectations/great_expectations/discussions/categories/request-for-comment
+    about: For proposals that need broader design discussion before implementation, open a Request For Comment discussion.
+  - name: Report a security vulnerability
+    url: https://github.com/great-expectations/great_expectations/security/advisories/new
+    about: Please do not report security vulnerabilities through public GitHub issues — use private vulnerability reporting instead (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature or Expectation request
+description: Suggest an idea, new Expectation, or new data source support for Great Expectations
+title: "[FEATURE] "
+labels: ["feature-request", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. For larger or more open-ended ideas, consider starting a
+        discussion thread first so the design can be worked out before a formal request is filed.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem are you trying to solve? What are you unable to do today?
+      placeholder: "e.g. I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-capability
+    attributes:
+      label: Proposed capability
+      description: A clear and concise description of what you'd like to happen or be able to do.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Is this a net-new capability or an enhancement?
+      description: Help us route this correctly.
+      multiple: false
+      options:
+        - New Expectation
+        - New data source / execution engine support
+        - Enhancement to an existing Expectation
+        - Enhancement to an existing data source / execution engine
+        - Other / not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: A clear and concise description of any alternative solutions, workarounds, or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or code samples about the feature request here.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/bug_report.yml`, a structured Issue Form that requires GX version, Python version, the execution engine/data source involved, and a minimal reproduction (steps + sample data/config) detailed enough to seed an integration test. Labeled `["bug", "triage"]`.
- Add `.github/ISSUE_TEMPLATE/feature_request.yml` for parity and structure: asks for the use case, the proposed capability, and whether the request is a net-new Expectation/data source or an enhancement to an existing one. Labeled `["feature-request", "triage"]`.
- Add `.github/ISSUE_TEMPLATE/config.yml`: disables blank issues and routes non-bug/feature traffic to the right place — early-stage ideas to Discussions → Ideas, RFC-level proposals to Discussions → Request For Comment, and security reports to GitHub's private vulnerability reporting flow (see SECURITY.md, landing in a separate, concurrent PR against this same base branch).
- The existing legacy Markdown templates (`bug_report.md`, `feature_request.md`) are left in place untouched; GitHub will surface both the new forms and the legacy templates until the Markdown versions are removed in a follow-up.

## Notes

- The `bug`, `feature-request`, and `triage` labels referenced in each form's `labels:` key need to exist on the repository for GitHub to apply them automatically when an issue is filed. Label creation/reconciliation is being tracked as a separate, concurrent change — until that lands, the `labels:` keys are inert metadata rather than applied labels.
- Decision on `feature_request.yml`: authored it alongside the bug report form for parity — having both structured forms keeps intake consistent and avoids a mismatched experience where bug reports are structured but feature requests remain freeform.

## Test plan

- [x] Validated all three YAML files parse and have the expected top-level keys (`name`/`description`/`title`/`labels`/`body` for the forms; `blank_issues_enabled`/`contact_links` for `config.yml`).
- [x] Confirmed `contact_links` entries use GitHub's documented `name`/`url`/`about` keys.
- [ ] Visual rendering of the forms on GitHub's issue-creation UI (not verifiable from this environment — recommend a quick look once this PR is up).
