### PR TITLE
[MAINTENANCE] Ignore pyOpenSSL X509.get_subject deprecation warning for snowflake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -667,6 +667,9 @@ filterwarnings = [
     "module: The GenericFunction 'flatten' is already registered and is going to be overridden:sqlalchemy.exc.SAWarning",
     # pyOpenSSL 25.0.1 starting raising this warning only for connecting to snowflake but no other datasources.
     "ignore: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception",
+    # pyOpenSSL 26.3.0 deprecated X509.get_subject/X509Name in favor of the cryptography.x509 APIs.
+    # snowflake-connector-python's ssl_wrap_socket still calls the deprecated API during the TLS handshake.
+    "ignore: X509.get_subject is deprecated. You should use cryptography's X.509 APIs instead.:DeprecationWarning",
     "ignore: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.:pytest_benchmark.logger.PytestBenchmarkWarning",
     "ignore: No data was collected\\. \\(no-data-collected\\):coverage.exceptions.CoverageWarning",
 


### PR DESCRIPTION
## Summary
- Scheduled CI runs are failing on every snowflake test (e.g. [this run](https://github.com/fivetran/great_expectations/actions/runs/29487965081/job/87587911865)) with `TestConnectionError` during `test_connection`.
- Root cause: pyOpenSSL 26.3.0 deprecated `X509.get_subject`/`X509Name` in favor of the `cryptography.x509` APIs. snowflake-connector-python's `ssl_wrap_socket` still calls the deprecated API while verifying the peer cert during the TLS handshake, emitting a new `DeprecationWarning`.
- This repo's pytest config treats all warnings as errors (`filterwarnings = ["error", ...]`) unless explicitly allow-listed, so the new warning is escalated into a real exception and caught/re-raised as `TestConnectionError` by `SQLDatasource.test_connection`.
- Same pattern as the existing pyOpenSSL 25.0.1 ignore entry a few lines above (added for a different Snowflake-only warning) — this adds the equivalent entry for the new message.

## Test plan
- [x] Verified locally: a standalone test emitting the exact warning message passes under this repo's pytest config with the new filter, and fails without it.
- [x] Verified the filter doesn't over-match: an unrelated `DeprecationWarning` still errors under the same config.
- [ ] CI on this branch should now pass the snowflake job (was failing on `develop`/scheduled runs beforehand).