### PR TITLE
[MAINTENANCE] Authenticate Databricks CI via OAuth M2M service principal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,7 +565,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{secrets.CI_AWS_ACCESS_KEY_ID}}
       AWS_DEFAULT_REGION: ${{secrets.CI_AWS_DEFAULT_REGION}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.CI_AWS_SECRET_ACCESS_KEY}}
-      DATABRICKS_TOKEN: ${{secrets.DATABRICKS_SQL_TOKEN}}
+      # DATABRICKS_TOKEN is minted at runtime from the service principal's OAuth
+      # credentials in the "Mint Databricks OAuth access token" step below.
       DATABRICKS_HOST: ${{secrets.DATABRICKS_HOST}}
       DATABRICKS_HTTP_PATH: ${{secrets.DATABRICKS_HTTP_PATH}}
       DATABRICKS_CATALOG: ${{ vars.DATABRICKS_CATALOG }}
@@ -642,6 +643,21 @@ jobs:
       - name: Install SQL Server odbc driver
         if: matrix.markers == 'sql_server'
         run: ./scripts/install_sql_server_odbc_driver.sh
+
+      # Personal access tokens are disabled in the Databricks workspace by org
+      # policy, so authenticate the service principal via OAuth M2M. The minted
+      # bearer token is masked and exported as DATABRICKS_TOKEN so the existing
+      # token-based connection path is used unchanged. OAuth M2M tokens are valid
+      # for one hour, which comfortably covers the marker suite's runtime.
+      - name: Mint Databricks OAuth access token
+        if: matrix.markers == 'databricks'
+        env:
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+        run: |
+          TOKEN="$(python ./scripts/mint_databricks_token.py)"
+          echo "::add-mask::$TOKEN"
+          echo "DATABRICKS_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
       - name: Run the tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,8 +644,7 @@ jobs:
         if: matrix.markers == 'sql_server'
         run: ./scripts/install_sql_server_odbc_driver.sh
 
-      # Personal access tokens are disabled in the Databricks workspace by org
-      # policy, so authenticate the service principal via OAuth M2M. The minted
+      # Authenticate the service principal via OAuth M2M. The minted
       # bearer token is masked and exported as DATABRICKS_TOKEN so the existing
       # token-based connection path is used unchanged. OAuth M2M tokens are valid
       # for one hour, which comfortably covers the marker suite's runtime.

--- a/.github/workflows/data_source_cleanup.yml
+++ b/.github/workflows/data_source_cleanup.yml
@@ -97,8 +97,7 @@ jobs:
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
           invoke deps --gx-install -m databricks
           pip install -e .
-      # Personal access tokens are disabled in the Databricks workspace by org
-      # policy, so authenticate the service principal via OAuth M2M and export the
+      # Authenticate the service principal via OAuth M2M and export the
       # masked bearer token as DATABRICKS_TOKEN for the cleanup script.
       - name: Mint Databricks OAuth access token
         env:

--- a/.github/workflows/data_source_cleanup.yml
+++ b/.github/workflows/data_source_cleanup.yml
@@ -76,7 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # databricks
-      DATABRICKS_TOKEN: ${{secrets.DATABRICKS_SQL_TOKEN}}
+      # DATABRICKS_TOKEN is minted at runtime from the service principal's OAuth
+      # credentials in the "Mint Databricks OAuth access token" step below.
       DATABRICKS_HOST: ${{secrets.DATABRICKS_HOST}}
       DATABRICKS_HTTP_PATH: ${{secrets.DATABRICKS_HTTP_PATH}}
       DATABRICKS_CATALOG: ${{ vars.DATABRICKS_CATALOG }}
@@ -96,6 +97,17 @@ jobs:
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
           invoke deps --gx-install -m databricks
           pip install -e .
+      # Personal access tokens are disabled in the Databricks workspace by org
+      # policy, so authenticate the service principal via OAuth M2M and export the
+      # masked bearer token as DATABRICKS_TOKEN for the cleanup script.
+      - name: Mint Databricks OAuth access token
+        env:
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+        run: |
+          TOKEN="$(python ./scripts/mint_databricks_token.py)"
+          echo "::add-mask::$TOKEN"
+          echo "DATABRICKS_TOKEN=$TOKEN" >> "$GITHUB_ENV"
       - name: Run Databricks cleanup script
         run: |
           python ./scripts/cleanup/cleanup_databricks.py

--- a/scripts/mint_databricks_token.py
+++ b/scripts/mint_databricks_token.py
@@ -1,0 +1,59 @@
+"""Mint a short-lived Databricks OAuth machine-to-machine (M2M) access token.
+
+Some Databricks workspaces disable personal access tokens (PATs) by organization
+policy. OAuth M2M lets a service principal authenticate with a client ID and secret
+via the client-credentials grant; the resulting bearer token is accepted anywhere a
+PAT is and is valid for one hour.
+
+This script prints ONLY the access token to stdout so a caller can capture it into
+an environment variable (e.g. ``DATABRICKS_TOKEN``) and reuse the existing
+token-based connection path unchanged. Callers must register the value for log
+masking before use (in GitHub Actions, ``echo "::add-mask::$TOKEN"``) so the token
+does not leak into logs.
+"""
+
+import sys
+
+import requests
+
+from great_expectations.compatibility.pydantic import BaseSettings
+
+TOKEN_REQUEST_TIMEOUT_SECONDS = 30
+
+
+class ServicePrincipalConfig(BaseSettings):
+    """OAuth M2M credentials.
+
+    Injected via CI, but when running locally you may use your own service
+    principal's credentials.
+    """
+
+    databricks_host: str
+    databricks_client_id: str
+    databricks_client_secret: str
+
+    @property
+    def token_endpoint(self) -> str:
+        host = self.databricks_host.removeprefix("https://").removeprefix("http://").rstrip("/")
+        return f"https://{host}/oidc/v1/token"
+
+
+def mint_access_token(config: ServicePrincipalConfig) -> str:
+    """Exchange the service principal's client credentials for an OAuth access token."""
+    response = requests.post(
+        config.token_endpoint,
+        auth=(config.databricks_client_id, config.databricks_client_secret),
+        data={"grant_type": "client_credentials", "scope": "all-apis"},
+        timeout=TOKEN_REQUEST_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    return str(response.json()["access_token"])
+
+
+def main() -> None:
+    config = ServicePrincipalConfig()  # type: ignore[call-arg]  # values come from env
+    sys.stdout.write(mint_access_token(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mint_databricks_token.py
+++ b/scripts/mint_databricks_token.py
@@ -1,7 +1,6 @@
 """Mint a short-lived Databricks OAuth machine-to-machine (M2M) access token.
 
-Some Databricks workspaces disable personal access tokens (PATs) by organization
-policy. OAuth M2M lets a service principal authenticate with a client ID and secret
+OAuth M2M lets a service principal authenticate with a client ID and secret
 via the client-credentials grant; the resulting bearer token is accepted anywhere a
 PAT is and is valid for one hour.
 


### PR DESCRIPTION
## Summary

Update GX CI to use service principal for databricks tests.