### PR TITLE
[CONTRIB] Add configurable connection retry logic for database backends (#11148)

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1302,6 +1302,21 @@ class SQLDatasource(Datasource):
     type: Literal["sql"] = "sql"
     connection_string: Union[ConfigStr, str]
     create_temp_table: bool = False
+    connection_retry_count: int = pydantic.Field(
+        default=0,
+        ge=0,
+        description="Number of times to retry a failed database connection. "
+        "Defaults to 0 (no retries). Set to a positive integer to enable "
+        "automatic retries with exponential backoff on transient connection failures.",
+    )
+    connection_retry_backoff_factor: float = pydantic.Field(
+        default=0.5,
+        ge=0,
+        description="Backoff factor for connection retries using exponential backoff. "
+        "The wait time between retries is calculated as: "
+        "backoff_factor * (2 ** attempt_number). "
+        "For example, with the default of 0.5 the waits are 0.5s, 1s, 2s, 4s, etc.",
+    )
     kwargs: Dict[str, Union[ConfigStr, Any]] = pydantic.Field(
         default={},
         description="Optional dictionary of `kwargs` will be passed to the SQLAlchemy Engine"

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -9,6 +9,7 @@ import os
 import random
 import re
 import string
+import time
 import traceback
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -41,6 +42,7 @@ from great_expectations.compatibility.not_imported import is_version_greater_or_
 from great_expectations.compatibility.sqlalchemy import (
     ColumnElement,
     DatabaseError,
+    OperationalError,
     PendingRollbackError,
     Subquery,
 )
@@ -280,6 +282,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         url: Optional[str] = None,
         batch_data_dict: Optional[dict] = None,
         create_temp_table: bool = True,
+        connection_retry_count: int = 0,
+        connection_retry_backoff_factor: float = 0.5,
         # kwargs will be passed as optional parameters to the SQLAlchemy engine, **not** the ExecutionEngine  # noqa: E501 # FIXME CoP
         **kwargs,
     ) -> None:
@@ -290,6 +294,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         self._connection_string = connection_string
         self._url = url
         self._create_temp_table = create_temp_table
+        self._connection_retry_count = connection_retry_count
+        self._connection_retry_backoff_factor = connection_retry_backoff_factor
         os.environ["SF_PARTNER"] = "great_expectations_oss"  # noqa: TID251 # FIXME CoP
 
         # sqlite/SQL Server temp tables only persist within a connection, so we need to keep the connection alive by  # noqa: E501 # FIXME CoP
@@ -1445,6 +1451,39 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
 
         return self._inspector  # type: ignore[return-value] # FIXME CoP
 
+    def _connect_with_retries(self) -> sqlalchemy.Connection:
+        """Establish a database connection with configurable retry logic.
+
+        Retries on OperationalError (transient network/connection failures)
+        using exponential backoff.
+
+        Returns:
+            A SQLAlchemy Connection object.
+
+        Raises:
+            The last OperationalError if all retries are exhausted,
+            or any non-retryable exception immediately.
+        """
+        max_attempts = 1 + self._connection_retry_count
+        for attempt in range(max_attempts):
+            try:
+                return self.engine.connect()
+            except OperationalError:
+                if attempt < max_attempts - 1:
+                    wait_time = self._connection_retry_backoff_factor * (2**attempt)
+                    logger.warning(
+                        "Database connection attempt %d of %d failed. "
+                        "Retrying in %.1f seconds...",
+                        attempt + 1,
+                        max_attempts,
+                        wait_time,
+                    )
+                    time.sleep(wait_time)
+                else:
+                    raise
+
+        raise RuntimeError("Unreachable")  # pragma: no cover
+
     @contextmanager
     def get_connection(self) -> Generator[sqlalchemy.Connection, None, None]:
         """Get a connection for executing queries.
@@ -1461,15 +1500,18 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         if self.dialect_name in _PERSISTED_CONNECTION_DIALECTS:
             try:
                 if not self._connection:
-                    self._connection = self.engine.connect()
+                    self._connection = self._connect_with_retries()
                 yield self._connection
             finally:
                 # Temp tables only persist within a connection for some dialects,
                 # so we need to keep the connection alive.
                 pass
         else:
-            with self.engine.connect() as connection:
+            connection = self._connect_with_retries()
+            try:
                 yield connection
+            finally:
+                connection.close()
 
     @staticmethod
     def _execute_query_with_recovery(

--- a/tests/execution_engine/test_sqlalchemy_connection_retry.py
+++ b/tests/execution_engine/test_sqlalchemy_connection_retry.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+    SqlAlchemyExecutionEngine,
+)
+
+
+try:
+    import sqlalchemy as sa
+
+    sqlalchemy_not_installed = False
+except ImportError:
+    sqlalchemy_not_installed = True
+
+
+pytestmark = [
+    pytest.mark.skipif(sqlalchemy_not_installed, reason="sqlalchemy not installed"),
+    pytest.mark.unit,
+]
+
+
+class TestConnectionRetryParameters:
+    def test_default_retry_count_is_zero(self):
+        engine = SqlAlchemyExecutionEngine(connection_string="sqlite://")
+        assert engine._connection_retry_count == 0
+
+    def test_default_backoff_factor(self):
+        engine = SqlAlchemyExecutionEngine(connection_string="sqlite://")
+        assert engine._connection_retry_backoff_factor == 0.5
+
+    def test_custom_retry_count(self):
+        engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=3,
+        )
+        assert engine._connection_retry_count == 3
+
+    def test_custom_backoff_factor(self):
+        engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_backoff_factor=1.0,
+        )
+        assert engine._connection_retry_backoff_factor == 1.0
+
+
+class TestConnectWithRetries:
+    def test_successful_connection_no_retry(self):
+        execution_engine = SqlAlchemyExecutionEngine(connection_string="sqlite://")
+        connection = execution_engine._connect_with_retries()
+        assert connection is not None
+        connection.close()
+
+    def test_no_retry_on_operational_error_when_retry_count_zero(self):
+        execution_engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=0,
+        )
+
+        mock_connect = MagicMock(
+            side_effect=sa.exc.OperationalError("test", {}, Exception("connection refused")),
+        )
+        execution_engine.engine.connect = mock_connect
+
+        with pytest.raises(sa.exc.OperationalError):
+            execution_engine._connect_with_retries()
+
+        assert mock_connect.call_count == 1
+
+    @patch("great_expectations.execution_engine.sqlalchemy_execution_engine.time.sleep")
+    def test_retry_succeeds_after_transient_failure(self, mock_sleep):
+        execution_engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=2,
+        )
+
+        mock_connection = MagicMock()
+        execution_engine.engine.connect = MagicMock(
+            side_effect=[
+                sa.exc.OperationalError("test", {}, Exception("connection refused")),
+                mock_connection,
+            ]
+        )
+
+        result = execution_engine._connect_with_retries()
+        assert result is mock_connection
+        assert execution_engine.engine.connect.call_count == 2
+        mock_sleep.assert_called_once_with(0.5)
+
+    @patch("great_expectations.execution_engine.sqlalchemy_execution_engine.time.sleep")
+    def test_retry_exhausted_raises_last_error(self, mock_sleep):
+        execution_engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=2,
+            connection_retry_backoff_factor=0.5,
+        )
+
+        execution_engine.engine.connect = MagicMock(
+            side_effect=sa.exc.OperationalError("test", {}, Exception("connection refused")),
+        )
+
+        with pytest.raises(sa.exc.OperationalError):
+            execution_engine._connect_with_retries()
+
+        assert execution_engine.engine.connect.call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(0.5)
+        mock_sleep.assert_any_call(1.0)
+
+    @patch("great_expectations.execution_engine.sqlalchemy_execution_engine.time.sleep")
+    def test_exponential_backoff_timing(self, mock_sleep):
+        execution_engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=3,
+            connection_retry_backoff_factor=1.0,
+        )
+
+        mock_connection = MagicMock()
+        execution_engine.engine.connect = MagicMock(
+            side_effect=[
+                sa.exc.OperationalError("test", {}, Exception("fail 1")),
+                sa.exc.OperationalError("test", {}, Exception("fail 2")),
+                sa.exc.OperationalError("test", {}, Exception("fail 3")),
+                mock_connection,
+            ]
+        )
+
+        result = execution_engine._connect_with_retries()
+        assert result is mock_connection
+        assert mock_sleep.call_count == 3
+        mock_sleep.assert_any_call(1.0)
+        mock_sleep.assert_any_call(2.0)
+        mock_sleep.assert_any_call(4.0)
+
+    def test_non_operational_error_not_retried(self):
+        execution_engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=3,
+        )
+
+        execution_engine.engine.connect = MagicMock(
+            side_effect=ValueError("bad config"),
+        )
+
+        with pytest.raises(ValueError, match="bad config"):
+            execution_engine._connect_with_retries()
+
+        assert execution_engine.engine.connect.call_count == 1
+
+
+class TestGetConnectionWithRetries:
+    def test_get_connection_uses_retry_logic(self):
+        execution_engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=1,
+        )
+
+        with execution_engine.get_connection() as connection:
+            assert connection is not None
+
+    @patch("great_expectations.execution_engine.sqlalchemy_execution_engine.time.sleep")
+    def test_get_connection_retries_on_failure(self, mock_sleep):
+        execution_engine = SqlAlchemyExecutionEngine(
+            connection_string="sqlite://",
+            connection_retry_count=1,
+        )
+
+        mock_connection = MagicMock()
+        mock_connection.close = MagicMock()
+        with patch.object(
+            execution_engine.engine,
+            "connect",
+            side_effect=[
+                sa.exc.OperationalError("test", {}, Exception("connection refused")),
+                mock_connection,
+            ],
+        ):
+            with execution_engine.get_connection() as connection:
+                assert connection is mock_connection


### PR DESCRIPTION
Adds connection_retry_count and connection_retry_backoff_factor parameters to SQLDatasource and SqlAlchemyExecutionEngine, allowing users to configure automatic retries with exponential backoff when transient database connection failures occur (e.g. AWS RDS dropping connections).

Defaults to 0 retries so existing behavior is unchanged.

Closes #11148

- [x] Description of PR changes above includes a link to an existing GitHub issue
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
- [ ] For any behavioral change to a data source, validation mechanic, or Expectation, at least one integration test exists in `tests/integration/data_sources_and_expectations` (see AGENTS.md#integration-test-requirement)
- [x] CI is green, including linting, mypy type-checking, and tests - this is required for merge
- [x] If this PR proposes adopting or recommending a particular third-party library or service, any affiliation with it (employment, financial interest, maintainership) is disclosed above for the reviewer's context
