### PR TITLE
[MAINTENANCE] Add Code of Conduct, security policy, and agent conventions doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md
+
+Conventions for coding agents (and human contributors) working in this repository. This
+complements [CONTRIBUTING.md](./CONTRIBUTING.md) and [DEVELOPMENT.md](./DEVELOPMENT.md), which
+cover the full contribution workflow and local environment setup.
+
+## Test markers
+
+Tests are organized with `pytest` markers declared in `pyproject.toml` under
+`[tool.pytest.ini_options]`. The two markers that matter most for scoping a run are:
+
+* `unit` — a unit test. These have no external dependencies and should run fast.
+* `integration` — an integration test, typically exercising a real backend or an end-to-end
+  code path.
+
+Other markers of note:
+
+* `slow` — a test that takes longer than 1 second.
+* Backend-specific markers identify tests that depend on a particular execution engine or
+  external service, for example `postgresql`, `mysql`, `sql_server`, `snowflake`, `bigquery`,
+  `redshift`, `databricks`, `spark`, `spark_connect`, `trino`, `clickhouse`, `singlestore`,
+  `athena`, `sqlite`, and `generic_sql`. A test carries one of these markers when it requires
+  that backend to be available (e.g., credentials, a running database, or an installed
+  optional dependency).
+
+Select or deselect tests by marker expression with `pytest -m`. For example:
+
+```bash
+# Run only unit tests
+pytest -m unit
+
+# Run everything except slow tests
+pytest -m "not slow"
+
+# Run postgresql-dependent tests only
+pytest -m postgresql
+
+# Run unit tests, excluding anything also marked slow
+pytest -m "unit and not slow"
+```
+
+When adding a new test, mark it accurately: `unit` for a fast, dependency-free test; `integration`
+plus the relevant backend marker(s) for anything that talks to a real or emulated backend.
+
+## Compatibility-shim import rule
+
+Optional third-party dependencies (e.g., `sqlalchemy`, `pyspark`, cloud-provider SDKs) must not
+be imported directly in library code. Instead, import them via the corresponding module under
+`great_expectations/compatibility/`, which wraps the import in a `try`/`except ImportError` and
+falls back to a `NotImported` sentinel (see `great_expectations/compatibility/not_imported.py`)
+when the dependency isn't installed.
+
+This lets `great_expectations/compatibility/sqlalchemy.py` (and its siblings) be imported
+unconditionally — the module itself never raises at import time — while any code path that
+actually *uses* a missing symbol raises a clear `ModuleNotFoundError` with an install hint, only
+at the point of use. This is what allows Great Expectations to degrade gracefully when an
+optional dependency isn't installed, rather than failing at import time for users who don't
+need that backend.
+
+In practice:
+
+```python
+# Correct
+from great_expectations.compatibility import sqlalchemy
+...
+engine = sqlalchemy.create_engine(...)
+
+# Incorrect — do not do this in library code
+import sqlalchemy
+```
+
+If you need a symbol from an optional dependency that isn't yet exposed in the matching
+`great_expectations/compatibility/<library>.py` module, add it there following the existing
+`try`/`except (ImportError, AttributeError)` pattern rather than importing the library directly
+at the call site.
+
+## Fluent API location
+
+The Fluent Datasources API — the primary interface for configuring datasources and data assets —
+lives under `great_expectations/datasource/fluent/`. Changes to datasource or data-asset
+configuration behavior generally belong there.
+
+## Local lint and type-checking commands
+
+This project uses `invoke` tasks (defined in `tasks.py`) for linting, formatting, and type
+checking, backed by `ruff` and `mypy`. Run these before submitting a change:
+
+```bash
+# Lint (ruff check), including formatting
+invoke lint
+
+# Check formatting only, without modifying files
+invoke fmt --check
+
+# Type-check with mypy, using the same flags as CI
+invoke type-check --ci --pretty
+```
+
+`invoke lint` runs `ruff format` followed by `ruff check` by default. Pass `--fix` to
+`invoke lint` to have `ruff check` attempt automatic fixes.
+
+## Integration test requirement
+
+A behavioral change to a data source, a validation mechanic, or an Expectation requires at
+least one integration test in `tests/integration/data_sources_and_expectations`. This directory
+contains the shared test utilities and fixtures for exercising Expectations and validation
+behavior against real (or realistically emulated) backends, rather than relying solely on unit
+tests with mocked components.
+
+If a change of this kind genuinely cannot be covered by a test in that directory, the pull
+request description must explain why and describe what coverage exists instead. Don't discover
+this exception in review — call it out up front.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,88 @@
+# Great Expectations Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone. We value everyone as
+whole human beings. To foster an atmosphere of kindness, cooperation, and
+understanding, we encourage and support participation regardless of age,
+body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, sexual identity and
+orientation, or other characteristics.
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces, such as GitHub and Slack, and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+The Code of Conduct also applies to any events associated with the Great
+Expectations project, both in-person and virtual.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting Kyle Eaton on the Great Expectations Developer Relations team at kyle@superconductive.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The Great Expectations core team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found a security vulnerability in Great Expectations, please report it
+privately using GitHub's private vulnerability reporting feature rather than opening a public
+issue or discussion:
+
+**[Report a vulnerability](https://github.com/great-expectations/great_expectations/security/advisories/new)**
+(Security tab → "Report a vulnerability")
+
+This creates a private draft security advisory that is visible only to maintainers, so the
+details aren't exposed publicly while a fix is developed.
+
+Please include as much of the following as you can:
+
+* A description of the vulnerability and its potential impact
+* Steps to reproduce, or a proof-of-concept
+* The affected version(s) of Great Expectations
+* Any known mitigations
+
+## What to Expect
+
+A maintainer will acknowledge your report and work with you through the advisory to confirm the
+issue, assess severity, and develop a fix. Once a fix is ready, we'll coordinate on disclosure
+timing and credit before the advisory is made public.
+
+## Please Don't Use Public Issues for Security Reports
+
+Public GitHub issues and discussions are visible to everyone, including potential attackers.
+Please don't use them to report security vulnerabilities — use the private reporting path above
+instead.


### PR DESCRIPTION
## What

Adds three baseline governance/documentation files at the repository root:

- **`CODE_OF_CONDUCT.md`** — restores the project's Code of Conduct (Contributor Covenant
  v1.4 based). This file existed on the project's original default branch history but was
  removed at some point and has no copy on `develop`; this change ports the last known copy
  back verbatim.
- **`SECURITY.md`** — documents how to report a security vulnerability privately, using
  GitHub's private vulnerability reporting feature (Security tab → "Report a vulnerability"),
  rather than a public issue. States what to include in a report and what response to expect.
- **`AGENTS.md`** — documents conventions that a coding agent (or any contributor) needs to
  work effectively in this codebase:
  - The `pytest` marker convention (`unit` vs. `integration`, `slow`, and backend-specific
    markers like `postgresql`, `snowflake`, `spark`, `bigquery`), and how to select/deselect
    them with `pytest -m`.
  - The rule that optional third-party dependencies must be imported via the corresponding
    `great_expectations/compatibility/` module rather than imported directly, so the package
    degrades gracefully when an optional dependency isn't installed.
  - The location of the Fluent Datasources API (`great_expectations/datasource/fluent/`).
  - The local lint/format/type-check commands (`invoke lint`, `invoke fmt --check`,
    `invoke type-check --ci --pretty`), matching what CI runs.
  - When a behavioral change to a data source, validation mechanic, or Expectation needs at
    least one integration test under `tests/integration/data_sources_and_expectations`, and
    that any exception should be justified in the pull request description.

## Why

These are common baseline files for an open-source project of this size: a Code of Conduct
sets expectations for community interactions, a security policy gives researchers a private
path to report vulnerabilities instead of filing a public issue, and a documented set of
repository conventions makes it easier for both new contributors and automated tooling to
make correct, consistent changes on the first attempt.

## Test plan

- [x] Ported `CODE_OF_CONDUCT.md` verbatim from its last known copy and diffed to confirm an
      exact match — no paraphrasing or content changes.
- [x] Verified the GitHub private-vulnerability-reporting link is the correct, currently
      enabled mechanism for this repository.
- [x] Cross-checked every claim in `AGENTS.md` against the actual repository contents:
      `pyproject.toml`'s `[tool.pytest.ini_options]` markers list,
      `great_expectations/compatibility/sqlalchemy.py` and `not_imported.py`,
      `great_expectations/datasource/fluent/`, `tasks.py`'s `lint`/`format`/`type_check`
      task definitions, and `.github/workflows/ci.yml`'s lint/type-check invocations.
- [x] This change only adds three new files; no other files are touched.
