### PR TITLE
[MAINTENANCE] Add per-metric override hooks for SqlAlchemy row-retrieval providers

### DIFF
--- a/great_expectations/expectations/metrics/map_metric_provider/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_metric_provider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import logging
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility.typing_extensions import override
@@ -101,6 +101,21 @@ class MapMetricProvider(MetricProvider):
     condition_value_keys: tuple[str, ...] = tuple()
     function_value_keys: tuple[str, ...] = tuple()
     filter_column_isnull = True
+
+    # Deliberately limited to the SQLAlchemy row-retrieval providers: only the SQL path has a
+    # narrow-selectable variant that needs to diverge from the generic full-row builders below.
+    # Assign plain module functions here, never a `@column_condition_partial`-decorated method —
+    # a decorated method carries `metric_engine` and would be double-registered by the
+    # `inspect.getmembers` scan in `_register_metric_functions` below.
+    sqlalchemy_unexpected_rows_provider: Callable[..., Any] = staticmethod(
+        _sqlalchemy_map_condition_rows
+    )
+    sqlalchemy_unexpected_index_list_provider: Callable[..., Any] = staticmethod(
+        _sqlalchemy_map_condition_index
+    )
+    sqlalchemy_unexpected_index_query_provider: Callable[..., Any] = staticmethod(
+        _sqlalchemy_map_condition_query
+    )
 
     @classmethod
     @override
@@ -267,7 +282,7 @@ class MapMetricProvider(MetricProvider):
                         metric_value_keys=(*metric_value_keys, "result_format"),
                         execution_engine=engine,
                         metric_class=cls,
-                        metric_provider=_sqlalchemy_map_condition_rows,
+                        metric_provider=cls.sqlalchemy_unexpected_rows_provider,
                         metric_fn_type=MetricFunctionTypes.VALUE,
                     )
                     register_metric(
@@ -276,7 +291,7 @@ class MapMetricProvider(MetricProvider):
                         metric_value_keys=(*metric_value_keys, "result_format"),
                         execution_engine=engine,
                         metric_class=cls,
-                        metric_provider=_sqlalchemy_map_condition_index,
+                        metric_provider=cls.sqlalchemy_unexpected_index_list_provider,
                         metric_fn_type=MetricFunctionTypes.VALUE,
                     )
                     register_metric(
@@ -285,7 +300,7 @@ class MapMetricProvider(MetricProvider):
                         metric_value_keys=(*metric_value_keys, "result_format"),
                         execution_engine=engine,
                         metric_class=cls,
-                        metric_provider=_sqlalchemy_map_condition_query,
+                        metric_provider=cls.sqlalchemy_unexpected_index_query_provider,
                         metric_fn_type=MetricFunctionTypes.VALUE,
                     )
                     if metric_fn_type == MetricPartialFunctionTypes.MAP_CONDITION_FN:

--- a/tests/expectations/metrics/test_metric_providers.py
+++ b/tests/expectations/metrics/test_metric_providers.py
@@ -27,6 +27,11 @@ from great_expectations.expectations.metrics.map_metric_provider.column_conditio
 from great_expectations.expectations.metrics.map_metric_provider.column_pair_condition_partial import (  # noqa: E501 # FIXME CoP
     column_pair_condition_partial,
 )
+from great_expectations.expectations.metrics.map_metric_provider.map_condition_auxilliary_methods import (  # noqa: E501 # FIXME CoP
+    _sqlalchemy_map_condition_index,
+    _sqlalchemy_map_condition_query,
+    _sqlalchemy_map_condition_rows,
+)
 from great_expectations.expectations.metrics.map_metric_provider.multicolumn_condition_partial import (  # noqa: E501 # FIXME CoP
     multicolumn_condition_partial,
 )
@@ -204,6 +209,91 @@ def test__column_map_metric__registration(mock_registry):
     ]
     for key in new_keys:
         assert key in mock_registry._registered_metrics
+
+
+def test__map_metric_provider__sqlalchemy_row_retrieval_provider_hooks(
+    mock_registry, caplog: pytest.LogCaptureFixture
+):
+    """MapMetricProvider exposes a per-metric override surface for the three SqlAlchemy
+    row-retrieval providers (unexpected_rows / unexpected_index_list / unexpected_index_query):
+    `sqlalchemy_unexpected_rows_provider`, `sqlalchemy_unexpected_index_list_provider`, and
+    `sqlalchemy_unexpected_index_query_provider`. A subclass overriding these class attributes
+    gets its custom provider registered exactly once -- no super()-then-re-register, no
+    "overwriting metric_provider" warning.
+    """  # FIXME CoP
+
+    def _custom_rows(cls, **kwargs):
+        raise NotImplementedError
+
+    def _custom_index_list(cls, **kwargs):
+        raise NotImplementedError
+
+    def _custom_index_query(cls, **kwargs):
+        raise NotImplementedError
+
+    class CustomColumnValuesEqualEight(ColumnMapMetricProvider):
+        condition_metric_name = "column_values.equal_eight"
+
+        sqlalchemy_unexpected_rows_provider = staticmethod(_custom_rows)
+        sqlalchemy_unexpected_index_list_provider = staticmethod(_custom_index_list)
+        sqlalchemy_unexpected_index_query_provider = staticmethod(_custom_index_query)
+
+        @column_condition_partial(engine=PandasExecutionEngine)
+        def _pandas(cls, column, **kwargs):
+            return column == 8
+
+        @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+        def _sqlalchemy(cls, column, **kwargs):
+            return column.is_(8)
+
+        @column_condition_partial(engine=SparkDFExecutionEngine)
+        def _spark(cls, column, **kwargs):
+            return column.contains(8)
+
+    with caplog.at_level("WARNING"):
+        CustomColumnValuesEqualEight()
+
+    assert "overwriting metric_provider" not in caplog.text
+
+    _, rows_fn = mock_registry.get_sqlalchemy_metric_provider(
+        "column_values.equal_eight.unexpected_rows"
+    )
+    _, index_list_fn = mock_registry.get_sqlalchemy_metric_provider(
+        "column_values.equal_eight.unexpected_index_list"
+    )
+    _, index_query_fn = mock_registry.get_sqlalchemy_metric_provider(
+        "column_values.equal_eight.unexpected_index_query"
+    )
+
+    assert rows_fn is _custom_rows
+    assert index_list_fn is _custom_index_list
+    assert index_query_fn is _custom_index_query
+
+
+def test__column_values_unique__sqlalchemy_row_retrieval_providers_are_generic(mock_registry):
+    """Regression guard for `column_values.unique`'s SqlAlchemy row-retrieval providers.
+
+    `ColumnValuesUnique` does not currently override the `MapMetricProvider` row-retrieval
+    provider hooks (see `test__map_metric_provider__sqlalchemy_row_retrieval_provider_hooks`), so
+    it still resolves to the generic full-row builders today. Once it overrides
+    `sqlalchemy_unexpected_rows_provider` / `sqlalchemy_unexpected_index_list_provider` /
+    `sqlalchemy_unexpected_index_query_provider` with narrow, single-scan providers, this test
+    must be updated to assert identity against those custom providers instead -- turning it into
+    a guard against silently reverting to the generic (wide-row) providers.
+    """  # FIXME CoP
+    _, rows_fn = mock_registry.get_sqlalchemy_metric_provider(
+        "column_values.unique.unexpected_rows"
+    )
+    _, index_list_fn = mock_registry.get_sqlalchemy_metric_provider(
+        "column_values.unique.unexpected_index_list"
+    )
+    _, index_query_fn = mock_registry.get_sqlalchemy_metric_provider(
+        "column_values.unique.unexpected_index_query"
+    )
+
+    assert rows_fn is _sqlalchemy_map_condition_rows
+    assert index_list_fn is _sqlalchemy_map_condition_index
+    assert index_query_fn is _sqlalchemy_map_condition_query
 
 
 def test__column_pair_map_metric__registration(mock_registry):


### PR DESCRIPTION
## Summary

`MapMetricProvider`'s base registration loop hardcoded its three SqlAlchemy row-retrieval providers (`unexpected_rows` / `unexpected_index_list` / `unexpected_index_query`) as literals. A subclass needing a custom provider for one of them had no way to opt in except calling `super()` and then re-registering with a different function -- which double-registers the metric and trips the registry's "different metric_provider" warning on every import.

This PR exposes the three providers as overridable class attributes (`sqlalchemy_unexpected_rows_provider`, `sqlalchemy_unexpected_index_list_provider`, `sqlalchemy_unexpected_index_query_provider`), defaulting to today's functions so registration is behavior-identical for every existing map metric. The base loop now registers `cls.<attr>` instead of the literal. A subclass can override one attribute and get single, warning-free registration -- and it also makes "which of the three did you override" an explicit, visible declaration instead of an implicit super()-then-overwrite that's easy to get partially wrong.

Prepares for #11863, which needs to override these three providers for `column_values.unique`'s narrow single-scan SQL path. No behavior for `column_values.unique` changes here -- that override belongs in #11863.

## Test plan
- [x] Added `test__map_metric_provider__sqlalchemy_row_retrieval_provider_hooks`: proves a subclass overriding the three attributes registers its custom provider exactly once, with no re-registration warning.
- [x] Added `test__column_values_unique__sqlalchemy_row_retrieval_providers_are_generic`: pins `column_values.unique`'s current (generic) provider identity as a regression guard. This is expected to be updated (asserting the custom providers instead) once #11863 overrides the new hooks.
- [x] `ruff check` / `ruff format` clean on both changed files.
- [x] `mypy` clean on both changed files (verified against develop baseline to confirm pre-existing unrelated stub errors elsewhere are unaffected).
- [x] Full `tests/expectations/` unit suite passes (1503 passed).