### PR TITLE
[MAINTENANCE] Make pyarrow compatibility type-ignore environment-independent

### DIFF
--- a/great_expectations/compatibility/pyarrow.py
+++ b/great_expectations/compatibility/pyarrow.py
@@ -7,4 +7,6 @@ PYARROW_NOT_IMPORTED = NotImported("pyarrow is not installed, please 'pip instal
 try:
     import pyarrow
 except ImportError:
-    pyarrow = PYARROW_NOT_IMPORTED  # type: ignore[assignment] # FIXME CoP
+    # The assignment error only occurs when pyarrow is installed, so the ignore is
+    # env-dependent; unused-ignore keeps --warn-unused-ignores quiet when it is not.
+    pyarrow = PYARROW_NOT_IMPORTED  # type: ignore[assignment,unused-ignore]


### PR DESCRIPTION
## Summary

`great_expectations/compatibility/pyarrow.py` guards its import with a `NotImported` fallback, and the `# type: ignore[assignment]` on that fallback assignment is environment-dependent:

- **pyarrow installed**: mypy types the imported name as `Module`, so assigning `NotImported` is an `[assignment]` error — the ignore is required.
- **pyarrow not installed** (the CI static-analysis environment): the name resolves as `Any`, the assignment is fine, and `--warn-unused-ignores` fails the build with `Unused "type: ignore"`.

CI static-analysis began failing on this today after a dependency drift in the `mypy --install-types` environment; it fails on `develop` independent of any open branch.

## Change

Add mypy's `unused-ignore` error code to the existing ignore — `# type: ignore[assignment,unused-ignore]` — which makes the ignore valid whether or not it is needed in a given environment. One line, no runtime behavior change.

## Testing

- `mypy --warn-unused-ignores` passes on the file in an environment **with** pyarrow installed (where the ignore is exercised).
- The same change already passed the full CI static-analysis job (environment **without** pyarrow, where the ignore is unused) on another branch.