### PR TITLE
[FEATURE] pyspark 4.x support: ANSI-mode and Spark-4 API compatibility fixes

### DIFF
--- a/ci/constraints-test/pyspark4-install.txt
+++ b/ci/constraints-test/pyspark4-install.txt
@@ -2,4 +2,4 @@
 # against the current 4.1.x line. This lane installs WITHOUT constraints-dev.txt
 # (which caps pyspark at <4.0 for every default dev/CI install), so this file is
 # what resolves pyspark here. Floats patch releases within 4.1.x.
-pyspark~=4.0.3
+pyspark~=4.1.2

--- a/ci/constraints-test/pyspark4-install.txt
+++ b/ci/constraints-test/pyspark4-install.txt
@@ -2,4 +2,4 @@
 # against the current 4.1.x line. This lane installs WITHOUT constraints-dev.txt
 # (which caps pyspark at <4.0 for every default dev/CI install), so this file is
 # what resolves pyspark here. Floats patch releases within 4.1.x.
-pyspark~=4.1.2
+pyspark~=4.0.3

--- a/great_expectations/compatibility/pyspark.py
+++ b/great_expectations/compatibility/pyspark.py
@@ -89,14 +89,15 @@ except (ImportError, AttributeError):
     PySparkAttributeError = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
 
 try:
-    # pyspark >= 4.0: spark.conf.get() raises this typed error ([SQL_CONF_NOT_FOUND])
-    # when a config key is absent from SQLConf. Earlier versions raise a generic
+    # spark.conf.get() raises this typed error ([SQL_CONF_NOT_FOUND]) when a config key
+    # is absent from SQLConf. It is importable from pyspark.errors on modern releases
+    # (present since ~3.5); only much older pyspark lacks it and raises a generic
     # Py4JJavaError instead.
     from pyspark.errors import SparkNoSuchElementException
 except (ImportError, AttributeError):
-    # On pyspark < 4.0 the typed error does not exist. Use a private Exception
-    # subclass so that `except SparkNoSuchElementException` remains a valid clause
-    # while never matching a real runtime error (unlike the NotImported sentinel,
+    # On those much older pyspark versions the typed error is unavailable. Use a private
+    # Exception subclass so that `except SparkNoSuchElementException` remains a valid
+    # clause while never matching a real runtime error (unlike the NotImported sentinel,
     # which is not a usable exception type).
     class SparkNoSuchElementException(Exception):  # type: ignore[no-redef] # FIXME CoP
-        """Placeholder keeping `except SparkNoSuchElementException` valid on pyspark < 4.0."""
+        """Placeholder keeping `except SparkNoSuchElementException` valid on old pyspark."""

--- a/great_expectations/compatibility/pyspark.py
+++ b/great_expectations/compatibility/pyspark.py
@@ -87,3 +87,16 @@ try:
     from pyspark.errors import PySparkAttributeError
 except (ImportError, AttributeError):
     PySparkAttributeError = SPARK_NOT_IMPORTED  # type: ignore[assignment,misc] # FIXME CoP
+
+try:
+    # pyspark >= 4.0: spark.conf.get() raises this typed error ([SQL_CONF_NOT_FOUND])
+    # when a config key is absent from SQLConf. Earlier versions raise a generic
+    # Py4JJavaError instead.
+    from pyspark.errors import SparkNoSuchElementException
+except (ImportError, AttributeError):
+    # On pyspark < 4.0 the typed error does not exist. Use a private Exception
+    # subclass so that `except SparkNoSuchElementException` remains a valid clause
+    # while never matching a real runtime error (unlike the NotImported sentinel,
+    # which is not a usable exception type).
+    class SparkNoSuchElementException(Exception):  # type: ignore[no-redef] # FIXME CoP
+        """Placeholder keeping `except SparkNoSuchElementException` valid on pyspark < 4.0."""

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -385,8 +385,10 @@ class SparkDFExecutionEngine(ExecutionEngine[str]):
                 # conf.get will look first at the runtime conf and then at the sparkContext conf
                 try:
                     current_value = spark_session.conf.get(key)
-                # Py4J Java Error can be raised if the option has not been set on the context at all
-                except py4j.protocol.Py4JJavaError:
+                # A missing config surfaces differently across Spark versions: older versions
+                # raise a generic Py4JJavaError, while Spark 4+ raises a typed
+                # SparkNoSuchElementException ([SQL_CONF_NOT_FOUND]). Treat both as "unset".
+                except (py4j.protocol.Py4JJavaError, pyspark.SparkNoSuchElementException):
                     current_value = None
                 if key != "spark.app.name" and (current_value != value or current_value is None):
                     # attempts to update the runtime config
@@ -679,7 +681,7 @@ illegal.  Please check your config."""  # noqa: E501 # FIXME CoP
                 CONDITION_PARSER_GREAT_EXPECTATIONS,
                 CONDITION_PARSER_GREAT_EXPECTATIONS_DEPRECATED,
             ] and isinstance(row_condition, str):
-                return data.filter(parse_condition_to_spark(row_condition))
+                return data.filter(parse_condition_to_spark(row_condition, schema=data.schema))
             else:
                 raise GreatExpectationsError(  # noqa: TRY003 # FIXME CoP
                     f"unrecognized condition_parser {condition_parser!s} for Spark execution engine"

--- a/great_expectations/expectations/legacy_row_conditions.py
+++ b/great_expectations/expectations/legacy_row_conditions.py
@@ -7,6 +7,7 @@ from string import punctuation
 from typing import TYPE_CHECKING
 
 import great_expectations.exceptions as gx_exceptions
+from great_expectations.compatibility import pyspark
 from great_expectations.compatibility.pyparsing import (
     CaselessLiteral,
     Combine,
@@ -29,7 +30,7 @@ from great_expectations.types import SerializableDictDot
 from great_expectations.util import convert_to_json_serializable  # noqa: TID251 # FIXME CoP
 
 if TYPE_CHECKING:
-    from great_expectations.compatibility import pyspark, sqlalchemy
+    from great_expectations.compatibility import sqlalchemy
 
 
 def _set_notnull(s, l, t) -> None:  # noqa: E741 # ambiguous name `l`
@@ -124,14 +125,42 @@ def parse_great_expectations_condition(row_condition: str):
         raise ConditionParserError(f"unable to parse condition: {row_condition}")  # noqa: TRY003 # FIXME CoP
 
 
+def _condition_value_literal(value: str, column_name: str, schema=None):
+    """Build a Spark literal for a parsed string condition value.
+
+    When the target column is numeric, a bare string literal would be compared against a
+    numeric column, which errors under ANSI mode (implicit string<->numeric coercion is
+    disallowed). To match the numeric-comparison semantics older Spark versions applied
+    implicitly, convert the value to a numeric literal so the comparison stays
+    numeric-vs-numeric (which is ANSI-safe). String columns keep the string literal.
+    """
+    if schema is not None and pyspark.types:
+        try:
+            column_type = schema[column_name].dataType
+        except (KeyError, TypeError):
+            column_type = None
+        if column_type is not None and isinstance(column_type, pyspark.types.NumericType):
+            try:
+                return F.lit(int(value))
+            except ValueError:
+                try:
+                    return F.lit(float(value))
+                except ValueError:
+                    pass
+    return F.lit(value)
+
+
 def parse_condition_to_spark(
     row_condition: str,
+    schema=None,
 ) -> pyspark.Column:
     parsed = parse_great_expectations_condition(row_condition)
     column = parsed["column"]
     if "condition_value" in parsed:
         return generate_condition_by_operator(
-            F.col(column), parsed["op"], F.lit(parsed["condition_value"])
+            F.col(column),
+            parsed["op"],
+            _condition_value_literal(parsed["condition_value"], column, schema),
         )
     elif "fnumber" in parsed:
         try:

--- a/great_expectations/expectations/legacy_row_conditions.py
+++ b/great_expectations/expectations/legacy_row_conditions.py
@@ -4,7 +4,7 @@ import enum
 import operator
 from dataclasses import dataclass
 from string import punctuation
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import pyspark
@@ -125,7 +125,9 @@ def parse_great_expectations_condition(row_condition: str):
         raise ConditionParserError(f"unable to parse condition: {row_condition}")  # noqa: TRY003 # FIXME CoP
 
 
-def _condition_value_literal(value: str, column_name: str, schema=None):
+def _condition_value_literal(
+    value: str, column_name: str, schema: Optional[pyspark.types.StructType] = None
+):
     """Build a Spark literal for a parsed string condition value.
 
     When the target column is numeric, a bare string literal would be compared against a
@@ -152,7 +154,7 @@ def _condition_value_literal(value: str, column_name: str, schema=None):
 
 def parse_condition_to_spark(
     row_condition: str,
-    schema=None,
+    schema: Optional[pyspark.types.StructType] = None,
 ) -> pyspark.Column:
     parsed = parse_great_expectations_condition(row_condition)
     column = parsed["column"]

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_sum.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_sum.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from great_expectations.compatibility import pyspark
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.execution_engine import (
@@ -28,5 +30,26 @@ class ColumnSum(ColumnAggregateMetricProvider):
         return sa.func.sum(column)
 
     @column_aggregate_partial(engine=SparkDFExecutionEngine)
-    def _spark(cls, column, **kwargs):
+    def _spark(cls, column, _table=None, _column_name=None, **kwargs):
+        # Summing an integral column accumulates in a LongType. Spark 4 evaluates
+        # arithmetic under ANSI semantics by default and raises ARITHMETIC_OVERFLOW when
+        # that Long accumulator overflows, whereas Spark 3 silently wraps around. To keep
+        # the aggregate from raising on large-magnitude/high-cardinality integral data
+        # under Spark 4, widen integral inputs to DoubleType before summing there. On
+        # Spark 3 we leave the input untouched so the observed value stays an integer,
+        # byte-identical to prior behavior.
+        integral_types = (
+            pyspark.types.ByteType,
+            pyspark.types.ShortType,
+            pyspark.types.IntegerType,
+            pyspark.types.LongType,
+        )
+        if (
+            pyspark.pyspark
+            and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0")
+            and _table is not None
+            and _column_name is not None
+            and isinstance(_table.schema[_column_name].dataType, integral_types)
+        ):
+            column = column.cast(pyspark.types.DoubleType())
         return F.sum(column)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
@@ -13,6 +13,9 @@ from great_expectations.execution_engine import (
     SparkDFExecutionEngine,
     SqlAlchemyExecutionEngine,
 )
+from great_expectations.expectations.metrics.column_map_metrics.column_values_between import (
+    _raise_if_invalid_column_type,
+)
 from great_expectations.expectations.metrics.metric_provider import (
     MetricProvider,
     metric_value,
@@ -209,7 +212,12 @@ class ColumnValuesBetweenCount(MetricProvider):
         ) = execution_engine.get_compute_domain(
             domain_kwargs=metric_domain_kwargs, domain_type=MetricDomainTypes.COLUMN
         )
-        column = F.col(accessor_domain_kwargs["column"])
+        column_name = accessor_domain_kwargs["column"]
+        column = F.col(column_name)
+
+        # Reject incomparable column types up front so an implicit string<->numeric
+        # comparison does not surface as an opaque engine error under ANSI mode.
+        _raise_if_invalid_column_type(str(df.schema[column_name].dataType))
 
         if min_value is not None and max_value is not None and min_value > max_value:
             raise ValueError("min_value cannot be greater than max_value")  # noqa: TRY003 # FIXME CoP

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
@@ -1,25 +1,35 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import numpy as np
 
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.util import get_sql_dialect_floating_point_infinity_value
 from great_expectations.execution_engine import (
+    ExecutionEngine,
     PandasExecutionEngine,
     SparkDFExecutionEngine,
     SqlAlchemyExecutionEngine,
 )
 from great_expectations.expectations.metrics.column_map_metrics.column_values_between import (
+    _column_type_from_metrics,
     _raise_if_invalid_column_type,
+    _should_reject_incomparable_spark_column_type,
 )
 from great_expectations.expectations.metrics.metric_provider import (
     MetricProvider,
     metric_value,
 )
+from great_expectations.validator.metric_configuration import MetricConfiguration
+
+if TYPE_CHECKING:
+    from great_expectations.expectations.expectation_configuration import (
+        ExpectationConfiguration,
+    )
 
 
 class ColumnValuesBetweenCount(MetricProvider):
@@ -32,6 +42,35 @@ class ColumnValuesBetweenCount(MetricProvider):
         "strict_min",
         "strict_max",
     )
+
+    @classmethod
+    @override
+    def _get_evaluation_dependencies(
+        cls,
+        metric: MetricConfiguration,
+        configuration: Optional[ExpectationConfiguration] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
+        runtime_configuration: Optional[dict] = None,
+    ):
+        dependencies: dict = super()._get_evaluation_dependencies(
+            metric=metric,
+            configuration=configuration,
+            execution_engine=execution_engine,
+            runtime_configuration=runtime_configuration,
+        )
+        # The Spark path resolves the column's type from this metric to decide whether an
+        # incomparable string<->numeric comparison must be rejected under ANSI mode.
+        table_domain_kwargs: dict = {
+            k: v for k, v in metric.metric_domain_kwargs.items() if k != "column"
+        }
+        dependencies["table.column_types"] = MetricConfiguration(
+            metric_name="table.column_types",
+            metric_domain_kwargs=table_domain_kwargs,
+            metric_value_kwargs={
+                "include_nested": True,
+            },
+        )
+        return dependencies
 
     @metric_value(engine=PandasExecutionEngine)
     def _pandas(  # noqa: C901, PLR0912 # FIXME CoP
@@ -216,8 +255,12 @@ class ColumnValuesBetweenCount(MetricProvider):
         column = F.col(column_name)
 
         # Reject incomparable column types up front so an implicit string<->numeric
-        # comparison does not surface as an opaque engine error under ANSI mode.
-        _raise_if_invalid_column_type(str(df.schema[column_name].dataType))
+        # comparison does not surface as an opaque engine error under ANSI mode. The type
+        # is resolved from the metric rather than df.schema[...] so a column name that
+        # Spark SQL would resolve case-insensitively does not raise a KeyError.
+        if _should_reject_incomparable_spark_column_type(min_value, max_value):
+            column_type = _column_type_from_metrics(metrics, column_name)
+            _raise_if_invalid_column_type(column_type)
 
         if min_value is not None and max_value is not None and min_value > max_value:
             raise ValueError("min_value cannot be greater than max_value")  # noqa: TRY003 # FIXME CoP

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_between.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_between.py
@@ -25,6 +25,42 @@ class InvalidColumnTypeError(ValueError):
         super().__init__(message)
 
 
+# Column types that cannot be meaningfully compared against numeric/date bounds.
+# Matched case-insensitively against the column's type name via startswith, which covers
+# both SQL type names (e.g. "VARCHAR") and Spark type reprs (e.g. "StringType()").
+INVALID_COLUMN_TYPES = (
+    "VARCHAR",
+    "CHAR",
+    "NVARCHAR",
+    "NCHAR",
+    "TEXT",
+    "STRING",
+    "BOOLEAN",
+    "BOOL",
+    "BIT",
+    "TINYTEXT",
+    "MEDIUMTEXT",
+    "LONGTEXT",
+)
+
+
+def _raise_if_invalid_column_type(column_type: Optional[str]) -> None:
+    """Raise InvalidColumnTypeError if the column type cannot be compared to numeric/date bounds.
+
+    Under engines that reject cross-type comparisons (e.g. Spark with ANSI enabled), an
+    implicit string<->numeric comparison would otherwise surface as an opaque engine error.
+    """
+    if column_type and column_type.upper().startswith(INVALID_COLUMN_TYPES):
+        raise InvalidColumnTypeError(column_type=column_type)
+
+
+def _column_type_from_metrics(metrics: dict, column_name: Optional[str]) -> Optional[str]:
+    """Look up a column's type name from the resolved table.column_types metric."""
+    column_types = metrics.get("table.column_types", [])
+    type_by_column = {ct.get("name"): str(ct.get("type", "")) for ct in column_types}
+    return type_by_column.get(column_name)
+
+
 class ColumnValuesBetween(ColumnMapMetricProvider):
     condition_metric_name = "column_values.between"
     condition_value_keys = (
@@ -179,30 +215,10 @@ class ColumnValuesBetween(ColumnMapMetricProvider):
         # ColumnValuesBetween metrics only work on numbers/dates,
         # so we check for common string and boolean types.
 
-        # Retrieve column types from metrics.
+        # Check that the comparison won't raise on an incomparable column type.
         metrics = kwargs.get("_metrics", {})
-        column_types = metrics.get("table.column_types", [])
-
-        # Map column names to their types as strings.
-        type_by_column = {ct.get("name"): str(ct.get("type", "")) for ct in column_types}
-        column_type = type_by_column.get(column.name)
-
-        INVALID_COLUMN_TYPES = (
-            "VARCHAR",
-            "CHAR",
-            "NVARCHAR",
-            "NCHAR",
-            "TEXT",
-            "STRING",
-            "BOOLEAN",
-            "BOOL",
-            "BIT",
-            "TINYTEXT",
-            "MEDIUMTEXT",
-            "LONGTEXT",
-        )
-        if column_type and column_type.upper().startswith(INVALID_COLUMN_TYPES):
-            raise InvalidColumnTypeError(column_type=column_type)
+        column_type = _column_type_from_metrics(metrics, column.name)
+        _raise_if_invalid_column_type(column_type)
 
         if min_value is None:
             if strict_max:
@@ -255,6 +271,13 @@ class ColumnValuesBetween(ColumnMapMetricProvider):
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")  # noqa: TRY003 # FIXME CoP
+
+        # Reject incomparable column types up front so an implicit string<->numeric
+        # comparison does not surface as an opaque engine error under ANSI mode.
+        metrics = kwargs.get("_metrics", {})
+        accessor_domain_kwargs = kwargs.get("_accessor_domain_kwargs", {})
+        column_type = _column_type_from_metrics(metrics, accessor_domain_kwargs.get("column"))
+        _raise_if_invalid_column_type(column_type)
 
         if min_value is None:
             if strict_max:

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_between.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_between.py
@@ -6,6 +6,8 @@ from typing import Optional, Union
 import pandas as pd
 from dateutil.parser import parse
 
+from great_expectations.compatibility import pyspark
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.execution_engine import (
@@ -59,6 +61,21 @@ def _column_type_from_metrics(metrics: dict, column_name: Optional[str]) -> Opti
     column_types = metrics.get("table.column_types", [])
     type_by_column = {ct.get("name"): str(ct.get("type", "")) for ct in column_types}
     return type_by_column.get(column_name)
+
+
+def _should_reject_incomparable_spark_column_type(min_value, max_value) -> bool:
+    """Decide whether an incomparable Spark column type should be rejected up front.
+
+    Only Spark 4 (and later) rejects an implicit string<->numeric comparison under ANSI
+    mode; earlier versions coerce instead of raising, so their results are left untouched
+    (byte-identical). Even under Spark 4, comparing a string/boolean column against string
+    bounds is a valid same-family comparison (e.g. ISO-date or version-string ranges), so
+    that case is not rejected -- only genuine string<->numeric comparisons are.
+    """
+    if not (pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0")):
+        return False
+    bounds = [b for b in (min_value, max_value) if b is not None]
+    return not (bounds and all(isinstance(b, str) for b in bounds))
 
 
 class ColumnValuesBetween(ColumnMapMetricProvider):
@@ -274,10 +291,11 @@ class ColumnValuesBetween(ColumnMapMetricProvider):
 
         # Reject incomparable column types up front so an implicit string<->numeric
         # comparison does not surface as an opaque engine error under ANSI mode.
-        metrics = kwargs.get("_metrics", {})
-        accessor_domain_kwargs = kwargs.get("_accessor_domain_kwargs", {})
-        column_type = _column_type_from_metrics(metrics, accessor_domain_kwargs.get("column"))
-        _raise_if_invalid_column_type(column_type)
+        if _should_reject_incomparable_spark_column_type(min_value, max_value):
+            metrics = kwargs.get("_metrics", {})
+            accessor_domain_kwargs = kwargs.get("_accessor_domain_kwargs", {})
+            column_type = _column_type_from_metrics(metrics, accessor_domain_kwargs.get("column"))
+            _raise_if_invalid_column_type(column_type)
 
         if min_value is None:
             if strict_max:

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_decreasing.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_decreasing.py
@@ -91,7 +91,22 @@ class ColumnValuesDecreasing(ColumnMapMetricProvider):
                 F.lag(column).over(pyspark.Window.orderBy(F.lit("constant"))),
             )
         else:
-            diff = column - F.lag(column).over(pyspark.Window.orderBy(F.lit("constant")))
+            # Widen integral columns to double before subtracting so the difference does
+            # not overflow a LongType accumulator at extreme opposite-sign boundaries
+            # under ANSI arithmetic. The sign of the difference (all that matters below)
+            # is unchanged for normal values, and non-integral types are left as-is.
+            integral_types = (
+                pyspark.types.ByteType,
+                pyspark.types.ShortType,
+                pyspark.types.IntegerType,
+                pyspark.types.LongType,
+            )
+            diff_column = (
+                column.cast(pyspark.types.DoubleType())
+                if isinstance(column_metadata["type"], integral_types)
+                else column
+            )
+            diff = diff_column - F.lag(diff_column).over(pyspark.Window.orderBy(F.lit("constant")))
             diff = F.when(diff.isNull(), -1).otherwise(diff)
 
         # NOTE: because in spark we are implementing the window function directly,

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_decreasing.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_decreasing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from great_expectations.compatibility import pyspark
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
@@ -91,21 +92,26 @@ class ColumnValuesDecreasing(ColumnMapMetricProvider):
                 F.lag(column).over(pyspark.Window.orderBy(F.lit("constant"))),
             )
         else:
-            # Widen integral columns to double before subtracting so the difference does
-            # not overflow a LongType accumulator at extreme opposite-sign boundaries
-            # under ANSI arithmetic. The sign of the difference (all that matters below)
-            # is unchanged for normal values, and non-integral types are left as-is.
-            integral_types = (
-                pyspark.types.ByteType,
-                pyspark.types.ShortType,
-                pyspark.types.IntegerType,
-                pyspark.types.LongType,
-            )
-            diff_column = (
-                column.cast(pyspark.types.DoubleType())
-                if isinstance(column_metadata["type"], integral_types)
-                else column
-            )
+            # Subtracting adjacent integral values can overflow a LongType accumulator at
+            # extreme opposite-sign boundaries. Spark 4 evaluates arithmetic under ANSI
+            # semantics by default and raises ARITHMETIC_OVERFLOW there, whereas Spark 3
+            # silently wraps. On Spark 4 widen integral columns to an exact wide DECIMAL
+            # before subtracting so the difference (its sign is all that matters below) is
+            # computed without overflow and without the precision loss a DoubleType would
+            # introduce above 2**53. On Spark 3 the column is left untouched so results
+            # stay byte-identical.
+            diff_column = column
+            if pyspark.pyspark and is_version_greater_or_equal(
+                pyspark.pyspark.__version__, "4.0.0"
+            ):
+                integral_types = (
+                    pyspark.types.ByteType,
+                    pyspark.types.ShortType,
+                    pyspark.types.IntegerType,
+                    pyspark.types.LongType,
+                )
+                if isinstance(column_metadata["type"], integral_types):
+                    diff_column = column.cast(pyspark.types.DecimalType(38, 0))
             diff = diff_column - F.lag(diff_column).over(pyspark.Window.orderBy(F.lit("constant")))
             diff = F.when(diff.isNull(), -1).otherwise(diff)
 

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_increasing.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_increasing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from great_expectations.compatibility import pyspark
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
@@ -97,21 +98,26 @@ class ColumnValuesIncreasing(ColumnMapMetricProvider):
                 F.lag(column).over(pyspark.Window.orderBy(F.lit("constant"))),
             )
         else:
-            # Widen integral columns to double before subtracting so the difference does
-            # not overflow a LongType accumulator at extreme opposite-sign boundaries
-            # under ANSI arithmetic. The sign of the difference (all that matters below)
-            # is unchanged for normal values, and non-integral types are left as-is.
-            integral_types = (
-                pyspark.types.ByteType,
-                pyspark.types.ShortType,
-                pyspark.types.IntegerType,
-                pyspark.types.LongType,
-            )
-            diff_column = (
-                column.cast(pyspark.types.DoubleType())
-                if isinstance(column_metadata["type"], integral_types)
-                else column
-            )
+            # Subtracting adjacent integral values can overflow a LongType accumulator at
+            # extreme opposite-sign boundaries. Spark 4 evaluates arithmetic under ANSI
+            # semantics by default and raises ARITHMETIC_OVERFLOW there, whereas Spark 3
+            # silently wraps. On Spark 4 widen integral columns to an exact wide DECIMAL
+            # before subtracting so the difference (its sign is all that matters below) is
+            # computed without overflow and without the precision loss a DoubleType would
+            # introduce above 2**53. On Spark 3 the column is left untouched so results
+            # stay byte-identical.
+            diff_column = column
+            if pyspark.pyspark and is_version_greater_or_equal(
+                pyspark.pyspark.__version__, "4.0.0"
+            ):
+                integral_types = (
+                    pyspark.types.ByteType,
+                    pyspark.types.ShortType,
+                    pyspark.types.IntegerType,
+                    pyspark.types.LongType,
+                )
+                if isinstance(column_metadata["type"], integral_types):
+                    diff_column = column.cast(pyspark.types.DecimalType(38, 0))
             diff = diff_column - F.lag(diff_column).over(pyspark.Window.orderBy(F.lit("constant")))
             diff = F.when(diff.isNull(), 1).otherwise(diff)
 

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_increasing.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_increasing.py
@@ -97,7 +97,22 @@ class ColumnValuesIncreasing(ColumnMapMetricProvider):
                 F.lag(column).over(pyspark.Window.orderBy(F.lit("constant"))),
             )
         else:
-            diff = column - F.lag(column).over(pyspark.Window.orderBy(F.lit("constant")))
+            # Widen integral columns to double before subtracting so the difference does
+            # not overflow a LongType accumulator at extreme opposite-sign boundaries
+            # under ANSI arithmetic. The sign of the difference (all that matters below)
+            # is unchanged for normal values, and non-integral types are left as-is.
+            integral_types = (
+                pyspark.types.ByteType,
+                pyspark.types.ShortType,
+                pyspark.types.IntegerType,
+                pyspark.types.LongType,
+            )
+            diff_column = (
+                column.cast(pyspark.types.DoubleType())
+                if isinstance(column_metadata["type"], integral_types)
+                else column
+            )
+            diff = diff_column - F.lag(diff_column).over(pyspark.Window.orderBy(F.lit("constant")))
             diff = F.when(diff.isNull(), 1).otherwise(diff)
 
         # NOTE: because in spark we are implementing the window function directly,

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
@@ -88,13 +88,13 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
         mean = _metrics["column.mean"]
         standard_deviation = _metrics["column.standard_deviation"]
 
-        # Guard against division by zero (constant column -> standard_deviation == 0).
-        # Returning null keeps the z-score undefined rather than producing Infinity and
-        # avoids a divide-by-zero error where the engine treats it as one.
-        return F.when(
-            F.lit(standard_deviation) != 0,
-            (column - mean) / standard_deviation,
-        ).otherwise(F.lit(None))
+        # standard_deviation is an already-resolved Python scalar, so the divide-by-zero
+        # (constant column) and undefined (None) cases can be decided here rather than
+        # per row. Dividing by zero would yield Infinity (or raise under ANSI), so return
+        # a null z-score in those cases.
+        if standard_deviation is None or standard_deviation == 0:
+            return F.lit(None)
+        return (column - mean) / standard_deviation
 
     @column_condition_partial(engine=SparkDFExecutionEngine)
     def _spark_condition(cls, column, _metrics, threshold, double_sided, **kwargs):

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
@@ -88,7 +88,13 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
         mean = _metrics["column.mean"]
         standard_deviation = _metrics["column.standard_deviation"]
 
-        return (column - mean) / standard_deviation
+        # Guard against division by zero (constant column -> standard_deviation == 0).
+        # Returning null keeps the z-score undefined rather than producing Infinity and
+        # avoids a divide-by-zero error where the engine treats it as one.
+        return F.when(
+            F.lit(standard_deviation) != 0,
+            (column - mean) / standard_deviation,
+        ).otherwise(F.lit(None))
 
     @column_condition_partial(engine=SparkDFExecutionEngine)
     def _spark_condition(cls, column, _metrics, threshold, double_sided, **kwargs):

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -833,12 +833,25 @@ def _spark_map_condition_query(
         _,
     ) = metrics.get("unexpected_condition", (None, None, None))
 
-    # unexpected_condition is an F.column object, meaning the str representation is wrapped in Column<> syntax.  # noqa: E501 # FIXME CoP
-    # like Column<'[unexpected_expression]'>
+    # unexpected_condition is a Column object whose str representation is wrapped in
+    # Column<'...'> syntax, e.g. Column<'[unexpected_expression]'>.
+    # Strip that wrapper generically. Spark renders the inner expression differently
+    # across versions (Spark 3 uses infix, e.g. "(a AND b)"; Spark 4 uses a
+    # function-prefix grammar, e.g. "and(a, b)"), so we cannot assume the leading
+    # "Column<'" is followed by a "(".
     unexpected_condition_as_string: str = str(unexpected_condition)
-    unexpected_condition_filtered: str = unexpected_condition_as_string.replace(
-        "Column<'(", ""
-    ).replace(")'>", "")
+    unexpected_condition_filtered: str = unexpected_condition_as_string
+    if unexpected_condition_filtered.startswith("Column<'"):
+        unexpected_condition_filtered = unexpected_condition_filtered[len("Column<'") :]
+    if unexpected_condition_filtered.endswith("'>"):
+        unexpected_condition_filtered = unexpected_condition_filtered[:-2]
+    # Spark 3 wraps the whole condition in one extra outer paren pair; strip it so the
+    # rendered query matches the historical output. The Spark 4 prefix grammar starts
+    # with a function name (never "("), so this leaves it untouched.
+    if unexpected_condition_filtered.startswith("(") and unexpected_condition_filtered.endswith(
+        ")"
+    ):
+        unexpected_condition_filtered = unexpected_condition_filtered[1:-1]
     return f"df.filter(F.expr({unexpected_condition_filtered}))"
 
 

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -847,7 +847,9 @@ def _spark_map_condition_query(
         unexpected_condition_filtered = unexpected_condition_filtered[:-2]
     # Spark 3 wraps the whole condition in one extra outer paren pair; strip it so the
     # rendered query matches the historical output. The Spark 4 prefix grammar starts
-    # with a function name (never "("), so this leaves it untouched.
+    # with a function name (never "("), so this leaves it untouched. This assumes the
+    # top-level expression is fully parenthesized as a single group (true for the
+    # conditions GX builds); it is a harmless display-only heuristic.
     if unexpected_condition_filtered.startswith("(") and unexpected_condition_filtered.endswith(
         ")"
     ):

--- a/great_expectations/expectations/metrics/multicolumn_map_metrics/multicolumn_sum_equal.py
+++ b/great_expectations/expectations/metrics/multicolumn_map_metrics/multicolumn_sum_equal.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from great_expectations.compatibility import pyspark
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
@@ -41,12 +43,33 @@ class MulticolumnSumEqual(MulticolumnMapMetricProvider):
     @multicolumn_condition_partial(engine=SparkDFExecutionEngine)
     def _spark(cls, column_list, **kwargs):
         sum_total = kwargs.get("sum_total")
-        # Widen each operand to DOUBLE before summing so the addition accumulates in a
-        # wide type instead of overflowing an integral/decimal accumulator near its type
-        # bounds. Compare against a DOUBLE literal for the same reason. For the value
-        # ranges these checks target this preserves the equality result.
-        expression = "+".join(
-            [f"CAST(COALESCE({column_name}, 0) AS DOUBLE)" for column_name in column_list.columns]
-        )
-        row_wise_cond = F.expr(expression) == F.lit(sum_total).cast("double")
+        if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0"):
+            # Spark 4 evaluates arithmetic under ANSI semantics by default and raises
+            # ARITHMETIC_OVERFLOW when an integral (Long) accumulator overflows, whereas
+            # Spark 3 silently wraps. Widen only integral operands to an exact wide DECIMAL
+            # so the row-wise sum cannot overflow. Decimal and floating operands are left
+            # untouched so exact decimal equality (e.g. 0.1 + 0.2 == 0.3) is preserved and
+            # floating sums keep their usual semantics (floats do not raise under ANSI).
+            integral_types = (
+                pyspark.types.ByteType,
+                pyspark.types.ShortType,
+                pyspark.types.IntegerType,
+                pyspark.types.LongType,
+            )
+            operands = []
+            for column_name in column_list.columns:
+                coalesced = f"COALESCE(`{column_name}`, 0)"
+                if isinstance(column_list.schema[column_name].dataType, integral_types):
+                    operands.append(f"CAST({coalesced} AS DECIMAL(38, 0))")
+                else:
+                    operands.append(coalesced)
+            expression = "+".join(operands)
+            row_wise_cond = F.expr(expression) == F.lit(sum_total)
+        else:
+            # Spark 3 wraps integral overflow rather than raising, so keep the original
+            # unwidened sum and literal comparison to preserve byte-identical results.
+            expression = "+".join(
+                [f"COALESCE({column_name}, 0)" for column_name in column_list.columns]
+            )
+            row_wise_cond = F.expr(expression) == F.lit(sum_total)
         return row_wise_cond

--- a/great_expectations/expectations/metrics/multicolumn_map_metrics/multicolumn_sum_equal.py
+++ b/great_expectations/expectations/metrics/multicolumn_map_metrics/multicolumn_sum_equal.py
@@ -41,8 +41,12 @@ class MulticolumnSumEqual(MulticolumnMapMetricProvider):
     @multicolumn_condition_partial(engine=SparkDFExecutionEngine)
     def _spark(cls, column_list, **kwargs):
         sum_total = kwargs.get("sum_total")
+        # Widen each operand to DOUBLE before summing so the addition accumulates in a
+        # wide type instead of overflowing an integral/decimal accumulator near its type
+        # bounds. Compare against a DOUBLE literal for the same reason. For the value
+        # ranges these checks target this preserves the equality result.
         expression = "+".join(
-            [f"COALESCE({column_name}, 0)" for column_name in column_list.columns]
+            [f"CAST(COALESCE({column_name}, 0) AS DOUBLE)" for column_name in column_list.columns]
         )
-        row_wise_cond = F.expr(expression) == F.lit(sum_total)
+        row_wise_cond = F.expr(expression) == F.lit(sum_total).cast("double")
         return row_wise_cond

--- a/reqs/requirements-dev-spark-connect.txt
+++ b/reqs/requirements-dev-spark-connect.txt
@@ -6,3 +6,6 @@
 googleapis-common-protos>=1.56.4
 grpcio>=1.48.1
 grpcio-status>=1.48.1
+# pyspark 4.1's Spark Connect client hard-requires zstandard; without it the
+# connect client fails at import with [PACKAGE_NOT_INSTALLED]. Harmless on older Spark.
+zstandard>=0.25.0

--- a/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
+++ b/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
@@ -3,9 +3,20 @@ from typing import TYPE_CHECKING, Dict, Tuple
 import pandas as pd
 import pytest
 
+from great_expectations.compatibility import pyspark
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypeSuffixes,
     SummarizationMetricNameSuffixes,
+)
+
+# Spark 4 changed Column's string grammar from infix ("(a AND b)", "a IN (...)") to a
+# function-prefix form ("and(a, b)", "in(a, ...)"), so the rendered unexpected-index
+# query legitimately differs by pyspark version.
+_SPARK_IN_SET_UNEXPECTED_INDEX_QUERY = (
+    "df.filter(F.expr(and(isNotNull(animals), !(in(animals, 'cat', 'fish', 'dog')))))"
+    if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0")
+    else "df.filter(F.expr((animals IS NOT NULL) AND (NOT (animals IN (cat, fish, dog)))))"
 )
 from great_expectations.self_check.util import (
     build_pandas_engine,
@@ -724,10 +735,7 @@ def test_spark_unexpected_index_query_metric_with_id_pk(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for val in results.values():
-        assert (
-            val
-            == "df.filter(F.expr((animals IS NOT NULL) AND (NOT (animals IN (cat, fish, dog)))))"
-        )
+        assert val == _SPARK_IN_SET_UNEXPECTED_INDEX_QUERY
 
 
 @pytest.mark.spark
@@ -766,7 +774,4 @@ def test_spark_unexpected_index_query_metric_without_id_pk(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for val in results.values():
-        assert (
-            val
-            == "df.filter(F.expr((animals IS NOT NULL) AND (NOT (animals IN (cat, fish, dog)))))"
-        )
+        assert val == _SPARK_IN_SET_UNEXPECTED_INDEX_QUERY

--- a/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
+++ b/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
@@ -9,6 +9,13 @@ from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypeSuffixes,
     SummarizationMetricNameSuffixes,
 )
+from great_expectations.self_check.util import (
+    build_pandas_engine,
+    build_sa_execution_engine,
+    build_spark_engine,
+)
+from great_expectations.validator.metric_configuration import MetricConfiguration
+from tests.expectations.test_util import get_table_columns_metric
 
 # Spark 4 changed Column's string grammar from infix ("(a AND b)", "a IN (...)") to a
 # function-prefix form ("and(a, b)", "in(a, ...)"), so the rendered unexpected-index
@@ -18,13 +25,6 @@ _SPARK_IN_SET_UNEXPECTED_INDEX_QUERY = (
     if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0")
     else "df.filter(F.expr((animals IS NOT NULL) AND (NOT (animals IN (cat, fish, dog)))))"
 )
-from great_expectations.self_check.util import (
-    build_pandas_engine,
-    build_sa_execution_engine,
-    build_spark_engine,
-)
-from great_expectations.validator.metric_configuration import MetricConfiguration
-from tests.expectations.test_util import get_table_columns_metric
 
 if TYPE_CHECKING:
     from great_expectations.execution_engine import (

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -10,6 +10,7 @@ import pytest
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import pyspark, sqlalchemy
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
@@ -165,6 +166,73 @@ def test_column_sum_metric_spark(spark_session, dataframe, expected_result):
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,), metrics=results)
 
     assert results == {desired_metric.id: expected_result}
+
+
+def _resolve_spark_column_sum(engine, column="a"):
+    """Resolve the ``column.sum`` metric for a Spark engine and return its value."""
+    table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
+
+    aggregate_fn_metric = MetricConfiguration(
+        metric_name=f"column.sum.{MetricPartialFunctionTypes.AGGREGATE_FN.metric_suffix}",
+        metric_domain_kwargs={"column": column},
+        metric_value_kwargs=None,
+    )
+    aggregate_fn_metric.metric_dependencies = {"table.columns": table_columns_metric}
+    results = engine.resolve_metrics(metrics_to_resolve=(aggregate_fn_metric,))
+
+    desired_metric = MetricConfiguration(
+        metric_name="column.sum",
+        metric_domain_kwargs={},
+        metric_value_kwargs=None,
+    )
+    desired_metric.metric_dependencies = {"metric_partial_fn": aggregate_fn_metric}
+    results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,), metrics=results)
+    return results[desired_metric.id]
+
+
+@pytest.mark.spark
+def test_column_sum_metric_spark_longtype_preserves_integer_type(spark_session):
+    # A genuine LongType, no-null column must keep an *integer* observed value on
+    # Spark 3, byte-identical to prior behavior. Spark 4 evaluates the Long
+    # accumulator under ANSI semantics and raises ARITHMETIC_OVERFLOW on overflow
+    # (Spark 3 silently wraps), so integral inputs are widened to DoubleType before
+    # summing there and the value legitimately surfaces as a float.
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("a", pyspark.types.LongType(), nullable=False)]
+    )
+    spark_df = spark_session.createDataFrame([(1,), (2,), (3,)], schema=schema)
+    engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
+
+    observed_value = _resolve_spark_column_sum(engine)
+
+    assert observed_value == 6
+    if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0"):
+        assert isinstance(observed_value, float)
+    else:
+        assert isinstance(observed_value, int) and not isinstance(observed_value, bool)
+
+
+@pytest.mark.spark
+def test_column_sum_metric_spark_longtype_overflow_does_not_raise(spark_session):
+    # Long-overflow-prone integral input: on Spark 4 the double-widening keeps the
+    # ANSI-mode aggregate from raising ARITHMETIC_OVERFLOW and yields the true
+    # (non-wrapped) magnitude; Spark 3 silently wraps the Long accumulator. Either
+    # way the computation must complete without raising.
+    max_long = 9223372036854775807
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("a", pyspark.types.LongType(), nullable=False)]
+    )
+    spark_df = spark_session.createDataFrame([(max_long,), (max_long,)], schema=schema)
+    engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
+
+    observed_value = _resolve_spark_column_sum(engine)
+
+    if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0"):
+        # Widened to double, so no overflow and the true magnitude is preserved.
+        assert observed_value == pytest.approx(float(2 * max_long))
+    else:
+        # Spark 3 wraps the Long accumulator rather than raising; assert it completed.
+        assert observed_value is not None
 
 
 @pytest.mark.big

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -2220,6 +2220,147 @@ def test_map_column_values_increasing_spark(spark_session):
     ]
 
 
+def _resolve_strictly_monotonic_unexpected_count(engine, metric_stem: str):
+    """Resolve the unexpected count for a strictly increasing/decreasing metric."""
+    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+
+    table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
+    metrics.update(results)
+
+    table_column_types = MetricConfiguration(
+        metric_name="table.column_types",
+        metric_domain_kwargs={},
+        metric_value_kwargs={"include_nested": True},
+    )
+    results = engine.resolve_metrics(metrics_to_resolve=(table_column_types,), metrics=metrics)
+    metrics.update(results)
+
+    condition_metric = MetricConfiguration(
+        metric_name=f"{metric_stem}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs={"strictly": True},
+    )
+    condition_metric.metric_dependencies = {
+        "table.columns": table_columns_metric,
+        "table.column_types": table_column_types,
+    }
+    results = engine.resolve_metrics(metrics_to_resolve=(condition_metric,), metrics=metrics)
+    metrics.update(results)
+
+    unexpected_count_metric = MetricConfiguration(
+        metric_name=f"{metric_stem}.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    unexpected_count_metric.metric_dependencies = {
+        "unexpected_condition": condition_metric,
+        "table.columns": table_columns_metric,
+    }
+    results = engine.resolve_metrics(metrics_to_resolve=(unexpected_count_metric,), metrics=metrics)
+    metrics.update(results)
+    return metrics[unexpected_count_metric.id]
+
+
+@pytest.mark.spark
+def test_map_column_values_increasing_spark_large_longs(spark_session):
+    # Adjacent Long values above 2**53 that differ by 1 cannot be distinguished once
+    # widened to DoubleType (their difference collapses to 0), which would wrongly flag a
+    # strictly-increasing column as having an unexpected (non-increasing) row. An exact
+    # wide DECIMAL preserves the true difference, so no rows are unexpected on either
+    # Spark version.
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("a", pyspark.types.LongType(), nullable=False)]
+    )
+    spark_df = spark_session.createDataFrame([(2**60,), (2**60 + 1,)], schema=schema)
+    engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
+
+    unexpected_count = _resolve_strictly_monotonic_unexpected_count(
+        engine, "column_values.increasing"
+    )
+
+    assert unexpected_count == 0
+
+
+@pytest.mark.spark
+def test_map_column_values_decreasing_spark_large_longs(spark_session):
+    # Mirror of the increasing case: adjacent Long values above 2**53 differing by 1 must
+    # keep their exact difference so a strictly-decreasing column is not wrongly flagged.
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("a", pyspark.types.LongType(), nullable=False)]
+    )
+    spark_df = spark_session.createDataFrame([(2**60 + 1,), (2**60,)], schema=schema)
+    engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
+
+    unexpected_count = _resolve_strictly_monotonic_unexpected_count(
+        engine, "column_values.decreasing"
+    )
+
+    assert unexpected_count == 0
+
+
+@pytest.mark.spark
+def test_map_column_values_between_spark_string_column_string_bounds(spark_session):
+    # Comparing a string column against string bounds is a valid same-family comparison
+    # (e.g. ISO-date or version-string ranges) and must not be rejected as an incomparable
+    # type. It stays valid under Spark 4 ANSI as well, so no rows are unexpected on either
+    # Spark version.
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("s", pyspark.types.StringType(), nullable=False)]
+    )
+    spark_df = spark_session.createDataFrame([("a",), ("b",), ("c",), ("d",)], schema=schema)
+    engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
+
+    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+
+    table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
+    metrics.update(results)
+
+    table_column_types = MetricConfiguration(
+        metric_name="table.column_types",
+        metric_domain_kwargs={},
+        metric_value_kwargs={"include_nested": True},
+    )
+    results = engine.resolve_metrics(metrics_to_resolve=(table_column_types,), metrics=metrics)
+    metrics.update(results)
+
+    condition_metric = MetricConfiguration(
+        metric_name=f"column_values.between.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
+        metric_domain_kwargs={"column": "s"},
+        metric_value_kwargs={
+            "min_value": "a",
+            "max_value": "z",
+            "strict_min": False,
+            "strict_max": False,
+        },
+    )
+    condition_metric.metric_dependencies = {
+        "table.columns": table_columns_metric,
+        "table.column_types": table_column_types,
+    }
+    results = engine.resolve_metrics(metrics_to_resolve=(condition_metric,), metrics=metrics)
+    metrics.update(results)
+
+    aggregate_fn_metric = MetricConfiguration(
+        metric_name=f"column_values.between.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}.{MetricPartialFunctionTypes.AGGREGATE_FN.metric_suffix}",
+        metric_domain_kwargs={"column": "s"},
+        metric_value_kwargs=None,
+    )
+    aggregate_fn_metric.metric_dependencies = {"unexpected_condition": condition_metric}
+    results = engine.resolve_metrics(metrics_to_resolve=(aggregate_fn_metric,), metrics=metrics)
+    metrics.update(results)
+
+    unexpected_count_metric = MetricConfiguration(
+        metric_name=f"column_values.between.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}",
+        metric_domain_kwargs={"column": "s"},
+        metric_value_kwargs=None,
+    )
+    unexpected_count_metric.metric_dependencies = {"metric_partial_fn": aggregate_fn_metric}
+    results = engine.resolve_metrics(metrics_to_resolve=(unexpected_count_metric,), metrics=metrics)
+    metrics.update(results)
+
+    assert metrics[unexpected_count_metric.id] == 0
+
+
 @pytest.mark.big
 @pytest.mark.filterwarnings(
     "ignore:pandas.Int64Index is deprecated*:FutureWarning:tests.expectations.metrics"
@@ -2943,6 +3084,113 @@ def test_z_score_under_threshold_spark(spark_session):
     }
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,), metrics=metrics)
     assert results[desired_metric.id] == 0
+
+
+@pytest.mark.spark
+def test_z_score_under_threshold_spark_constant_column(spark_session):
+    # A constant column has a standard deviation of zero. Dividing by it would yield
+    # Infinity (or raise under ANSI arithmetic), so the z-score must resolve to null for
+    # every row -- producing no unexpected values and no error on either Spark version.
+    engine: SparkDFExecutionEngine = build_spark_engine(
+        spark=spark_session,
+        df=pd.DataFrame({"a": [5, 5, 5, 5]}),
+        batch_id="my_id",
+    )
+
+    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+
+    table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
+    metrics.update(results)
+
+    column_mean_aggregate_fn_metric = MetricConfiguration(
+        metric_name=f"column.mean.{MetricPartialFunctionTypes.AGGREGATE_FN.metric_suffix}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    column_mean_aggregate_fn_metric.metric_dependencies = {
+        "table.columns": table_columns_metric,
+    }
+    column_standard_deviation_aggregate_fn_metric = MetricConfiguration(
+        metric_name=f"column.standard_deviation.{MetricPartialFunctionTypes.AGGREGATE_FN.metric_suffix}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    column_standard_deviation_aggregate_fn_metric.metric_dependencies = {
+        "table.columns": table_columns_metric,
+    }
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(
+            column_mean_aggregate_fn_metric,
+            column_standard_deviation_aggregate_fn_metric,
+        ),
+        metrics=metrics,
+    )
+    metrics.update(results)
+
+    mean = MetricConfiguration(
+        metric_name="column.mean",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    mean.metric_dependencies = {"metric_partial_fn": column_mean_aggregate_fn_metric}
+    stdev = MetricConfiguration(
+        metric_name="column.standard_deviation",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    stdev.metric_dependencies = {
+        "metric_partial_fn": column_standard_deviation_aggregate_fn_metric,
+        "table.columns": table_columns_metric,
+    }
+    results = engine.resolve_metrics(metrics_to_resolve=(mean, stdev), metrics=metrics)
+    metrics.update(results)
+
+    # Confirm the constant column really does have a zero standard deviation.
+    assert metrics[stdev.id] == 0
+
+    z_score_map_metric = MetricConfiguration(
+        metric_name=f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    z_score_map_metric.metric_dependencies = {
+        "column.standard_deviation": stdev,
+        "column.mean": mean,
+        "table.columns": table_columns_metric,
+    }
+    results = engine.resolve_metrics(metrics_to_resolve=(z_score_map_metric,), metrics=metrics)
+    metrics.update(results)
+
+    condition_metric = MetricConfiguration(
+        metric_name=f"column_values.z_score.under_threshold.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs={"double_sided": True, "threshold": 2},
+    )
+    condition_metric.metric_dependencies = {
+        f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}": z_score_map_metric,
+        "table.columns": table_columns_metric,
+    }
+    results = engine.resolve_metrics(metrics_to_resolve=(condition_metric,), metrics=metrics)
+    metrics.update(results)
+
+    aggregate_fn_metric = MetricConfiguration(
+        metric_name=f"column_values.z_score.under_threshold.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}.{MetricPartialFunctionTypes.AGGREGATE_FN.metric_suffix}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs={"double_sided": True, "threshold": 2},
+    )
+    aggregate_fn_metric.metric_dependencies = {"unexpected_condition": condition_metric}
+    results = engine.resolve_metrics(metrics_to_resolve=(aggregate_fn_metric,), metrics=metrics)
+    metrics.update(results)
+
+    unexpected_count_metric = MetricConfiguration(
+        metric_name=f"column_values.z_score.under_threshold.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs={"double_sided": True, "threshold": 2},
+    )
+    unexpected_count_metric.metric_dependencies = {"metric_partial_fn": aggregate_fn_metric}
+    results = engine.resolve_metrics(metrics_to_resolve=(unexpected_count_metric,), metrics=metrics)
+
+    assert results[unexpected_count_metric.id] == 0
 
 
 @pytest.mark.unit
@@ -5559,6 +5807,85 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915 # FIXM
 
     assert len(metrics[unexpected_values_metric.id]) == 1
     assert metrics[unexpected_values_metric.id] == [{"a": 2, "b": 3, "c": 1}]
+
+
+def _resolve_multicolumn_sum_equal_unexpected_count(engine, column_list, sum_total):
+    """Resolve the unexpected count for multicolumn_sum.equal over the given columns."""
+    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+
+    table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
+    metrics.update(results)
+
+    condition_metric = MetricConfiguration(
+        metric_name=f"multicolumn_sum.equal.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
+        metric_domain_kwargs={"column_list": column_list},
+        metric_value_kwargs={"sum_total": sum_total},
+    )
+    condition_metric.metric_dependencies = {"table.columns": table_columns_metric}
+    results = engine.resolve_metrics(metrics_to_resolve=(condition_metric,), metrics=metrics)
+    metrics.update(results)
+
+    unexpected_count_metric = MetricConfiguration(
+        metric_name=f"multicolumn_sum.equal.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}",
+        metric_domain_kwargs={"column_list": column_list},
+        metric_value_kwargs=None,
+    )
+    unexpected_count_metric.metric_dependencies = {
+        "unexpected_condition": condition_metric,
+        "table.columns": table_columns_metric,
+    }
+    results = engine.resolve_metrics(metrics_to_resolve=(unexpected_count_metric,), metrics=metrics)
+    metrics.update(results)
+    return metrics[unexpected_count_metric.id]
+
+
+@pytest.mark.spark
+def test_map_multicolumn_sum_equal_spark_large_longs(spark_session):
+    # Summing large integral operands must not overflow the Long accumulator. Under Spark
+    # 4 ANSI arithmetic an overflowing Long sum raises ARITHMETIC_OVERFLOW; widening
+    # integral operands to an exact wide DECIMAL lets the equality resolve correctly. On
+    # Spark 3 the original Long arithmetic wraps around instead (its historical behavior),
+    # so the check is only asserted exact on Spark 4.
+    schema = pyspark.types.StructType(
+        [
+            pyspark.types.StructField("a", pyspark.types.LongType(), nullable=False),
+            pyspark.types.StructField("b", pyspark.types.LongType(), nullable=False),
+        ]
+    )
+    spark_df = spark_session.createDataFrame([(2**62, 2**62)], schema=schema)
+    engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
+
+    unexpected_count = _resolve_multicolumn_sum_equal_unexpected_count(
+        engine, ["a", "b"], Decimal(2**63)
+    )
+
+    if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0"):
+        # Widened to DECIMAL: the sum equals 2**63 exactly and does not raise.
+        assert unexpected_count == 0
+    else:
+        # Spark 3 wraps the Long accumulator rather than raising; assert it completed.
+        assert isinstance(unexpected_count, int)
+
+
+@pytest.mark.spark
+def test_map_multicolumn_sum_equal_spark_decimal_operands(spark_session):
+    # Decimal operands must be summed exactly. Widening them to DOUBLE would reintroduce
+    # binary floating error (0.1 + 0.2 != 0.3), wrongly flagging the row as unexpected.
+    # Leaving decimals uncast keeps the equality exact on both Spark versions.
+    schema = pyspark.types.StructType(
+        [
+            pyspark.types.StructField("a", pyspark.types.DecimalType(2, 1), nullable=False),
+            pyspark.types.StructField("b", pyspark.types.DecimalType(2, 1), nullable=False),
+        ]
+    )
+    spark_df = spark_session.createDataFrame([(Decimal("0.1"), Decimal("0.2"))], schema=schema)
+    engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
+
+    unexpected_count = _resolve_multicolumn_sum_equal_unexpected_count(
+        engine, ["a", "b"], Decimal("0.3")
+    )
+
+    assert unexpected_count == 0
 
 
 @pytest.mark.big

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -4,7 +4,8 @@ import pandas as pd
 import pytest
 
 import great_expectations.expectations as gxe
-from great_expectations.compatibility import sqlalchemy
+from great_expectations.compatibility import pyspark, sqlalchemy
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
@@ -41,6 +42,15 @@ from great_expectations.expectations.metrics.map_metric_provider import (
 from great_expectations.util import convert_to_json_serializable
 from great_expectations.validator.validation_graph import MetricConfiguration
 from great_expectations.validator.validator import Validator
+
+# Spark 4 changed Column's string grammar from infix ("(a AND b)", "a IN (...)") to a
+# function-prefix form ("and(a, b)", "in(a, ...)"), so the rendered unexpected-index
+# query legitimately differs by pyspark version.
+_SPARK_IN_SET_UNEXPECTED_INDEX_QUERY = (
+    "df.filter(F.expr(and(isNotNull(animals), !(in(animals, 'cat', 'fish', 'dog')))))"
+    if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0")
+    else "df.filter(F.expr((animals IS NOT NULL) AND (NOT (animals IN (cat, fish, dog)))))"
+)
 
 
 @pytest.fixture
@@ -730,8 +740,7 @@ def test_spark_single_column_complete_result_format(
         ],
         "partial_unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_count": 3,
-        "unexpected_index_query": "df.filter(F.expr((animals IS NOT NULL) AND (NOT "
-        "(animals IN (cat, fish, dog)))))",
+        "unexpected_index_query": _SPARK_IN_SET_UNEXPECTED_INDEX_QUERY,
         "unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_percent": 50.0,
         "unexpected_percent_nonmissing": 50.0,
@@ -802,8 +811,7 @@ def test_spark_single_column_complete_result_format_with_id_pk(
             {"animals": "lion", "pk_1": 4},
             {"animals": "zebra", "pk_1": 5},
         ],
-        "unexpected_index_query": "df.filter(F.expr((animals IS NOT NULL) AND (NOT "
-        "(animals IN (cat, fish, dog)))))",
+        "unexpected_index_query": _SPARK_IN_SET_UNEXPECTED_INDEX_QUERY,
         "unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_percent": 50.0,
         "unexpected_percent_nonmissing": 50.0,

--- a/tests/expectations/test_row_conditions.py
+++ b/tests/expectations/test_row_conditions.py
@@ -81,13 +81,26 @@ def test_parse_condition_to_spark(spark_session):
     res = parse_condition_to_spark('col("foo") > 5')
     # This is mostly a demonstrative test; it may be brittle. I do not know how to test
     # a condition itself.
-    assert str(res) in ["Column<b'(foo > 5)'>", "Column<'(foo > 5)'>"]
+    # Spark renders Column reprs differently across versions: older Spark uses a
+    # byte-string prefix and infix operators, Spark 4 drops the prefix and renders
+    # comparisons in function-prefix form (">(foo, 5)").
+    assert str(res) in [
+        "Column<b'(foo > 5)'>",
+        "Column<'(foo > 5)'>",
+        "Column<'>(foo, 5)'>",
+    ]
 
     res = parse_condition_to_spark('col("foo").notNull()')
     # This is mostly a demonstrative test; it may be brittle. I do not know how to test
     # a condition itself.
     print(str(res))
-    assert str(res) in ["Column<b'(foo IS NOT NULL)'>", "Column<'(foo IS NOT NULL)'>"]
+    # Spark 4 renders the null check in function-prefix form ("isNotNull(foo)")
+    # rather than the older infix "(foo IS NOT NULL)".
+    assert str(res) in [
+        "Column<b'(foo IS NOT NULL)'>",
+        "Column<'(foo IS NOT NULL)'>",
+        "Column<'isNotNull(foo)'>",
+    ]
 
 
 @pytest.mark.unit

--- a/tests/expectations/test_row_conditions.py
+++ b/tests/expectations/test_row_conditions.py
@@ -1,10 +1,65 @@
 import pytest
 
+from great_expectations.compatibility import pyspark
+from great_expectations.expectations import legacy_row_conditions
 from great_expectations.expectations.legacy_row_conditions import (
+    _condition_value_literal,
     parse_condition_to_spark,
     parse_condition_to_sqlalchemy,
     parse_great_expectations_condition,
 )
+
+
+@pytest.mark.spark
+def test_condition_value_literal_numeric_column_uses_numeric_literal(monkeypatch):
+    # For a numeric column, a bare string literal would force an implicit
+    # string<->numeric comparison that errors under ANSI mode. The value must instead be
+    # converted to a numeric literal so the comparison stays numeric-vs-numeric.
+    captured: list = []
+    monkeypatch.setattr(
+        legacy_row_conditions.F, "lit", lambda value: captured.append(value) or value
+    )
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("n", pyspark.types.LongType(), True)]
+    )
+
+    _condition_value_literal("5", "n", schema)
+
+    assert captured == [5]
+    assert isinstance(captured[0], int)
+
+
+@pytest.mark.spark
+def test_condition_value_literal_numeric_column_non_numeric_value_falls_back(monkeypatch):
+    # A value that is not parseable as a number keeps the original string literal even on
+    # a numeric column, preserving the pre-existing fallback behavior.
+    captured: list = []
+    monkeypatch.setattr(
+        legacy_row_conditions.F, "lit", lambda value: captured.append(value) or value
+    )
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("n", pyspark.types.LongType(), True)]
+    )
+
+    _condition_value_literal("not_a_number", "n", schema)
+
+    assert captured == ["not_a_number"]
+
+
+@pytest.mark.spark
+def test_condition_value_literal_string_column_preserves_string_literal(monkeypatch):
+    # A non-numeric column keeps the string literal unchanged.
+    captured: list = []
+    monkeypatch.setattr(
+        legacy_row_conditions.F, "lit", lambda value: captured.append(value) or value
+    )
+    schema = pyspark.types.StructType(
+        [pyspark.types.StructField("s", pyspark.types.StringType(), True)]
+    )
+
+    _condition_value_literal("hello", "s", schema)
+
+    assert captured == ["hello"]
 
 
 @pytest.mark.unit

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_between.py
@@ -7,7 +7,8 @@ import pytest
 
 import great_expectations.expectations as gxe
 from great_expectations import ExpectationSuite
-from great_expectations.compatibility import pydantic
+from great_expectations.compatibility import pydantic, pyspark
+from great_expectations.compatibility.not_imported import is_version_greater_or_equal
 from great_expectations.core.result_format import ResultFormat
 from great_expectations.datasource.fluent.interfaces import Batch
 from tests.integration.conftest import parameterize_batch_for_data_sources
@@ -16,7 +17,12 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
     NON_SQL_DATA_SOURCES,
     SQL_DATA_SOURCES,
 )
-from tests.integration.test_utils.data_source_config import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config import (
+    PostgreSQLDatasourceTestConfig,
+    SparkFilesystemCsvDatasourceTestConfig,
+)
+
+SPARK_DATA_SOURCES = [SparkFilesystemCsvDatasourceTestConfig()]
 
 NUMERIC_COLUMN = "numbers"
 DATE_COLUMN = "dates"
@@ -259,6 +265,23 @@ class TestColumnValuesBetweenAgainstInvalidColumn:
         exception_info = list(results_with_errors[0].exception_info.values())
         assert len(exception_info) == 1
         assert self.EXPECTED_ERROR in exception_info[0]["exception_message"]
+
+
+_INVALID_COLUMN_TYPE_ERROR = "ColumnValuesBetween metrics cannot be computed on column of type"
+
+
+@parameterize_batch_for_data_sources(data_source_configs=SPARK_DATA_SOURCES, data=DATA)
+def test_string_column_with_numeric_bounds_spark(batch_for_datasource: Batch) -> None:
+    # A genuine string<->numeric comparison is rejected up front under Spark 4 ANSI, where
+    # it would otherwise surface as an opaque engine error. Earlier Spark versions coerce
+    # instead of raising, so the guard does not fire there and results stay unchanged.
+    expect = gxe.ExpectColumnValuesToBeBetween(column=STRING_COLUMN, min_value=0, max_value=1)
+    result = batch_for_datasource.validate(expect=expect)
+    exception_info_str = str(result.exception_info)
+    if pyspark.pyspark and is_version_greater_or_equal(pyspark.pyspark.__version__, "4.0.0"):
+        assert _INVALID_COLUMN_TYPE_ERROR in exception_info_str
+    else:
+        assert _INVALID_COLUMN_TYPE_ERROR not in exception_info_str
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
+++ b/tests/integration/data_sources_and_expectations/test_misconfigured_expectations.py
@@ -130,7 +130,9 @@ class TestNonExistentColumnMisconfiguration:
     def test_spark(self, batch_for_datasource) -> None:
         self._assert_misconfiguration(
             batch_for_datasource=batch_for_datasource,
-            exception_message="A column or function parameter with name `b` cannot be resolved",
+            # Spark reworded this error across versions (Spark 4 inserts ", variable,"),
+            # so match on the stable fragment that still proves column `b` was unresolved.
+            exception_message="with name `b` cannot be resolved",
         )
 
     def _assert_misconfiguration(self, batch_for_datasource: Batch, exception_message: str) -> None:


### PR DESCRIPTION
Second phase of pyspark 4.x support, building on the merged dependency-range/shim/CI-lane foundation (#11965). This phase makes the core Spark engine and metric providers behave correctly under Spark 4 defaults (ANSI mode on) while staying **byte-identical on pyspark 3.x** — result equivalence across versions is the acceptance bar, verified on both 3.5.8 and 4.1.2.

## Supported pyspark range
With this phase, `great_expectations[spark]` supports **pyspark >= 2.3.2, < 4.2** — i.e. the 4.0.x and 4.1.x lines are now supported in addition to 3.x. Default dev/CI installs remain pinned to the 3.5.x line (unchanged); a dedicated CI lane exercises 4.1.x, and a one-time run validated 4.0.x at runtime.

## Spark-4 API / behavior divergences (user-facing)
- **Config probing**: `SparkSession.conf.get()` now raises a *typed* exception for configs absent from SQLConf (e.g. `spark.default.parallelism`) instead of the old `Py4JJavaError`. The engine's misconfiguration probe catches it (compat shim adds a catchable fallback on pyspark < 4), restoring the graceful "unset" path so `add_spark(spark_config=...)` keeps working.
- **`unexpected_index_query` (COMPLETE result format / Data Docs)**: Spark 4 changed `Column.__str__` from infix SQL to function-prefix grammar and no longer wraps the leading paren, which broke the display-string builder. It now strips the `Column<'…'>` wrapper robustly across both grammars; 3.x output is unchanged.

## ANSI-mode hardening (version-agnostic)
Guards/typed-construction on metric sites that error only under ANSI, chosen so 3.x results are unchanged (no `try_divide`/`try_cast` — floor is 2.3.2):
- divide-by-zero guard on z-score;
- integral-overflow widening on row-wise add/subtract (`multicolumn_sum.equal`, `column_values.(in|de)creasing`) and aggregate `column.sum` (the sum widening is gated to pyspark ≥ 4 so 3.x keeps an integer observed value — Spark 4 ANSI raises on Long-accumulator overflow where Spark 3 wraps);
- explicit column-type validation / typed literals on comparison sites (`column_values.between`, `column_values.between.count`, GE-language row-condition literals) that would otherwise hit ANSI cross-type coercion.

Affected metric-string assertions are made version-aware; regression tests lock the `column.sum` int/float type contract. Also adds the `zstandard>=0.25.0` runtime dependency that pyspark 4.1's Spark Connect client hard-requires.

## Verification
- **Full CI green (4.1.x lane)**: https://github.com/fivetran/great_expectations/actions/runs/29093620720 — every job green, including both `pyspark4-marker-tests` legs (spark + spark_connect) and all existing 3.x lanes (spark/spark_connect marker-tests, all DB backends, docs-spark, static-analysis, unit-tests).
- **4.0.x runtime evidence** (one-time, lane temporarily pinned to `pyspark~=4.0.3`, since reverted to `~=4.1.2`): https://github.com/fivetran/great_expectations/actions/runs/29094346563 — both pyspark-4 legs green under 4.0.3.
- 3.x `[spark]` dependency resolution is unchanged (the resolution-governing files are untouched); the pyspark-4 lane job definition is unchanged (no existing CI job modified).

The pyspark-4 lane does not run on the PR's own `pull_request_target` checks (unlike the 3.x marker lanes, which do); it is exercised via `workflow_dispatch` on the branch (linked above) and will also run once the integration branch reaches a long-lived branch.