### PR TITLE
[BUGFIX] Sync CLA labels directly from the CLA check, not via the status webhook

### DIFF
--- a/.github/actions/cla-label-sync/action.yml
+++ b/.github/actions/cla-label-sync/action.yml
@@ -1,0 +1,75 @@
+name: 'CLA label sync'
+description: >-
+  Reconciles the cla-signed / cla-not-signed labels on a single pull request to
+  match a verification/cla-signed status state, ensuring the matching label is
+  present and the stale one is removed.
+
+inputs:
+  pr-number:
+    description: 'Pull request number to reconcile labels on.'
+    required: true
+  state:
+    description: >-
+      The verification/cla-signed status state to reconcile to: "success" or
+      "error"/"failure". Any other value (e.g. "pending") is a no-op.
+    required: true
+  token:
+    description: 'Token used to read/write labels on the pull request.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Reconcile CLA labels to the given state
+      uses: actions/github-script@v7
+      env:
+        CLA_PR_NUMBER: ${{ inputs.pr-number }}
+        CLA_STATE: ${{ inputs.state }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          // Kept in lockstep with the equivalent status-event reconcile logic in
+          // cla-label-sync.yml, which cannot call this action directly because it
+          // fans out over a dynamically-sized list of PRs discovered at runtime
+          // (a composite action can only be invoked as a static job step).
+          const SIGNED = 'cla-signed';
+          const NOT_SIGNED = 'cla-not-signed';
+
+          const prNumber = Number(process.env.CLA_PR_NUMBER);
+          const state = process.env.CLA_STATE;
+
+          // Map a CLA status state to the desired label pair. `pending`/unknown -> no-op.
+          function labelsForState(s) {
+            if (s === 'success') return { present: SIGNED, absent: NOT_SIGNED };
+            if (s === 'error' || s === 'failure') return { present: NOT_SIGNED, absent: SIGNED };
+            return null;
+          }
+
+          const target = labelsForState(state);
+          if (!target) {
+            core.info(`No-op for state ${state}`);
+            return;
+          }
+
+          // Convergent (set-to-match) reconcile: ensure `present` is on the PR and
+          // `absent` is off it. Both API calls are idempotent -- adding a label that
+          // is already applied is a no-op, and removing an absent label 404s
+          // (guarded) -- so repeated/out-of-order calls converge without flapping.
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            labels: [target.present],
+          });
+          core.info(`PR #${prNumber}: ensured ${target.present}`);
+          try {
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              name: target.absent,
+            });
+            core.info(`PR #${prNumber}: ensured ${target.absent} removed`);
+          } catch (err) {
+            if (err.status !== 404) throw err; // already absent: fine
+          }

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -8,6 +8,14 @@
 # pull-request and commit metadata through the API, then calls a composite action
 # that queries an external endpoint using already-public GitHub handles. No fork
 # secret is used -- only this workflow's own token.
+#
+# Every job also syncs the cla-signed / cla-not-signed labels itself, right after
+# posting the status: a commit status created with this workflow's own GITHUB_TOKEN
+# does not fire the `status` event, so cla-label-sync.yml's primary `on: status`
+# trigger never runs for a status this workflow posts. Reconciling the labels here,
+# from the same write-capable token that already posted the status, keeps labeling in
+# lockstep with the status this workflow controls rather than depending on a webhook
+# that GitHub's own anti-recursion rule for GITHUB_TOKEN never delivers.
 
 name: CLA check
 
@@ -89,6 +97,13 @@ jobs:
           enumeration-complete: ${{ steps.enumerate.outputs.enumeration-complete }}
           unidentified: ${{ steps.enumerate.outputs.unidentified }}
           unidentified-policy: fail
+          token: ${{ github.token }}
+
+      - name: Sync CLA labels to this check's own result
+        uses: fivetran/great_expectations/.github/actions/cla-label-sync@develop
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          state: ${{ steps.cla-status.outputs.state }}
           token: ${{ github.token }}
 
       - name: Build guiding comment body
@@ -244,6 +259,14 @@ jobs:
           enumeration-complete: ${{ steps.enumerate.outputs.enumeration-complete }}
           unidentified: ${{ steps.enumerate.outputs.unidentified }}
           unidentified-policy: fail
+          token: ${{ github.token }}
+
+      - name: Sync CLA labels to this check's own result
+        if: steps.enumerate.outputs.skip == 'false'
+        uses: fivetran/great_expectations/.github/actions/cla-label-sync@develop
+        with:
+          pr-number: ${{ github.event.issue.number }}
+          state: ${{ steps.cla-status.outputs.state }}
           token: ${{ github.token }}
 
       - name: Build guiding comment body

--- a/.github/workflows/cla-label-sync.yml
+++ b/.github/workflows/cla-label-sync.yml
@@ -9,17 +9,26 @@
 # Label state is derived ONLY from the `verification/cla-signed` status — never by
 # re-checking signatures — so the labels can never contradict the merge gate.
 #
+# cla-check.yml (the self-hosted check that posts this status) now syncs these same
+# labels itself, immediately after posting the status, using the write-capable
+# base-repo token it already holds. That is the primary path for every status it
+# posts: a commit status created with a workflow's own GITHUB_TOKEN does not fire
+# the `status` webhook event (GitHub's anti-recursion rule for the default token), so
+# this workflow's own `status` trigger never runs for those statuses. This workflow
+# now exists as a backstop, kept for any status posted by a different actor and for
+# the race where a PR is opened before the status is resolvable:
+#
 # Triggers:
-#   * status         — the primary path. Fires when the CLA check posts/updates the
-#                      status. Runs from the default branch with a read-write base-repo
-#                      token, so it can label fork-originated pull requests (the common
-#                      case) with no extra secret.
-#   * pull_request   — a backstop for the race where the status is posted before the PR
-#                      object is resolvable. NOTE: a pull_request run triggered from a
-#                      fork gets a read-only token, so it cannot label fork PRs; fork-PR
-#                      labeling therefore rests on the `status` path, which self-heals on
-#                      the next status event. This is safe because the merge gate is the
-#                      status itself, not the label.
+#   * status         — fires for a `verification/cla-signed` status posted by an actor
+#                      other than this repo's own GITHUB_TOKEN (e.g. a third-party
+#                      integration), or replayed for self-healing. Runs from the
+#                      default branch with a read-write base-repo token.
+#   * pull_request   — a backstop for the race where a status already exists before
+#                      the PR object is resolvable. NOTE: a pull_request run triggered
+#                      from a fork gets a read-only token, so it cannot label fork
+#                      PRs; that failure is expected and tolerated here (see below) —
+#                      fork PRs are labeled by cla-check.yml's own base-repo token
+#                      instead, not by this backstop.
 #
 # Note: the `status` trigger only takes effect once this file is on the default branch;
 # its behavior is validated on a live pull request there, not from a feature branch.
@@ -136,6 +145,22 @@ jobs:
                 core.info(`No-op for state ${claStatus.state}`);
                 return;
               }
-              await reconcile(pr.number, target.present, target.absent);
+              try {
+                await reconcile(pr.number, target.present, target.absent);
+              } catch (err) {
+                if (err.status === 403) {
+                  // Expected on a fork PR: a pull_request-triggered run gets a
+                  // read-only token and cannot write labels. cla-check.yml's own
+                  // base-repo token already synced these labels directly, so this
+                  // backstop has nothing left to do here.
+                  core.warning(
+                    `PR #${pr.number}: no write access to labels from this pull_request run ` +
+                    `(likely a fork PR with a read-only token). cla-check.yml's direct sync ` +
+                    'is the labeling path for this case; treating this as a no-op.'
+                  );
+                  return;
+                }
+                throw err;
+              }
               return;
             }


### PR DESCRIPTION
## Summary
- `cla-check.yml` posts `verification/cla-signed` using its own `GITHUB_TOKEN`. GitHub's anti-recursion rule for the default token means that status creation never fires the `status` webhook event, so `cla-label-sync.yml`'s primary `on: status` trigger never runs for it — confirmed live: a PR whose status flipped to `success` kept its stale `cla-not-signed` label indefinitely.
- `cla-check.yml` now syncs the labels itself, immediately after posting the status, via a new shared composite action (`.github/actions/cla-label-sync`) and the same write-capable base-repo token it already holds for both its `pull_request_target` job and its `@cla-bot check` recheck job.
- `cla-label-sync.yml` keeps its existing triggers as a backstop (e.g. a status posted by some other actor), and now tolerates the known read-only-token limitation on a fork-triggered `pull_request` run (logs and no-ops on a `403`) instead of throwing an unhandled error and failing the job outright.

## Test plan
- [x] `actionlint` clean on `cla-check.yml`, `cla-label-sync.yml`, and the new composite action (validated via a throwaway scratch workflow referencing it, since actionlint can't lint a bare `action.yml`).
- [x] `node --check` on every inline script touched.
- [ ] Live: confirm on a real PR that the label now updates in the same run that posts a passing/failing status, with no separate `status` event required.
- [ ] Live: confirm a fork PR still gets correctly labeled (via `cla-check.yml`'s own sync) and that `cla-label-sync.yml`'s `pull_request` backstop no-ops cleanly rather than failing on that PR.