### PR TITLE
[FEATURE] pyspark 4.x support: dependency range, compatibility shim, and CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,6 +669,65 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: "${{ matrix.python-version }} ${{ matrix.markers }}"
 
+  pyspark4-marker-tests:
+    needs: [unit-tests, static-analysis, check-actor-permissions]
+    if: github.event.pull_request.draft == false
+    env:
+      GX_PYTHON_EXPERIMENTAL: true # allow for python 3.13+
+      # Compose override, matched to the 4.1.x pip client installed below. No official
+      # client<->server cross-version guarantee exists for Spark Connect, so the image
+      # tag is kept in lockstep with the lane's pyspark constraint.
+      SPARK_IMAGE: apache/spark:4.1.2
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        markers:
+          - spark
+          - spark_connect
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Upgrade Docker Compose
+        uses: docker/setup-compose-action@v1
+        with:
+          version: latest
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: |
+            reqs/requirements-dev-test.txt
+            setup.py
+
+      - name: Set up Java
+        # Classic-path pyspark 4 needs a host JDK 17+; pin it here rather than relying
+        # on the runner default so this lane is deterministic.
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Verify pyspark 4.0.x resolution (dry run)
+        # Runs before the real install so the environment is clean. Proves the [spark]
+        # extra still resolves the 4.0.x line even though this lane pins 4.1.x.
+        run: pip install --dry-run --quiet ".[spark]" "pyspark~=4.0.3"
+
+      - name: Install dependencies
+        # Direct pip install with the lane constraint file, bypassing constraints-dev.txt
+        # (the 3.x freeze) so pyspark resolves to 4.1.x.
+        run: |
+          pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
+          pip install . -c ci/constraints-test/pyspark4-install.txt -r reqs/requirements-dev-test.txt -r reqs/requirements-dev-spark.txt -r reqs/requirements-dev-spark-connect.txt
+
+      - name: Run the tests
+        run: invoke ci-tests '${{ matrix.markers }}' --up-services --verbose --reports
+
   marker-tests-snowflake:
     needs: [unit-tests, static-analysis, check-actor-permissions]
     if: github.event.pull_request.draft == false

--- a/assets/docker/spark/README.md
+++ b/assets/docker/spark/README.md
@@ -1,4 +1,6 @@
-1. Run `java -version` to check if you have java installed. If no java is installed you can download it here: [https://www.java.com/en/download/](https://www.java.com/en/download/)
-2. Run `docker compose up -d` in this directory to start the spark container
+Spark 4 requires JDK 17 or newer.
+
+1. Run `java -version` to check your installed JDK — it should report 17 or newer. If you don't have a JDK 17+, download one from Adoptium (Eclipse Temurin): [https://adoptium.net/](https://adoptium.net/)
+2. Alternatively, if you don't want to install a JDK on your host, run `docker compose up -d` in this directory to start the spark container — it bundles its own JDK.
 
 You should now be able to run the tests via `pytest --spark`

--- a/assets/docker/spark/docker-compose.yml
+++ b/assets/docker/spark/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   spark-connect:
-    image: apache/spark:latest@sha256:fb5c5e61e7bb1be94b7f3a31afe1f73c5b4d20b6008f4ffa7278fc085da08a9e
+    # Default server pinned by explicit version + digest (the image the `latest`
+    # tag previously resolved to). Override SPARK_IMAGE to run a different server
+    # version against a matching client.
+    image: ${SPARK_IMAGE:-apache/spark:4.0.1@sha256:fb5c5e61e7bb1be94b7f3a31afe1f73c5b4d20b6008f4ffa7278fc085da08a9e}
     ports:
       - "15002:15002" # Spark Connect port
     environment:

--- a/ci/constraints-test/pyspark4-install.txt
+++ b/ci/constraints-test/pyspark4-install.txt
@@ -1,0 +1,5 @@
+# Lane pin for the dedicated pyspark-4 CI job: exercises great_expectations[spark]
+# against the current 4.1.x line. This lane installs WITHOUT constraints-dev.txt
+# (which caps pyspark at <4.0 for every default dev/CI install), so this file is
+# what resolves pyspark here. Floats patch releases within 4.1.x.
+pyspark~=4.1.2

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -5,3 +5,11 @@
 # We use it to place limits on certain packages to help the resolver come to a compatible configuration more quickly
 # To install dev dependencies using the new pip resolver (recommended) please use the following syntax:
 # `python -m pip install -c constraints-dev.txt ".[test, postgresql, spark]"`
+
+# pyspark is capped here so that every default dev and CI install stays on the 3.x line,
+# even though the spark extra's declared range (reqs/requirements-dev-spark.txt) now permits 4.x.
+# This keeps the spark, spark_connect, docs-spark, and cloud dependency sets, along with plain
+# local `invoke deps` installs, resolving pyspark exactly as they did before that range was widened.
+# The dedicated pyspark-4 CI lane installs WITHOUT this constraints file, using its own lane
+# constraint file (ci/constraints-test/pyspark4-install.txt) instead.
+pyspark<4.0

--- a/great_expectations/compatibility/pyarrow.py
+++ b/great_expectations/compatibility/pyarrow.py
@@ -7,4 +7,6 @@ PYARROW_NOT_IMPORTED = NotImported("pyarrow is not installed, please 'pip instal
 try:
     import pyarrow
 except ImportError:
-    pyarrow = PYARROW_NOT_IMPORTED  # type: ignore[assignment] # FIXME CoP
+    # The assignment error only occurs when pyarrow is installed, so the ignore is
+    # env-dependent; unused-ignore keeps --warn-unused-ignores quiet when it is not.
+    pyarrow = PYARROW_NOT_IMPORTED  # type: ignore[assignment,unused-ignore]

--- a/great_expectations/compatibility/pyspark.py
+++ b/great_expectations/compatibility/pyspark.py
@@ -65,11 +65,6 @@ except (ImportError, AttributeError):
     SparkConnectSession = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
 
 try:
-    from pyspark.sql import SQLContext
-except (ImportError, AttributeError):
-    SQLContext = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
-
-try:
     from pyspark.sql import Window
 except (ImportError, AttributeError):
     Window = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
@@ -80,9 +75,13 @@ except (ImportError, AttributeError):
     DataFrameReader = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
 
 try:
-    from pyspark.sql.utils import AnalysisException
+    # pyspark >= 3.4; base class covering both classic and Spark Connect exception hierarchies
+    from pyspark.errors import AnalysisException
 except (ImportError, AttributeError):
-    AnalysisException = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
+    try:
+        from pyspark.sql.utils import AnalysisException  # pyspark < 3.4
+    except (ImportError, AttributeError):
+        AnalysisException = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
 
 try:
     from pyspark.errors import PySparkAttributeError

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -289,7 +289,11 @@ class SparkDFExecutionEngine(ExecutionEngine[str]):
 
         spark_session: pyspark.SparkSession
         try:
-            spark_session = pyspark.SparkConnectSession.builder.getOrCreate()
+            # Under pyspark 4.x the Connect session is a distinct SparkSession subclass;
+            # the two session types are interchangeable here. The assignment error only
+            # occurs on pyspark 4.x, so unused-ignore keeps --warn-unused-ignores quiet
+            # on older pyspark.
+            spark_session = pyspark.SparkConnectSession.builder.getOrCreate()  # type: ignore[assignment,unused-ignore]
         except (ModuleNotFoundError, ValueError, KeyError):
             spark_session = pyspark.SparkSession.builder.getOrCreate()
 

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -695,7 +695,16 @@ def _get_test_validator_with_data_spark(  # noqa: C901, PLR0912, PLR0915 # FIXME
             )
             spark_df = spark.createDataFrame(data_reshaped, string_schema)
             for c in spark_df.columns:
-                spark_df = spark_df.withColumn(c, spark_df[c].cast(spark_types[schema[c]]()))
+                # Coerce the string-loaded columns to their declared types via SQL try_cast
+                # rather than Column.cast. Under strict ANSI SQL evaluation, Column.cast raises
+                # on unparseable input, whereas try_cast resolves it to null. These legacy test
+                # fixtures intentionally include values that don't parse into their declared type
+                # and rely on those becoming null at load time, so try_cast preserves the intended
+                # semantics regardless of the ANSI evaluation mode.
+                type_str = spark_types[schema[c]]().simpleString()
+                spark_df = spark_df.withColumn(
+                    c, pyspark.functions.expr(f"try_cast(`{c}` as {type_str})")
+                )
     elif len(data_reshaped) == 0:
         # if we have an empty dataset and no schema, need to assign an arbitrary type
         columns = list(data.keys())

--- a/reqs/requirements-dev-spark.txt
+++ b/reqs/requirements-dev-spark.txt
@@ -1,1 +1,4 @@
-pyspark>=2.3.2,<4.0  # spark
+# The ceiling admits the 4.x line (tested through 4.1.x) while keeping the 2.3.2 floor.
+# Everyday dev/CI resolution is held to the 3.x series by constraints-dev.txt; a
+# separate CI lane with its own constraint file exercises the pyspark-4 resolution.
+pyspark>=2.3.2,<4.2  # spark

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -211,7 +211,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         (
             "requirements-dev-spark.txt",
             "pyspark",
-            (("<", "4.0"), (">=", "2.3.2")),
+            (("<", "4.2"), (">=", "2.3.2")),
         ),
         ("requirements-dev-sqlalchemy.txt", "moto", (("<", "5.0"), (">=", "4.2.13"))),
         ("requirements-dev-sqlalchemy.txt", "pact-python", (("<", "4"), (">=", "3.1.0"))),
@@ -247,7 +247,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         (
             "requirements-dev.txt",
             "pyspark",
-            (("<", "4.0"), (">=", "2.3.2")),
+            (("<", "4.2"), (">=", "2.3.2")),
         ),
         ("requirements-dev.txt", "pypd", (("==", "1.1.0"),)),
         ("requirements-dev.txt", "sqlalchemy", (("<", "2.0.0"),)),


### PR DESCRIPTION
Foundational work to make `great_expectations[spark]` installable and tested against pyspark 4.x (classic and Spark Connect) while keeping pyspark 3.x behavior unchanged for existing users. This PR targets the `f/spark-4-compatibility` integration branch; remediation of Spark 4 behavior differences and driving the new CI lane green follow in subsequent PRs onto the same branch.

## Changes
- **Dependency range**: widen the `spark` extra to `pyspark>=2.3.2,<4.2` (floor unchanged; the 4.x line is tested through 4.1.x). Packaging-test version tuples updated to match.
- **Dev/CI resolution freeze**: add `pyspark<4.0` to `constraints-dev.txt` so every default `invoke deps` lane (spark, spark_connect, docs-spark, cloud, local dev) keeps resolving pyspark 3.x exactly as before the range widened.
- **Compatibility shim**: import `AnalysisException` version-agnostically — `pyspark.errors` (the >=3.4 base class covering classic and Spark Connect hierarchies) → `pyspark.sql.utils` (older pyspark) → not-imported sentinel. Remove the unused `SQLContext` compatibility entry.
- **Test-support ANSI safety**: the Spark test-support string→typed coercion now uses SQL `try_cast`, which returns null for unparseable values under ANSI (matching the prior behavior); unchanged on pyspark 3.x.
- **Spark Connect image**: parameterize the compose image via `${SPARK_IMAGE:-...}` so a matching client/server pair can be selected per lane. The default is pinned to the exact image the previous `latest@digest` resolved to (byte-identical), so the existing Connect lane is unchanged.
- **CI**: add an additive `pyspark4-marker-tests` job that runs the `spark` and `spark_connect` markers against pyspark 4.1.x on Python 3.13 with a JDK 17 toolchain, installing via a dedicated lane constraint file that bypasses the 3.x dev pin. No existing job is modified.
- **Docs**: document the JDK 17+ requirement for the local Spark setup (Adoptium/Temurin), keeping the docker path as the no-host-JDK alternative.

## Notes for reviewers
- The Spark Connect compose image previously pinned by `latest@digest` actually resolved to Spark 4.0.1; the default now pins that same image explicitly (same digest) with a `SPARK_IMAGE` override for the pyspark-4 lane. The existing Connect lane's server is therefore unchanged.
- A pyspark-4.1.x exploratory run surfaced no ANSI or Arrow-conversion regressions in the current suite; the remaining Spark 4 behavior differences (e.g. a typed config exception no longer matching the existing `except`, and a `Column.__str__` format change affecting one metric's string handling) are addressed in follow-up PRs on this branch.
- Under `pull_request_target` the new CI job does not run on this PR; it will be exercised via workflow dispatch on the branch and after merge.

Draft: foundation only — Spark 4 behavior remediation and the green pyspark-4 lane land in follow-up PRs onto `f/spark-4-compatibility`.
