### PR TITLE
[MAINTENANCE] Namespace ephemeral SQL test schemas under gx_ci_test_ and fix cleanup regex charsets

### DIFF
--- a/scripts/cleanup/cleanup_big_query.py
+++ b/scripts/cleanup/cleanup_big_query.py
@@ -25,7 +25,7 @@ class BigQueryConnectionConfig(BaseSettings):
 
 
 # Schema patterns for different test types
-SCHEMA_PATTERN_TEST = "^gx_ci_test_[a-z]{10}$"  # General SQL testing framework
+SCHEMA_PATTERN_TEST = "^gx_ci_test_[a-f0-9]{10}$"  # General SQL testing framework
 SCHEMA_PATTERN_PY_VERSION = "^py3[0-9]{1,2}_i[a-f0-9]{32}$"  # Python version-specific test schemas
 SCHEMA_FORMAT = f"{SCHEMA_PATTERN_TEST}|{SCHEMA_PATTERN_PY_VERSION}"
 

--- a/scripts/cleanup/cleanup_big_query.py
+++ b/scripts/cleanup/cleanup_big_query.py
@@ -25,7 +25,7 @@ class BigQueryConnectionConfig(BaseSettings):
 
 
 # Schema patterns for different test types
-SCHEMA_PATTERN_TEST = "^test_[a-z]{10}$"  # General SQL testing framework
+SCHEMA_PATTERN_TEST = "^gx_ci_test_[a-z]{10}$"  # General SQL testing framework
 SCHEMA_PATTERN_PY_VERSION = "^py3[0-9]{1,2}_i[a-f0-9]{32}$"  # Python version-specific test schemas
 SCHEMA_FORMAT = f"{SCHEMA_PATTERN_TEST}|{SCHEMA_PATTERN_PY_VERSION}"
 

--- a/scripts/cleanup/cleanup_databricks.py
+++ b/scripts/cleanup/cleanup_databricks.py
@@ -9,7 +9,7 @@ logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 # Schema patterns for different test types
-SCHEMA_PATTERN_10_CHAR = "gx_ci_test_[a-z]{10}"  # General SQL testing framework
+SCHEMA_PATTERN_10_CHAR = "gx_ci_test_[a-f0-9]{10}"  # General SQL testing framework
 SCHEMA_PATTERN_8_CHAR = "gx_ci_test_[a-f0-9]{8}"  # Databricks-specific tests
 SCHEMA_PATTERN_PY_VERSION = "py3[0-9]{1,2}_i[a-f0-9]{32}"  # Python version-specific test schemas
 SCHEMA_PATTERN = f"{SCHEMA_PATTERN_10_CHAR}|{SCHEMA_PATTERN_8_CHAR}|{SCHEMA_PATTERN_PY_VERSION}"

--- a/scripts/cleanup/cleanup_databricks.py
+++ b/scripts/cleanup/cleanup_databricks.py
@@ -9,8 +9,8 @@ logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 # Schema patterns for different test types
-SCHEMA_PATTERN_10_CHAR = "test_[a-z]{10}"  # General SQL testing framework
-SCHEMA_PATTERN_8_CHAR = "test_[a-f0-9]{8}"  # Databricks-specific tests
+SCHEMA_PATTERN_10_CHAR = "gx_ci_test_[a-z]{10}"  # General SQL testing framework
+SCHEMA_PATTERN_8_CHAR = "gx_ci_test_[a-f0-9]{8}"  # Databricks-specific tests
 SCHEMA_PATTERN_PY_VERSION = "py3[0-9]{1,2}_i[a-f0-9]{32}"  # Python version-specific test schemas
 SCHEMA_PATTERN = f"{SCHEMA_PATTERN_10_CHAR}|{SCHEMA_PATTERN_8_CHAR}|{SCHEMA_PATTERN_PY_VERSION}"
 

--- a/scripts/cleanup/cleanup_snowflake.py
+++ b/scripts/cleanup/cleanup_snowflake.py
@@ -36,7 +36,7 @@ class SnowflakeConnectionConfig(BaseSettings):
 
 # Regex to match uppercase schema names
 # (Snowflake converts unquoted identifiers to uppercase)
-SCHEMA_PATTERN_TEST = "^GX_CI_TEST_[A-Z]{10}$"  # General SQL testing framework
+SCHEMA_PATTERN_TEST = "^GX_CI_TEST_[A-F0-9]{10}$"  # General SQL testing framework
 SCHEMA_PATTERN_PY_VERSION = "^PY3[0-9]{1,2}_I[A-F0-9]{32}$"  # Python version-specific test schemas
 SCHEMA_FORMAT = f"{SCHEMA_PATTERN_TEST}|{SCHEMA_PATTERN_PY_VERSION}"
 

--- a/scripts/cleanup/cleanup_snowflake.py
+++ b/scripts/cleanup/cleanup_snowflake.py
@@ -36,7 +36,7 @@ class SnowflakeConnectionConfig(BaseSettings):
 
 # Regex to match uppercase schema names
 # (Snowflake converts unquoted identifiers to uppercase)
-SCHEMA_PATTERN_TEST = "^TEST_[A-Z]{10}$"  # General SQL testing framework
+SCHEMA_PATTERN_TEST = "^GX_CI_TEST_[A-Z]{10}$"  # General SQL testing framework
 SCHEMA_PATTERN_PY_VERSION = "^PY3[0-9]{1,2}_I[A-F0-9]{32}$"  # Python version-specific test schemas
 SCHEMA_FORMAT = f"{SCHEMA_PATTERN_TEST}|{SCHEMA_PATTERN_PY_VERSION}"
 

--- a/tests/integration/execution_engine/test_databricks_execution_engine.py
+++ b/tests/integration/execution_engine/test_databricks_execution_engine.py
@@ -33,7 +33,7 @@ def generate_large_table_for_metrics(sa):
         df = pd.DataFrame(data)
 
         config = DatabricksConnectionConfig()
-        schema_name = f"test_{uuid.uuid4().hex[:8]}"
+        schema_name = f"gx_ci_test_{uuid.uuid4().hex[:8]}"
         connection_string = config.build_connection_string(schema_name)
 
         execution_engine = SqlAlchemyExecutionEngine(connection_string=connection_string)

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -86,7 +86,7 @@ InferredColumnTypes = dict[str, Union[type[TypeEngine], TypeEngine]]
 
 
 class SQLBatchTestSetup(BatchTestSetup[_ConfigT, TableAsset], ABC, Generic[_ConfigT]):
-    SCHEMA_PREFIX = "test_"
+    SCHEMA_PREFIX = "gx_ci_test_"
 
     @abstractmethod
     def build_connection_string(self, schema: str | None = None) -> str:


### PR DESCRIPTION
## Summary

Two related fixes to the ephemeral schema lifecycle for the SQL integration test suite:

1. Renames `SCHEMA_PREFIX` on `SQLBatchTestSetup` (base class for every SQL-backed test datasource: Postgres, MySQL, SQL Server, Snowflake, Databricks, BigQuery, Redshift) from `test_` to `gx_ci_test_`, and updates the schema-name-matching cleanup scripts (`cleanup_big_query.py`, `cleanup_databricks.py`, `cleanup_snowflake.py`) to match.
2. Fixes the character class in those same cleanup regexes: the suffix is `uuid4().hex[:N]` (alphabet `0-9a-f`), but the existing patterns only matched `a-z`/`A-Z`, silently excluding any suffix containing a digit.

## Why

**Prefix rename:** the bare `test_` prefix is not exclusive to this project's CI infrastructure — in at least one shared environment it collides with thousands of unrelated datasets created by other teams. That makes it unsafe to use as a scoping boundary for IAM permissions or the hourly stale-schema cleanup job (`data_source_cleanup.yml`). `gx_ci_test_` gives this suite's ephemeral schemas an unambiguous, exclusive prefix.

**Charset fix:** while updating the cleanup patterns, found that all three (`^test_[a-z]{10}$`, `test_[a-z]{10}`, `^TEST_[A-Z]{10}$`) required every suffix character to be a letter, but the suffix is hex (`0-9a-f`) — so any suffix containing a digit failed to match. With 10 hex characters, the odds of an all-letter suffix are ~0.006%, meaning the hourly cleanup job has been dropping only a tiny fraction of stale schemas since it was written. Also found `test_databricks_execution_engine.py` generates its own schema directly (bypassing `SQLBatchTestSetup`) using the same bare `test_` prefix, with no teardown of its own — it depends entirely on the cleanup job's regex to ever get removed, so it needed the same prefix update to keep being swept.

## User impact

None. This only affects ephemeral schema/dataset names created and torn down (or cleaned up) by the integration test suite itself; no public API or library behavior changes.