### PR TITLE
[FEATURE] Self-hosted CLA status check

### DIFF
--- a/.github/actions/cla-status/action.yml
+++ b/.github/actions/cla-status/action.yml
@@ -1,0 +1,110 @@
+name: 'CLA status'
+description: >-
+  Queries the contributor-handle endpoint for a set of committer logins and posts
+  the verification/cla-signed commit status as success or error, failing closed
+  whenever committer enumeration is incomplete, the endpoint is unreachable or
+  returns an error, or a committer could not be resolved to a handle.
+
+inputs:
+  endpoint:
+    description: >-
+      Contributor-handle endpoint; the encoded login is appended directly to this
+      value per query. Held here as the single URL literal so every caller shares
+      one endpoint-query path.
+    required: false
+    default: 'https://script.google.com/macros/s/AKfycbw0IdCrD5hyElMg9J9gUCfl67py0bp8s5uCACnBY9_iUm3cTLd8G9oyB6ivNJPOw_Kt/exec?checkContributor='
+  status-sha:
+    description: 'Commit SHA to post the verification/cla-signed status on.'
+    required: true
+  logins:
+    description: 'JSON array of unique GitHub logins to check.'
+    required: true
+  enumeration-complete:
+    description: >-
+      "true" when every committer in the evaluated range was enumerated; "false"
+      fails the check closed without querying the endpoint.
+    required: true
+  unidentified:
+    description: 'JSON array of commit refs with no resolvable author login.'
+    required: false
+    default: '[]'
+  unidentified-policy:
+    description: >-
+      How to treat `unidentified`: "fail" counts each one as not signed, "skip"
+      ignores them entirely.
+    required: false
+    default: 'fail'
+  token:
+    description: 'Base-repo token used to post the commit status.'
+    required: true
+
+outputs:
+  state:
+    description: 'The posted status state: "success" or "error".'
+    value: ${{ steps.decide.outputs.state }}
+  unsigned:
+    description: 'JSON array of logins that have not signed the CLA.'
+    value: ${{ steps.decide.outputs.unsigned }}
+  unidentified:
+    description: 'JSON array of commit refs with no resolvable author login (echoed input).'
+    value: ${{ steps.decide.outputs.unidentified }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine CLA status and post it
+      id: decide
+      uses: actions/github-script@v7
+      env:
+        # `github.action_path` is resolved at YAML-evaluation time against this
+        # composite action, unambiguously -- unlike the `GITHUB_ACTION_PATH`
+        # runtime env var, which a nested action invocation (github-script here)
+        # can rebind to its own install directory.
+        CLA_ACTION_PATH: ${{ github.action_path }}
+        CLA_ENDPOINT: ${{ inputs.endpoint }}
+        CLA_STATUS_SHA: ${{ inputs.status-sha }}
+        CLA_LOGINS: ${{ inputs.logins }}
+        CLA_ENUMERATION_COMPLETE: ${{ inputs.enumeration-complete }}
+        CLA_UNIDENTIFIED: ${{ inputs.unidentified }}
+        CLA_UNIDENTIFIED_POLICY: ${{ inputs.unidentified-policy }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          // Every committer-adjacent value arrives via env/process.env above, never
+          // string-interpolated into this script body -- so nothing a pull request
+          // controls (a login, a commit SHA) can execute as script content here.
+          const { decide } = require(`${process.env.CLA_ACTION_PATH}/decide.js`);
+
+          const logins = JSON.parse(process.env.CLA_LOGINS || '[]');
+          const unidentified = JSON.parse(process.env.CLA_UNIDENTIFIED || '[]');
+          const enumerationComplete = process.env.CLA_ENUMERATION_COMPLETE === 'true';
+          const unidentifiedPolicy = process.env.CLA_UNIDENTIFIED_POLICY === 'skip' ? 'skip' : 'fail';
+          const endpoint = process.env.CLA_ENDPOINT;
+          const statusSha = process.env.CLA_STATUS_SHA;
+
+          // decide() rejects (throws) on an unreachable or non-OK endpoint response;
+          // left unhandled here, that fails this step -- and the job -- with no
+          // commit status posted at all, never a silent success on an outage.
+          const result = await decide({
+            logins,
+            enumerationComplete,
+            unidentified,
+            unidentifiedPolicy,
+            endpoint,
+            fetchImpl: fetch,
+          });
+
+          await github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: statusSha,
+            context: 'verification/cla-signed',
+            state: result.state,
+            description: result.description,
+          });
+
+          core.info(`verification/cla-signed = ${result.state} on ${statusSha} (checked ${logins.length} login(s))`);
+
+          core.setOutput('state', result.state);
+          core.setOutput('unsigned', JSON.stringify(result.unsigned));
+          core.setOutput('unidentified', JSON.stringify(result.unidentified));

--- a/.github/actions/cla-status/decide.js
+++ b/.github/actions/cla-status/decide.js
@@ -1,0 +1,123 @@
+/**
+ * Decision logic for the CLA-status composite action: given a resolved committer
+ * set, decide whether the pull request or merge-queue candidate has satisfied the
+ * CLA gate, and produce the `verification/cla-signed` state and description.
+ *
+ * Extracted into a plain module (rather than living inline in the wrapped
+ * `github-script` step) so it can run under a stubbed endpoint outside the
+ * Actions runtime -- no live endpoint, no GitHub API, no network required.
+ *
+ * Fails closed by construction:
+ *   - Incomplete committer enumeration is treated as not-signed immediately,
+ *     without ever querying the endpoint for a partially-seen committer set.
+ *   - An unresolvable committer handle counts as not-signed under
+ *     `unidentifiedPolicy: 'fail'`; it is ignored only under `'skip'`.
+ *   - An unreachable, timed-out, or non-OK endpoint response for any login makes
+ *     this function reject outright rather than return a status -- the caller
+ *     must let that rejection fail the job so no `success` (or any status at
+ *     all) is ever posted on an outage.
+ *
+ * The only value ever sent to the endpoint is the bare GitHub login being
+ * checked; no other committer- or contributor-derived data is transmitted.
+ */
+'use strict';
+
+var CLA_STATUS_CONTEXT = 'verification/cla-signed';
+var DESCRIPTION_MAX_LENGTH = 140;
+
+/**
+ * Build the commit-status description, matching the established
+ * "All committers have signed the CLA" / "CLA not signed: <list>" wording and
+ * staying within the Statuses API's description length limit.
+ */
+function buildDescription(signed, unsigned, unidentified, policy) {
+  if (signed) return 'All committers have signed the CLA';
+
+  var notSigned = unsigned.slice();
+  if (policy === 'fail' && unidentified.length > 0) {
+    notSigned = notSigned.concat(unidentified.map(function (ref) { return 'unidentified:' + ref; }));
+  }
+
+  var text = notSigned.length > 0
+    ? 'CLA not signed: ' + notSigned.join(', ')
+    : 'CLA verification incomplete: committer enumeration was not confirmed complete';
+  return text.slice(0, DESCRIPTION_MAX_LENGTH);
+}
+
+/**
+ * @param {object} args
+ * @param {string[]} args.logins - Committer GitHub logins to check (deduplicated internally).
+ * @param {boolean} args.enumerationComplete - Whether every committer was enumerated.
+ * @param {string[]} [args.unidentified] - Commit refs with no resolvable author login.
+ * @param {'fail'|'skip'} [args.unidentifiedPolicy] - How to treat `unidentified` (default 'fail').
+ * @param {string} args.endpoint - Endpoint base URL; the encoded login is appended per query.
+ * @param {(url: string) => Promise<{ok: boolean, status?: number, json: () => Promise<any>}>} [args.fetchImpl]
+ *   Injected fetch (defaults to the global `fetch`), so a test can stub the endpoint with no network.
+ * @returns {Promise<{state: 'success'|'error', unsigned: string[], unidentified: string[], description: string}>}
+ *   Resolves with the decision. Rejects (throws) if the endpoint is unreachable or
+ *   returns non-OK for any login -- callers must propagate that rejection to fail
+ *   the job, never catch it into a posted status.
+ */
+async function decide(args) {
+  var logins = args.logins;
+  var enumerationComplete = args.enumerationComplete;
+  var unidentified = args.unidentified;
+  var unidentifiedPolicy = args.unidentifiedPolicy;
+  var endpoint = args.endpoint;
+  var fetchImpl = args.fetchImpl;
+
+  var uniqueLogins = Array.from(new Set(logins || []));
+  var unidentifiedList = Array.isArray(unidentified) ? unidentified : [];
+  var policy = unidentifiedPolicy === 'skip' ? 'skip' : 'fail';
+  var doFetch = fetchImpl || fetch;
+
+  // Incomplete enumeration fails closed immediately: an endpoint that is never
+  // even queried can never wave a partially-seen committer set through.
+  if (!enumerationComplete) {
+    return {
+      state: 'error',
+      unsigned: [],
+      unidentified: unidentifiedList,
+      description: buildDescription(false, [], unidentifiedList, policy),
+    };
+  }
+
+  var unsigned = [];
+  for (var i = 0; i < uniqueLogins.length; i++) {
+    var login = uniqueLogins[i];
+    var res;
+    try {
+      res = await doFetch(endpoint + encodeURIComponent(login));
+    } catch (err) {
+      // Fail the job outright: no status is posted at all rather than a silent
+      // success on an unreachable endpoint.
+      throw new Error('CLA endpoint request failed for ' + login + ': ' + err.message);
+    }
+    if (!res.ok) {
+      throw new Error('CLA endpoint returned ' + res.status + ' for ' + login);
+    }
+    var body = await res.json();
+    if (!body.isContributor) unsigned.push(login);
+  }
+
+  var unidentifiedCountsAsUnsigned = policy === 'fail' && unidentifiedList.length > 0;
+  var signed = unsigned.length === 0 && !unidentifiedCountsAsUnsigned;
+
+  return {
+    state: signed ? 'success' : 'error',
+    unsigned: unsigned,
+    unidentified: unidentifiedList,
+    description: buildDescription(signed, unsigned, unidentifiedList, policy),
+  };
+}
+
+// Guarded export matching the established pattern for the pure-logic modules
+// behind this gate, so this file loads the same way whether it's `require()`d by
+// the wrapped github-script step or by a plain-Node test.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    decide: decide,
+    buildDescription: buildDescription,
+    CLA_STATUS_CONTEXT: CLA_STATUS_CONTEXT,
+  };
+}

--- a/.github/actions/cla-status/decide.test.js
+++ b/.github/actions/cla-status/decide.test.js
@@ -198,6 +198,92 @@ async function run() {
     });
   })();
 
+  console.log('endpoint non-OK for a login after an earlier login already succeeded -> throws (fail-closed regardless of position)');
+  await (async function () {
+    var calls = [];
+    var fetchImpl = function (url) {
+      calls.push(url);
+      if (url.indexOf('alice') !== -1) {
+        return Promise.resolve({ ok: true, status: 200, json: function () { return Promise.resolve({ isContributor: true }); } });
+      }
+      return Promise.resolve({ ok: false, status: 500, json: function () { return Promise.resolve({}); } });
+    };
+    var threw = false;
+    try {
+      await decide({
+        logins: ['alice', 'bob'],
+        enumerationComplete: true,
+        unidentified: [],
+        unidentifiedPolicy: 'fail',
+        endpoint: ENDPOINT,
+        fetchImpl: fetchImpl,
+      });
+    } catch (e) { threw = true; }
+    check('decide() rejects when any queried login is non-OK, not only the first', function () { assert.strictEqual(threw, true); });
+  })();
+
+  console.log('login value is percent-encoded before being appended to the endpoint URL (no raw query injection)');
+  await (async function () {
+    var calls = [];
+    var fetchImpl = function (url) {
+      calls.push(url);
+      return Promise.resolve({ ok: true, status: 200, json: function () { return Promise.resolve({ isContributor: true }); } });
+    };
+    var weirdLogin = 'weird user&extra=x';
+    await decide({
+      logins: [weirdLogin],
+      enumerationComplete: true,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: fetchImpl,
+    });
+    check('the request URL is exactly the endpoint plus the percent-encoded login', function () {
+      assert.strictEqual(calls[0], ENDPOINT + encodeURIComponent(weirdLogin));
+    });
+    check('the raw, unescaped login never appears in the request URL', function () {
+      assert.strictEqual(calls[0].indexOf(weirdLogin), -1);
+    });
+  })();
+
+  console.log('unidentified commit refs are never sent to the endpoint, even when non-empty');
+  await (async function () {
+    var endpoint = stubEndpoint(['alice']);
+    var sensitiveRef = 'commit-authored-by-jane.doe@example.com';
+    await decide({
+      logins: ['alice'],
+      enumerationComplete: true,
+      unidentified: ['deadbeef', sensitiveRef],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: endpoint,
+    });
+    check('endpoint is queried exactly once, for the login only', function () { assert.strictEqual(endpoint.calls.length, 1); });
+    check('no unidentified ref value appears in any endpoint call', function () {
+      endpoint.calls.forEach(function (url) {
+        assert.strictEqual(url.indexOf('deadbeef'), -1);
+        assert.strictEqual(url.indexOf('jane.doe'), -1);
+      });
+    });
+  })();
+
+  console.log('multiple logins are each queried with exactly their own bare, encoded handle -- no cross-contamination');
+  await (async function () {
+    var endpoint = stubEndpoint(['alice', 'bob']);
+    await decide({
+      logins: ['alice', 'bob'],
+      enumerationComplete: true,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: endpoint,
+    });
+    check('exactly two calls were made', function () { assert.strictEqual(endpoint.calls.length, 2); });
+    check('each call is exactly the endpoint plus that login\'s own encoded handle', function () {
+      assert.deepStrictEqual(endpoint.calls, [ENDPOINT + 'alice', ENDPOINT + 'bob']);
+    });
+  })();
+
   console.log('description stays within the 140-character commit-status limit');
   await (async function () {
     var manyUnsigned = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r'];

--- a/.github/actions/cla-status/decide.test.js
+++ b/.github/actions/cla-status/decide.test.js
@@ -1,0 +1,219 @@
+/**
+ * Repeatable check of the CLA-status composite action's decision logic: the
+ * endpoint-query + fail-closed + signed/unsigned computation, run against a
+ * stubbed endpoint (no network, no Actions runtime required).
+ *
+ * Run: node .github/actions/cla-status/decide.test.js
+ */
+'use strict';
+
+var assert = require('assert');
+var decide = require('./decide.js').decide;
+
+var failures = 0;
+var passed = 0;
+function check(name, fn) {
+  try { fn(); passed++; console.log('  ok   - ' + name); }
+  catch (e) { failures++; console.log('  FAIL - ' + name + '\n         ' + e.message); }
+}
+
+// A stubbed endpoint: `signed` lists the logins that are contributors; any login
+// not in the set answers `isContributor: false`. Records every URL it was asked
+// so tests can assert only the bare login (no other contributor value) is sent.
+function stubEndpoint(signedLogins) {
+  var signed = new Set(signedLogins);
+  var calls = [];
+  var fn = function (url) {
+    calls.push(url);
+    var login = decodeURIComponent(url.split('checkContributor=')[1]);
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: function () { return Promise.resolve({ isContributor: signed.has(login) }); },
+    });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function nonOkEndpoint(status) {
+  return function () {
+    return Promise.resolve({ ok: false, status: status || 502, json: function () { return Promise.resolve({}); } });
+  };
+}
+
+function rejectingEndpoint() {
+  return function () { return Promise.reject(new Error('network unreachable')); };
+}
+
+var ENDPOINT = 'https://example.invalid/exec?checkContributor=';
+
+async function run() {
+  console.log('all committers signed and enumeration complete -> success');
+  await (async function () {
+    var result = await decide({
+      logins: ['alice', 'bob'],
+      enumerationComplete: true,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: stubEndpoint(['alice', 'bob']),
+    });
+    check('state is success', function () { assert.strictEqual(result.state, 'success'); });
+    check('unsigned is empty', function () { assert.deepStrictEqual(result.unsigned, []); });
+    check('unidentified is echoed back empty', function () { assert.deepStrictEqual(result.unidentified, []); });
+  })();
+
+  console.log('one unsigned committer -> error');
+  await (async function () {
+    var result = await decide({
+      logins: ['alice', 'bob'],
+      enumerationComplete: true,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: stubEndpoint(['alice']),
+    });
+    check('state is error', function () { assert.strictEqual(result.state, 'error'); });
+    check('unsigned names bob', function () { assert.deepStrictEqual(result.unsigned, ['bob']); });
+  })();
+
+  console.log('enumeration-complete=false -> error, fails closed without querying the endpoint');
+  await (async function () {
+    var endpoint = stubEndpoint(['alice', 'bob']);
+    var result = await decide({
+      logins: ['alice', 'bob'],
+      enumerationComplete: false,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: endpoint,
+    });
+    check('state is error', function () { assert.strictEqual(result.state, 'error'); });
+    check('endpoint is never queried', function () { assert.strictEqual(endpoint.calls.length, 0); });
+  })();
+
+  console.log('unidentified committers under policy=fail -> error, even if every named login signed');
+  await (async function () {
+    var result = await decide({
+      logins: ['alice'],
+      enumerationComplete: true,
+      unidentified: ['deadbeef'],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: stubEndpoint(['alice']),
+    });
+    check('state is error', function () { assert.strictEqual(result.state, 'error'); });
+    check('unsigned logins list is still empty', function () { assert.deepStrictEqual(result.unsigned, []); });
+    check('unidentified is echoed back', function () { assert.deepStrictEqual(result.unidentified, ['deadbeef']); });
+  })();
+
+  console.log('same unidentified committers under policy=skip -> ignored, success');
+  await (async function () {
+    var result = await decide({
+      logins: ['alice'],
+      enumerationComplete: true,
+      unidentified: ['deadbeef'],
+      unidentifiedPolicy: 'skip',
+      endpoint: ENDPOINT,
+      fetchImpl: stubEndpoint(['alice']),
+    });
+    check('state is success', function () { assert.strictEqual(result.state, 'success'); });
+    check('unidentified is still echoed back (informational)', function () { assert.deepStrictEqual(result.unidentified, ['deadbeef']); });
+  })();
+
+  console.log('endpoint returns non-OK for a login -> throws (job fails, no status posted)');
+  await (async function () {
+    var threw = false;
+    try {
+      await decide({
+        logins: ['alice'],
+        enumerationComplete: true,
+        unidentified: [],
+        unidentifiedPolicy: 'fail',
+        endpoint: ENDPOINT,
+        fetchImpl: nonOkEndpoint(503),
+      });
+    } catch (e) { threw = true; }
+    check('decide() rejects rather than returning a status', function () { assert.strictEqual(threw, true); });
+  })();
+
+  console.log('endpoint fetch rejects (unreachable) -> throws (job fails, no status posted)');
+  await (async function () {
+    var threw = false;
+    try {
+      await decide({
+        logins: ['alice'],
+        enumerationComplete: true,
+        unidentified: [],
+        unidentifiedPolicy: 'fail',
+        endpoint: ENDPOINT,
+        fetchImpl: rejectingEndpoint(),
+      });
+    } catch (e) { threw = true; }
+    check('decide() rejects rather than returning a status', function () { assert.strictEqual(threw, true); });
+  })();
+
+  console.log('posted state is only ever success or error, never pending/neutral/failure');
+  await (async function () {
+    var allSigned = await decide({
+      logins: ['alice'], enumerationComplete: true, unidentified: [], unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT, fetchImpl: stubEndpoint(['alice']),
+    });
+    var incomplete = await decide({
+      logins: ['alice'], enumerationComplete: false, unidentified: [], unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT, fetchImpl: stubEndpoint(['alice']),
+    });
+    check('success case state is exactly "success"', function () { assert.ok(['success', 'error'].indexOf(allSigned.state) !== -1); assert.strictEqual(allSigned.state, 'success'); });
+    check('fail-closed case state is exactly "error"', function () { assert.ok(['success', 'error'].indexOf(incomplete.state) !== -1); assert.strictEqual(incomplete.state, 'error'); });
+  })();
+
+  console.log('duplicate logins are queried once');
+  await (async function () {
+    var endpoint = stubEndpoint(['alice']);
+    await decide({
+      logins: ['alice', 'alice', 'alice'],
+      enumerationComplete: true,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: endpoint,
+    });
+    check('endpoint queried once per unique login', function () { assert.strictEqual(endpoint.calls.length, 1); });
+  })();
+
+  console.log('only the bare GitHub handle is ever sent to the endpoint (no other contributor value)');
+  await (async function () {
+    var endpoint = stubEndpoint(['alice']);
+    await decide({
+      logins: ['alice'],
+      enumerationComplete: true,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: endpoint,
+    });
+    check('request URL is exactly the endpoint plus the encoded login', function () {
+      assert.strictEqual(endpoint.calls[0], ENDPOINT + 'alice');
+    });
+  })();
+
+  console.log('description stays within the 140-character commit-status limit');
+  await (async function () {
+    var manyUnsigned = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r'];
+    var result = await decide({
+      logins: manyUnsigned,
+      enumerationComplete: true,
+      unidentified: [],
+      unidentifiedPolicy: 'fail',
+      endpoint: ENDPOINT,
+      fetchImpl: stubEndpoint([]),
+    });
+    check('description is 140 characters or fewer', function () { assert.ok(result.description.length <= 140, 'length was ' + result.description.length); });
+  })();
+
+  console.log('\n' + passed + ' passed, ' + failures + ' failed');
+  process.exit(failures ? 1 : 0);
+}
+
+run();

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -75,6 +75,7 @@ jobs:
             core.setOutput('unidentified', JSON.stringify(unidentified));
 
       - name: Check CLA status and post verification/cla-signed
+        id: cla-status
         # Referenced by repo path@ref, not a local `./` path, so this step resolves
         # with no checkout: the runner fetches the action directly from the given
         # ref, independent of this job's (empty) workspace. This also means the
@@ -89,6 +90,77 @@ jobs:
           unidentified: ${{ steps.enumerate.outputs.unidentified }}
           unidentified-policy: fail
           token: ${{ github.token }}
+
+      - name: Build guiding comment body
+        id: build-comment
+        if: steps.cla-status.outputs.state == 'error'
+        uses: actions/github-script@v7
+        env:
+          CLA_UNSIGNED: ${{ steps.cla-status.outputs.unsigned }}
+          CLA_UNIDENTIFIED: ${{ steps.cla-status.outputs.unidentified }}
+        with:
+          script: |
+            // --- guiding-comment body transform (start) ----------------------------
+            // Mirrored 1:1 in the cla-recheck job below, for the same reason the
+            // enumeration transform above is: no checkout step here to require()
+            // shared logic from live.
+            const unsigned = JSON.parse(process.env.CLA_UNSIGNED || '[]');
+            const unidentified = JSON.parse(process.env.CLA_UNIDENTIFIED || '[]');
+
+            const sections = [];
+            if (unsigned.length > 0) {
+              const mentions = unsigned.map((login) => `@${login}`).join(', ');
+              sections.push(
+                `We could not find a signed CLA for: ${mentions}. Please sign the ` +
+                '[Individual Contributor License Agreement](https://forms.gle/wvregSivqgAaJNEX8), ' +
+                'or the [Software Grant and Corporate Contributor License Agreement]' +
+                '(https://forms.gle/6viSVNxZjui9Vhi29) if you are contributing on behalf of your ' +
+                'employer (see [CLA.md](https://github.com/fivetran/great_expectations/blob/develop/CLA.md) ' +
+                'for details).'
+              );
+            }
+            if (unidentified.length > 0) {
+              const refs = unidentified.map((sha) => `\`${String(sha).substring(0, 7)}\``).join(', ');
+              sections.push(
+                `We were unable to identify the GitHub account for the following commit(s): ${refs}. ` +
+                'Please make sure the email address on your commits is linked to your GitHub account.'
+              );
+            }
+            if (sections.length === 0) {
+              // Enumeration-incomplete case: state is `error` with neither list
+              // populated. Keep the comment non-empty and honest about why.
+              sections.push('We were unable to fully verify the CLA status for this pull request.');
+            }
+
+            const body = [
+              'Thank you for your contribution! Before we can merge this pull request, every ' +
+              'committer needs to have signed our Contributor License Agreement (CLA).',
+              ...sections,
+              'Once resolved, comment `@cla-bot check` on this pull request to re-run the check.',
+            ].join('\n\n');
+
+            core.setOutput('body', body);
+            // --- guiding-comment body transform (end) ------------------------------
+
+      - name: Post or update unsigned-CLA guiding comment
+        if: steps.cla-status.outputs.state == 'error'
+        uses: thollander/actions-comment-pull-request@v2.5.0
+        with:
+          comment_tag: cla-check
+          pr_number: ${{ github.event.pull_request.number }}
+          message: ${{ steps.build-comment.outputs.body }}
+
+      - name: Resolve guiding comment once the CLA is signed
+        if: steps.cla-status.outputs.state == 'success'
+        uses: thollander/actions-comment-pull-request@v2.5.0
+        with:
+          comment_tag: cla-check
+          # Only update a comment that's already there -- a PR that was fully
+          # signed from its first run never had an unsigned comment to resolve,
+          # so there's nothing to say here.
+          create_if_not_exists: false
+          pr_number: ${{ github.event.pull_request.number }}
+          message: 'All committers have signed the CLA. :white_check_mark:'
 
   cla-recheck:
     # Lets a committer re-trigger the check after signing, without pushing a new commit
@@ -160,6 +232,7 @@ jobs:
             core.setOutput('unidentified', JSON.stringify(unidentified));
 
       - name: Check CLA status and post verification/cla-signed
+        id: cla-status
         if: steps.enumerate.outputs.skip == 'false'
         # Same repo-path@ref reference as the pull_request_target job, for the same
         # reason: this job also has no checkout step, so a local `./` action path would
@@ -172,3 +245,74 @@ jobs:
           unidentified: ${{ steps.enumerate.outputs.unidentified }}
           unidentified-policy: fail
           token: ${{ github.token }}
+
+      - name: Build guiding comment body
+        id: build-comment
+        if: steps.enumerate.outputs.skip == 'false' && steps.cla-status.outputs.state == 'error'
+        uses: actions/github-script@v7
+        env:
+          CLA_UNSIGNED: ${{ steps.cla-status.outputs.unsigned }}
+          CLA_UNIDENTIFIED: ${{ steps.cla-status.outputs.unidentified }}
+        with:
+          script: |
+            // --- guiding-comment body transform (start) ----------------------------
+            // Mirrored 1:1 from the cla-check job above, for the same reason the
+            // enumeration transform is: no checkout step here to require() shared
+            // logic from live.
+            const unsigned = JSON.parse(process.env.CLA_UNSIGNED || '[]');
+            const unidentified = JSON.parse(process.env.CLA_UNIDENTIFIED || '[]');
+
+            const sections = [];
+            if (unsigned.length > 0) {
+              const mentions = unsigned.map((login) => `@${login}`).join(', ');
+              sections.push(
+                `We could not find a signed CLA for: ${mentions}. Please sign the ` +
+                '[Individual Contributor License Agreement](https://forms.gle/wvregSivqgAaJNEX8), ' +
+                'or the [Software Grant and Corporate Contributor License Agreement]' +
+                '(https://forms.gle/6viSVNxZjui9Vhi29) if you are contributing on behalf of your ' +
+                'employer (see [CLA.md](https://github.com/fivetran/great_expectations/blob/develop/CLA.md) ' +
+                'for details).'
+              );
+            }
+            if (unidentified.length > 0) {
+              const refs = unidentified.map((sha) => `\`${String(sha).substring(0, 7)}\``).join(', ');
+              sections.push(
+                `We were unable to identify the GitHub account for the following commit(s): ${refs}. ` +
+                'Please make sure the email address on your commits is linked to your GitHub account.'
+              );
+            }
+            if (sections.length === 0) {
+              // Enumeration-incomplete case: state is `error` with neither list
+              // populated. Keep the comment non-empty and honest about why.
+              sections.push('We were unable to fully verify the CLA status for this pull request.');
+            }
+
+            const body = [
+              'Thank you for your contribution! Before we can merge this pull request, every ' +
+              'committer needs to have signed our Contributor License Agreement (CLA).',
+              ...sections,
+              'Once resolved, comment `@cla-bot check` on this pull request to re-run the check.',
+            ].join('\n\n');
+
+            core.setOutput('body', body);
+            // --- guiding-comment body transform (end) ------------------------------
+
+      - name: Post or update unsigned-CLA guiding comment
+        if: steps.enumerate.outputs.skip == 'false' && steps.cla-status.outputs.state == 'error'
+        uses: thollander/actions-comment-pull-request@v2.5.0
+        with:
+          comment_tag: cla-check
+          pr_number: ${{ github.event.issue.number }}
+          message: ${{ steps.build-comment.outputs.body }}
+
+      - name: Resolve guiding comment once the CLA is signed
+        if: steps.enumerate.outputs.skip == 'false' && steps.cla-status.outputs.state == 'success'
+        uses: thollander/actions-comment-pull-request@v2.5.0
+        with:
+          comment_tag: cla-check
+          # Only update a comment that's already there -- a PR that was fully
+          # signed from its first run never had an unsigned comment to resolve,
+          # so there's nothing to say here.
+          create_if_not_exists: false
+          pr_number: ${{ github.event.issue.number }}
+          message: 'All committers have signed the CLA. :white_check_mark:'

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -18,9 +18,17 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  issue_comment:
+    types:
+      - created
 
 jobs:
   cla-check:
+    # Scoped to its own trigger now that the workflow has a second one (issue_comment):
+    # context.payload.pull_request only exists on the pull_request_target event, so
+    # without this guard an issue_comment event (which carries issue/comment, not
+    # pull_request) would also activate this job and fail resolving the PR.
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -73,6 +81,89 @@ jobs:
         # call always tracks develop's current tip at run time rather than a
         # commit frozen to this workflow file -- acceptable for a same-repo
         # self-reference to code that changes on the same cadence as this file.
+        uses: fivetran/great_expectations/.github/actions/cla-status@develop
+        with:
+          status-sha: ${{ steps.enumerate.outputs.head-sha }}
+          logins: ${{ steps.enumerate.outputs.logins }}
+          enumeration-complete: ${{ steps.enumerate.outputs.enumeration-complete }}
+          unidentified: ${{ steps.enumerate.outputs.unidentified }}
+          unidentified-policy: fail
+          token: ${{ github.token }}
+
+  cla-recheck:
+    # Lets a committer re-trigger the check after signing, without pushing a new commit
+    # (e.g. a commit made before signing would otherwise never get re-evaluated). Scoped
+    # to the exact recognized phrase so it can't be triggered by unrelated PR discussion,
+    # and to comments on a pull request specifically (issue_comment fires for both issues
+    # and PR comments; `issue.pull_request` is only set for the latter).
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '@cla-bot check'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Resolve PR and re-enumerate committers
+        id: enumerate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = (await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            })).data;
+
+            // A comment can arrive after the PR closed or merged. There's nothing to
+            // re-check at that point -- exit cleanly rather than posting a status update
+            // to a PR that's no longer open for one.
+            if (pr.state !== 'open') {
+              core.info(`PR #${pr.number} is ${pr.state}; recheck is a no-op.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            // --- enumeration transform (start) -------------------------------------
+            // Pure transform from `commits` + `pr.commits` only. Mirrored 1:1 by a
+            // standalone unit test elsewhere, since this workflow has no checkout
+            // step to require() this logic from live -- keep it self-contained here
+            // so that mirror stays easy to verify faithful.
+            //
+            // The pull-commits API hard-caps what a single (paginated) call can
+            // return. If the PR has more commits than were returned, some authors
+            // are invisible to us, so completeness must fail closed rather than
+            // silently treat a partial read as the full set.
+            const enumerationComplete = pr.commits <= commits.length;
+            const logins = [...new Set(commits.map(c => c.author && c.author.login).filter(Boolean))];
+            const unidentified = commits.filter(c => !(c.author && c.author.login)).map(c => c.sha);
+            // --- enumeration transform (end) ---------------------------------------
+
+            core.info(
+              `PR #${pr.number}: enumerated ${commits.length}/${pr.commits} commit(s), ` +
+              `${logins.length} login(s), ${unidentified.length} unidentified, ` +
+              `enumeration-complete=${enumerationComplete}`
+            );
+
+            core.setOutput('skip', 'false');
+            core.setOutput('head-sha', pr.head.sha);
+            core.setOutput('logins', JSON.stringify(logins));
+            core.setOutput('enumeration-complete', enumerationComplete ? 'true' : 'false');
+            core.setOutput('unidentified', JSON.stringify(unidentified));
+
+      - name: Check CLA status and post verification/cla-signed
+        if: steps.enumerate.outputs.skip == 'false'
+        # Same repo-path@ref reference as the pull_request_target job, for the same
+        # reason: this job also has no checkout step, so a local `./` action path would
+        # not resolve.
         uses: fivetran/great_expectations/.github/actions/cla-status@develop
         with:
           status-sha: ${{ steps.enumerate.outputs.head-sha }}

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,83 @@
+# Posts the required `verification/cla-signed` status on pull requests.
+#
+# Runs on pull_request_target rather than pull_request specifically so it has a
+# write-capable, base-repo GITHUB_TOKEN even on fork PRs -- pull_request would hand a
+# fork PR only a read-only token, unable to post a commit status at all. Because that
+# grants base-repo write access to a PR-triggered run, this workflow never checks out
+# the repository and never executes anything the pull request supplies: it only reads
+# pull-request and commit metadata through the API, then calls a composite action
+# that queries an external endpoint using already-public GitHub handles. No fork
+# secret is used -- only this workflow's own token.
+
+name: CLA check
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Enumerate PR committers
+        id: enumerate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            // --- enumeration transform (start) -------------------------------------
+            // Pure transform from `commits` + `pr.commits` only. Mirrored 1:1 by a
+            // standalone unit test elsewhere, since this workflow has no checkout
+            // step to require() this logic from live -- keep it self-contained here
+            // so that mirror stays easy to verify faithful.
+            //
+            // The pull-commits API hard-caps what a single (paginated) call can
+            // return. If the PR has more commits than were returned, some authors
+            // are invisible to us, so completeness must fail closed rather than
+            // silently treat a partial read as the full set.
+            const enumerationComplete = pr.commits <= commits.length;
+            const logins = [...new Set(commits.map(c => c.author && c.author.login).filter(Boolean))];
+            const unidentified = commits.filter(c => !(c.author && c.author.login)).map(c => c.sha);
+            // --- enumeration transform (end) ---------------------------------------
+
+            core.info(
+              `PR #${pr.number}: enumerated ${commits.length}/${pr.commits} commit(s), ` +
+              `${logins.length} login(s), ${unidentified.length} unidentified, ` +
+              `enumeration-complete=${enumerationComplete}`
+            );
+
+            core.setOutput('head-sha', pr.head.sha);
+            core.setOutput('logins', JSON.stringify(logins));
+            core.setOutput('enumeration-complete', enumerationComplete ? 'true' : 'false');
+            core.setOutput('unidentified', JSON.stringify(unidentified));
+
+      - name: Check CLA status and post verification/cla-signed
+        # Referenced by repo path@ref, not a local `./` path, so this step resolves
+        # with no checkout: the runner fetches the action directly from the given
+        # ref, independent of this job's (empty) workspace. This also means the
+        # call always tracks develop's current tip at run time rather than a
+        # commit frozen to this workflow file -- acceptable for a same-repo
+        # self-reference to code that changes on the same cadence as this file.
+        uses: fivetran/great_expectations/.github/actions/cla-status@develop
+        with:
+          status-sha: ${{ steps.enumerate.outputs.head-sha }}
+          logins: ${{ steps.enumerate.outputs.logins }}
+          enumeration-complete: ${{ steps.enumerate.outputs.enumeration-complete }}
+          unidentified: ${{ steps.enumerate.outputs.unidentified }}
+          unidentified-policy: fail
+          token: ${{ github.token }}

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Post or update unsigned-CLA guiding comment
         if: steps.cla-status.outputs.state == 'error'
-        uses: thollander/actions-comment-pull-request@v2.5.0
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           comment_tag: cla-check
           pr_number: ${{ github.event.pull_request.number }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Resolve guiding comment once the CLA is signed
         if: steps.cla-status.outputs.state == 'success'
-        uses: thollander/actions-comment-pull-request@v2.5.0
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           comment_tag: cla-check
           # Only update a comment that's already there -- a PR that was fully
@@ -299,7 +299,7 @@ jobs:
 
       - name: Post or update unsigned-CLA guiding comment
         if: steps.enumerate.outputs.skip == 'false' && steps.cla-status.outputs.state == 'error'
-        uses: thollander/actions-comment-pull-request@v2.5.0
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           comment_tag: cla-check
           pr_number: ${{ github.event.issue.number }}
@@ -307,7 +307,7 @@ jobs:
 
       - name: Resolve guiding comment once the CLA is signed
         if: steps.enumerate.outputs.skip == 'false' && steps.cla-status.outputs.state == 'success'
-        uses: thollander/actions-comment-pull-request@v2.5.0
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           comment_tag: cla-check
           # Only update a comment that's already there -- a PR that was fully

--- a/.github/workflows/cla-merge-queue.yml
+++ b/.github/workflows/cla-merge-queue.yml
@@ -29,17 +29,12 @@ jobs:
   cla-merge-queue:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify CLA for queued commit authors and report status
+      - name: Enumerate queued commit authors
+        id: enumerate
         uses: actions/github-script@v7
         with:
           script: |
-            const CLA_CONTEXT = 'verification/cla-signed';
-            // Must match `.clabot`'s `contributors` value (the contributor-handle endpoint,
-            // per-committer webhook form). cla-bot appends the bare login; so do we.
-            const ENDPOINT = 'https://script.google.com/macros/s/AKfycbw0IdCrD5hyElMg9J9gUCfl67py0bp8s5uCACnBY9_iUm3cTLd8G9oyB6ivNJPOw_Kt/exec?checkContributor=';
-
             const mg = context.payload.merge_group;
-            const headSha = mg.head_sha;
 
             // Commits the queue is adding on top of its base (the batched PR commits).
             const cmp = await github.rest.repos.compareCommitsWithBasehead({
@@ -49,14 +44,9 @@ jobs:
             });
 
             // The compare API returns at most 250 commits. If the range is larger we
-            // can't see every author, so fail closed rather than risk passing an
-            // unverified committer.
-            if (cmp.data.total_commits > cmp.data.commits.length) {
-              throw new Error(
-                `Merge group has ${cmp.data.total_commits} commits (> ${cmp.data.commits.length} returned); ` +
-                `cannot verify all authors — failing closed.`
-              );
-            }
+            // can't see every author, so completeness must fail closed rather than
+            // silently treat a partial read as the full set.
+            const enumerationComplete = cmp.data.total_commits <= cmp.data.commits.length;
 
             // Unique GitHub author logins. Commits with no resolvable author account
             // (e.g. the queue's own merge commit) contribute no login and are skipped;
@@ -66,26 +56,29 @@ jobs:
               cmp.data.commits.map((c) => c.author && c.author.login).filter(Boolean)
             )];
 
-            const unsigned = [];
-            for (const login of logins) {
-              const res = await fetch(ENDPOINT + encodeURIComponent(login));
-              if (!res.ok) {
-                // Fail closed: never post success if the endpoint can't be reached.
-                throw new Error(`CLA endpoint returned ${res.status} for ${login}`);
-              }
-              const body = await res.json();
-              if (!body.isContributor) unsigned.push(login);
-            }
+            core.info(
+              `Merge group ${mg.head_sha}: enumerated ${cmp.data.commits.length}/${cmp.data.total_commits} commit(s), ` +
+              `${logins.length} login(s), enumeration-complete=${enumerationComplete}`
+            );
 
-            const signed = unsigned.length === 0;
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: headSha,
-              context: CLA_CONTEXT,
-              state: signed ? 'success' : 'error',
-              description: signed
-                ? 'All committers have signed the CLA'
-                : `CLA not signed: ${unsigned.join(', ')}`.slice(0, 140),
-            });
-            core.info(`${CLA_CONTEXT} = ${signed ? 'success' : 'error'} on ${headSha} (checked ${logins.length} author(s))`);
+            core.setOutput('logins', JSON.stringify(logins));
+            core.setOutput('enumeration-complete', enumerationComplete ? 'true' : 'false');
+
+      - name: Check CLA status and post verification/cla-signed
+        id: cla-status
+        # Referenced by repo path@ref, not a local `./` path, so this step resolves
+        # with no checkout: the runner fetches the action directly from the given
+        # ref, independent of this job's (empty) workspace. This also means the
+        # call always tracks develop's current tip at run time rather than a
+        # commit frozen to this workflow file -- acceptable for a same-repo
+        # self-reference to code that changes on the same cadence as this file.
+        uses: fivetran/great_expectations/.github/actions/cla-status@develop
+        with:
+          status-sha: ${{ github.event.merge_group.head_sha }}
+          logins: ${{ steps.enumerate.outputs.logins }}
+          enumeration-complete: ${{ steps.enumerate.outputs.enumeration-complete }}
+          # Queued commits were already vetted at the PR head before entering the
+          # queue, so an author with no resolvable login here is skipped rather
+          # than treated as unsigned.
+          unidentified-policy: skip
+          token: ${{ github.token }}

--- a/.github/workflows/tests/cla-check-enumerate.test.js
+++ b/.github/workflows/tests/cla-check-enumerate.test.js
@@ -1,0 +1,201 @@
+/**
+ * Repeatable check of cla-check.yml's inline `github-script` logic: the PR-head
+ * commit-enumeration transform and the guiding-comment body builder.
+ *
+ * cla-check.yml has no checkout step (by design -- see the workflow's own header
+ * comment), so its inline scripts can't require() shared logic live. The functions
+ * below are byte-identical mirrors of what's actually inline in cla-check.yml, kept
+ * here purely so a plain Node test can exercise them; this file is never loaded by
+ * the real workflow. The workflow carries the enumeration transform and the
+ * comment-body transform twice (once in the `cla-check` job, once in `cla-recheck`)
+ * as intentionally identical copies -- no checkout means no shared `require()`
+ * across jobs -- so mirroring either copy here covers both.
+ *
+ * Run: node .github/workflows/tests/cla-check-enumerate.test.js
+ */
+'use strict';
+
+var assert = require('assert');
+
+// --- mirror of cla-check.yml's enumeration transform (verbatim) -----------------
+// Copied from the `cla-check` job's "Enumerate PR committers" step (identical to
+// the `cla-recheck` job's copy). Takes the paginated `commits` array and the PR's
+// own reported `pr.commits` count.
+function enumerate(commits, pr) {
+  const enumerationComplete = pr.commits <= commits.length;
+  const logins = [...new Set(commits.map(c => c.author && c.author.login).filter(Boolean))];
+  const unidentified = commits.filter(c => !(c.author && c.author.login)).map(c => c.sha);
+  return { enumerationComplete, logins, unidentified };
+}
+// --- end mirror -------------------------------------------------------------------
+
+// --- mirror of cla-check.yml's guiding-comment body transform (verbatim) --------
+// Copied from the `cla-check` job's "Build guiding comment body" step (identical to
+// the `cla-recheck` job's copy).
+function buildCommentBody(unsigned, unidentified) {
+  const sections = [];
+  if (unsigned.length > 0) {
+    const mentions = unsigned.map((login) => `@${login}`).join(', ');
+    sections.push(
+      `We could not find a signed CLA for: ${mentions}. Please sign the ` +
+      '[Individual Contributor License Agreement](https://forms.gle/wvregSivqgAaJNEX8), ' +
+      'or the [Software Grant and Corporate Contributor License Agreement]' +
+      '(https://forms.gle/6viSVNxZjui9Vhi29) if you are contributing on behalf of your ' +
+      'employer (see [CLA.md](https://github.com/fivetran/great_expectations/blob/develop/CLA.md) ' +
+      'for details).'
+    );
+  }
+  if (unidentified.length > 0) {
+    const refs = unidentified.map((sha) => `\`${String(sha).substring(0, 7)}\``).join(', ');
+    sections.push(
+      `We were unable to identify the GitHub account for the following commit(s): ${refs}. ` +
+      'Please make sure the email address on your commits is linked to your GitHub account.'
+    );
+  }
+  if (sections.length === 0) {
+    // Enumeration-incomplete case: state is `error` with neither list populated.
+    // Keep the comment non-empty and honest about why.
+    sections.push('We were unable to fully verify the CLA status for this pull request.');
+  }
+
+  const body = [
+    'Thank you for your contribution! Before we can merge this pull request, every ' +
+    'committer needs to have signed our Contributor License Agreement (CLA).',
+    ...sections,
+    'Once resolved, comment `@cla-bot check` on this pull request to re-run the check.',
+  ].join('\n\n');
+
+  return body;
+}
+// --- end mirror -------------------------------------------------------------------
+
+var failures = 0;
+var passed = 0;
+function check(name, fn) {
+  try { fn(); passed++; console.log('  ok   - ' + name); }
+  catch (e) { failures++; console.log('  FAIL - ' + name + '\n         ' + e.message); }
+}
+
+function commit(sha, login) {
+  return { sha: sha, author: login ? { login: login } : null };
+}
+
+console.log('enumeration: normal PR, full enumeration');
+(function () {
+  var commits = [commit('sha1', 'alice'), commit('sha2', 'bob'), commit('sha3', 'alice')];
+  var pr = { commits: 3 };
+  var result = enumerate(commits, pr);
+  check('enumerationComplete is true when pr.commits === commits.length', function () {
+    assert.strictEqual(result.enumerationComplete, true);
+  });
+  check('logins is the deduped set of resolvable logins', function () {
+    assert.deepStrictEqual(result.logins, ['alice', 'bob']);
+  });
+  check('unidentified is empty', function () {
+    assert.deepStrictEqual(result.unidentified, []);
+  });
+})();
+
+console.log('enumeration: truncated PR (simulated 250-commit cap)');
+(function () {
+  var commits = [commit('sha1', 'alice')];
+  var pr = { commits: 300 };
+  var result = enumerate(commits, pr);
+  check('enumerationComplete is false when pr.commits exceeds the returned set', function () {
+    assert.strictEqual(result.enumerationComplete, false);
+  });
+})();
+
+console.log('enumeration: unidentified commit collected by SHA, not email/name');
+(function () {
+  var commits = [
+    { sha: 'deadbeef', author: null },
+    { sha: 'cafefeed', author: {} },
+  ];
+  var pr = { commits: 2 };
+  var result = enumerate(commits, pr);
+  check('unidentified lists the SHAs of unresolvable commits', function () {
+    assert.deepStrictEqual(result.unidentified, ['deadbeef', 'cafefeed']);
+  });
+  check('logins is empty when no commit has a resolvable login', function () {
+    assert.deepStrictEqual(result.logins, []);
+  });
+})();
+
+console.log('enumeration: duplicate logins across commits dedupe to one entry');
+(function () {
+  var commits = [commit('sha1', 'alice'), commit('sha2', 'alice'), commit('sha3', 'alice')];
+  var pr = { commits: 3 };
+  var result = enumerate(commits, pr);
+  check('logins contains "alice" exactly once', function () {
+    assert.deepStrictEqual(result.logins, ['alice']);
+  });
+})();
+
+console.log('comment body: both unsigned and unidentified non-empty');
+(function () {
+  var body = buildCommentBody(['alice', 'bob'], ['deadbeef']);
+  check('is a non-empty string', function () {
+    assert.ok(typeof body === 'string' && body.length > 0);
+  });
+  check('mentions each unsigned login', function () {
+    assert.ok(body.indexOf('@alice') !== -1);
+    assert.ok(body.indexOf('@bob') !== -1);
+  });
+  check('includes both CLA form links', function () {
+    assert.ok(body.indexOf('https://forms.gle/wvregSivqgAaJNEX8') !== -1);
+    assert.ok(body.indexOf('https://forms.gle/6viSVNxZjui9Vhi29') !== -1);
+  });
+  check('mentions the unidentified commit by its short SHA', function () {
+    assert.ok(body.indexOf('deadbee') !== -1);
+  });
+  check('always includes the recheck instruction', function () {
+    assert.ok(body.indexOf('@cla-bot check') !== -1);
+  });
+})();
+
+console.log('comment body: only unsigned committers');
+(function () {
+  var body = buildCommentBody(['alice'], []);
+  check('mentions the unsigned login and form links', function () {
+    assert.ok(body.indexOf('@alice') !== -1);
+    assert.ok(body.indexOf('https://forms.gle/wvregSivqgAaJNEX8') !== -1);
+  });
+  check('does not include the unidentified-committer section', function () {
+    assert.ok(body.indexOf('unable to identify the GitHub account') === -1);
+  });
+  check('always includes the recheck instruction', function () {
+    assert.ok(body.indexOf('@cla-bot check') !== -1);
+  });
+})();
+
+console.log('comment body: only unidentified committers');
+(function () {
+  var body = buildCommentBody([], ['cafefeed']);
+  check('mentions the unidentified commit by its short SHA', function () {
+    assert.ok(body.indexOf('cafefee') !== -1);
+  });
+  check('does not include the unsigned-committer section', function () {
+    assert.ok(body.indexOf('could not find a signed CLA') === -1);
+  });
+  check('always includes the recheck instruction', function () {
+    assert.ok(body.indexOf('@cla-bot check') !== -1);
+  });
+})();
+
+console.log('comment body: enumeration-incomplete fallback (both lists empty)');
+(function () {
+  var body = buildCommentBody([], []);
+  check('falls back to the enumeration-incomplete sentence', function () {
+    assert.ok(body.indexOf('unable to fully verify the CLA status') !== -1);
+  });
+  check('is still a non-empty, well-formed string', function () {
+    assert.ok(typeof body === 'string' && body.length > 0);
+  });
+  check('always includes the recheck instruction', function () {
+    assert.ok(body.indexOf('@cla-bot check') !== -1);
+  });
+})();
+
+console.log('\n' + passed + ' passed, ' + failures + ' failed');
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

Replaces the hosted `cla-bot` App's status-posting with a repository-native
GitHub Actions check. `verification/cla-signed` is now posted automatically by
this repo's own workflows, querying the existing contributor-handle endpoint
directly, with no dependency on a third-party App.

- **`cla-status` composite action** (`.github/actions/cla-status/`): single
  shared endpoint-query + fail-closed + status-post path. Emits exactly
  `success`/`error` (never `pending`/`failure`) so the existing
  `cla-label-sync.yml` keeps reconciling correctly. Holds the endpoint URL as
  its one input default -- the single URL literal left in the tree.
- **`cla-check.yml`** (new): runs on `pull_request_target`
  (opened/reopened/synchronize/ready_for_review), enumerates PR committers
  with no checkout and a base-repo token only, fails closed if a PR has more
  commits than the API returned, and posts the status via the shared action.
  Also handles `@cla-bot check` comments to re-run the check without a new
  commit, and posts/updates one idempotent guiding comment naming any
  unsigned or unidentified committer with links to sign.
- **`cla-merge-queue.yml`** (refactored): now calls the same shared action
  instead of its own inline endpoint query, so the PR-head and merge-queue
  paths provably share one code path and one URL literal. Trigger,
  permissions, and author enumeration are unchanged.

Fork PRs are handled identically to same-repo PRs: no fork-supplied secret is
ever used, and no pull-request-supplied code is checked out or executed
anywhere in this change.

## Test plan

- [x] `.github/actions/cla-status/decide.test.js` -- 26 cases covering the
      full fail-closed decision matrix (all-signed, unsigned, endpoint
      unreachable, incomplete enumeration, unidentified committers under both
      policies, no-PII transmission), run via plain `node`.
- [x] `.github/workflows/tests/cla-check-enumerate.test.js` -- 21 cases
      mirroring `cla-check.yml`'s enumeration and guiding-comment logic
      (verified byte-identical to the live workflow), covering full
      enumeration, truncation, unidentified-by-SHA handling, login dedup, and
      comment rendering.
- [x] `actionlint` clean on every touched action/workflow file.
- [ ] Live validation on a real PR, a fork PR, an `@cla-bot check` recheck,
      and a merge-queue candidate -- pending merge to `develop` (these
      triggers only take effect once the workflow files are on the default
      branch).