### PR TITLE
[MAINTENANCE] Skip broken GCP SDK setup in docs-snippets during CI transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,16 +249,27 @@ jobs:
           cache-dependency-path: |
             reqs/requirements-dev-test.txt
 
+      # TEMPORARY (CI transition): the GCP service account these steps activate no
+      # longer exists, so `gcloud auth activate-service-account` fails with
+      # "invalid_grant: account not found" and hard-fails every docs-snippets leg
+      # before any test runs. No docs snippet test currently exercises a GCP-backed
+      # backend (the cloud/warehouse pytest flags were already removed from
+      # docs-creds-needed), so this setup is dead weight until the credentials are
+      # re-provisioned. Skip it until then; restore by removing the `if: false`
+      # guards once valid credentials are available.
       - name: Authenticate with GCP
+        if: false
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{secrets.GE_TEST_GCP_CREDENTIALS}}
 
       - name: Create JSON file for following step
+        if: false
         run: |
           echo "$GE_TEST_GCP_CREDENTIALS" > gcp-credentials.json
 
       - name: Install and setup Google Cloud SDK
+        if: false
         run: |
           # this is recommended by the Google documentation for CI/CD https://cloud.google.com/sdk/docs/install#other_installation_options
           curl -sS https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-370.0.0-linux-x86_64.tar.gz > ./google-cloud-sdk-370.0.0-linux-x86_64.tar.gz && tar -xf ./google-cloud-sdk-370.0.0-linux-x86_64.tar.gz

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -530,6 +530,17 @@ def _check_for_skipped_tests(  # noqa: C901, PLR0912 # FIXME CoP
     ]
     if integration_test_fixture.name in TESTS_TO_SKIP_DURING_CI_TRANSITION:
         pytest.skip("CI TRANSITION")
+    # TEMPORARY: This custom-expectation example declares no backend dependencies, so
+    # it runs unconditionally, but its diagnostic checklist opens a connection to every
+    # installed SQL backend -- including BigQuery, whose credentials are unavailable
+    # during the CI transition. That makes it fail on GCP auth regardless of the backend
+    # pytest flags. Gate it by name until the credentials are re-provisioned; remove this
+    # block to re-enable.
+    TESTS_TO_SKIP_DURING_CI_TRANSITION_GCP = [
+        "expect_column_max_to_be_between_custom",
+    ]
+    if integration_test_fixture.name in TESTS_TO_SKIP_DURING_CI_TRANSITION_GCP:
+        pytest.skip("CI TRANSITION")
     dependencies = integration_test_fixture.backend_dependencies
     if not dependencies:
         return


### PR DESCRIPTION
## Problem

The `docs-snippets` CI job (all three matrix legs) fails fast at **"Install and setup Google Cloud SDK"**:

```
ERROR: (gcloud.auth.activate-service-account) There was a problem refreshing your current auth tokens:
('invalid_grant: Invalid grant: account not found', {'error': 'invalid_grant', ...})
```

The `google-github-actions/auth` step succeeds (it only writes the key file); the actual failure is `gcloud auth activate-service-account` — the service account no longer exists in the current CI environment. Because this step has no matrix guard, it kills all three legs before a single docs test runs (`docs-basic` fails first and fail-fast cancels the rest), blocking `ci-required` on every non-draft PR with docs changes.

## Changes

This continues the CI-transition cleanup (the cloud/warehouse pytest flags were already trimmed to Trino-only for `docs-creds-needed` in an earlier change). Two complementary skips:

1. **`ci.yml`** — guard the three GCP setup steps (`Authenticate with GCP`, `Create JSON file for following step`, `Install and setup Google Cloud SDK`) with `if: false`. No docs snippet test targets a GCP-backed backend anymore, so this setup is dead weight that only fails.
2. **`tests/integration/test_script_runner.py`** — name-gate the `expect_column_max_to_be_between_custom` docs test. It declares no backend dependencies (so it runs unconditionally), but it's a custom-expectation example whose diagnostic checklist opens a connection to every installed SQL backend — including BigQuery, which now has no credentials. This mirrors the existing `TESTS_TO_SKIP_DURING_CI_TRANSITION` pattern.

**Restore path (both):** remove the `if: false` guards and the `TESTS_TO_SKIP_DURING_CI_TRANSITION_GCP` block once valid GCP credentials are re-provisioned.

## Verification

This workflow is triggered by `pull_request_target`, so GitHub reads `ci.yml` from the **base branch (`develop`)**, not the PR head — meaning **this PR's own `docs-snippets` checks will still show red** until it merges. That's expected and not a sign the fix is broken.

The edited workflow was exercised via a `workflow_dispatch` run on this branch (the one trigger that uses the PR-head workflow file). Result — **all three legs green**:

| Leg | Result |
|-----|--------|
| `docs-snippets (docs-basic)` | ✅ success |
| `docs-snippets (docs-creds-needed)` | ✅ success (44 passed, 74 skipped, 0 failed) |
| `docs-snippets (docs-spark)` | ✅ success |

## Out of scope (flagging for awareness)

The same invalid service-account secret (`GE_TEST_GCP_CREDENTIALS`) is consumed by code-PR jobs elsewhere in `ci.yml`. Those only write the key file (they don't call `activate-service-account`), so they fail differently, if at all. Not addressed here — this PR is scoped to the docs checks.

## Coverage note

Skipping `expect_column_max_to_be_between_custom` drops its diagnostic-checklist coverage for **all** backends it exercised (pandas, spark, sqlite as well as BigQuery), not just BigQuery. This is an accepted, temporary loss for the transition; the restore block re-enables the full test once credentials return.

## Merging this PR

`ci-required` on this PR is red **by design** and cannot go green pre-merge: under `pull_request_target`, the required check runs `ci.yml` from `develop`, which still contains the broken gcloud step this PR fixes (chicken-and-egg). The fix is independently verified via the `workflow_dispatch` run above.

`ci-required` is a required status check on `develop`, but branch protection has `enforce_admins: false` — so this needs an **admin merge** (override the red required check). Merging it to `develop` is what makes the workflow correct for every subsequent PR.
