### PR TITLE
[MAINTENANCE] Defer the schema listing in TableAsset.test_connection to the failure path

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1160,21 +1160,7 @@ class TableAsset(_SQLAsset):
         """
         datasource: SQLDatasource = self.datasource
         engine: sqlalchemy.Engine = datasource.get_engine()
-        inspector: sqlalchemy.Inspector = sa.inspect(engine)
-
-        schema_names = inspector.get_schema_names()
-        schema_names = (
-            [self._to_lower_if_not_bracketed_by_quotes(name) for name in schema_names]
-            if schema_names
-            else []
-        )
-
         effective_schema = self._effective_schema_name
-        if effective_schema and effective_schema not in schema_names:
-            raise TestConnectionError(  # noqa: TRY003 # FIXME CoP
-                f'Attempt to connect to table: "{self.qualified_name}" failed because the schema '
-                f'"{effective_schema}" does not exist.'
-            )
 
         try:
             with engine.connect() as connection:
@@ -1183,10 +1169,41 @@ class TableAsset(_SQLAsset):
                 connection.execute(sa.select(1, table).limit(1))
         except Exception as query_error:
             LOGGER.info(f"{self.name} `.test_connection()` query failed: {query_error!r}")
+            # A missing schema is a common cause of this failure and deserves a more
+            # specific message, but determining it requires listing every schema on the
+            # server. On some backends that listing is dramatically more expensive than
+            # the probe query itself -- it can be a server-wide metadata scan whose cost
+            # scales with the whole instance rather than with this table -- so it is only
+            # worth paying for once we already know the probe failed.
+            if effective_schema and not self._schema_exists(engine, effective_schema):
+                raise TestConnectionError(  # noqa: TRY003 # FIXME CoP
+                    f'Attempt to connect to table: "{self.qualified_name}" failed because '
+                    f'the schema "{effective_schema}" does not exist.'
+                ) from query_error
             raise TestConnectionError(  # noqa: TRY003 # FIXME CoP
                 f"Attempt to connect to table: {self.qualified_name} failed because the test query "
                 f"failed. Ensure the table exists and the user has access to select data from the table: {query_error}"  # noqa: E501 # FIXME CoP
             ) from query_error
+
+    def _schema_exists(self, engine: sqlalchemy.Engine, effective_schema: str) -> bool:
+        """Whether ``effective_schema`` is visible on the server.
+
+        Only ever called after the connection probe has already failed, to decide
+        between two error messages. If the listing itself fails we cannot tell, so
+        report the schema as present and let the caller fall back to the generic
+        message rather than masking the original error with this one.
+        """
+        try:
+            inspector: sqlalchemy.Inspector = sa.inspect(engine)
+            schema_names = inspector.get_schema_names() or []
+        except Exception as inspect_error:
+            LOGGER.info(
+                f"{self.name} `.test_connection()` could not list schemas: {inspect_error!r}"
+            )
+            return True
+        return effective_schema in [
+            self._to_lower_if_not_bracketed_by_quotes(name) for name in schema_names
+        ]
 
     @override
     def as_selectable(self) -> sqlalchemy.Selectable:

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -809,6 +809,93 @@ def test_test_connection_failures(
         bad_configuration_datasource.test_connection()
 
 
+def _schema_qualified_datasource() -> PostgresDatasource:
+    return PostgresDatasource(
+        name="postgres_datasource",
+        connection_string="postgresql+psycopg2://postgres:@localhost/test_ci",
+        assets=[
+            TableAsset(
+                name="table_asset",
+                table_name="my_table",
+                schema_name="my_schema",
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def spy_inspector(mocker: MockFixture) -> Mock:
+    """An inspector whose get_schema_names is a spy, so calls can be asserted on."""
+    inspector = MockSaInspector()
+    inspector.get_schema_names = mocker.Mock(return_value=["my_schema"])  # type: ignore[method-assign]
+    mocker.patch("sqlalchemy.inspect").return_value = inspector
+    return inspector.get_schema_names
+
+
+@pytest.mark.postgresql
+def test_test_connection_does_not_list_schemas_when_probe_succeeds(
+    mock_create_engine: Mock,
+    spy_inspector: Mock,
+):
+    """The schema listing exists only to refine an error message.
+
+    Listing every schema on the server can cost far more than the probe query --
+    on some backends it is a server-wide metadata scan -- so nothing should list
+    schemas while the connection is healthy.
+    """
+    _schema_qualified_datasource().test_connection()
+
+    spy_inspector.assert_not_called()
+
+
+@pytest.mark.postgresql
+def test_test_connection_reports_missing_schema_when_probe_fails(
+    mock_create_engine: Mock,
+    mock_connection_execute_failure: Mock,
+    spy_inspector: Mock,
+):
+    """A failed probe plus an absent schema still names the schema as the cause."""
+    spy_inspector.return_value = ["some_other_schema"]
+
+    with pytest.raises(TestConnectionError) as exc_info:
+        _schema_qualified_datasource().test_connection()
+
+    assert 'schema "my_schema" does not exist' in str(exc_info.value)
+    spy_inspector.assert_called_once()
+
+
+@pytest.mark.postgresql
+def test_test_connection_reports_query_failure_when_schema_exists(
+    mock_create_engine: Mock,
+    mock_connection_execute_failure: Mock,
+    spy_inspector: Mock,
+):
+    """A failed probe against a schema that does exist reports the query failure."""
+    spy_inspector.return_value = ["my_schema"]
+
+    with pytest.raises(TestConnectionError) as exc_info:
+        _schema_qualified_datasource().test_connection()
+
+    assert "the test query" in str(exc_info.value)
+    assert "does not exist" not in str(exc_info.value)
+
+
+@pytest.mark.postgresql
+def test_test_connection_query_failure_survives_unusable_schema_listing(
+    mock_create_engine: Mock,
+    mock_connection_execute_failure: Mock,
+    spy_inspector: Mock,
+):
+    """A broken schema listing must not mask the probe failure that came first."""
+    spy_inspector.side_effect = Exception("metadata backend unavailable")
+
+    with pytest.raises(TestConnectionError) as exc_info:
+        _schema_qualified_datasource().test_connection()
+
+    assert "the test query" in str(exc_info.value)
+    assert "metadata backend unavailable" not in str(exc_info.value)
+
+
 @pytest.mark.filesystem
 def test_query_data_asset(empty_data_context, create_source):
     query = "SELECT * FROM my_table"

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -826,10 +826,11 @@ def _schema_qualified_datasource() -> PostgresDatasource:
 @pytest.fixture
 def spy_inspector(mocker: MockFixture) -> Mock:
     """An inspector whose get_schema_names is a spy, so calls can be asserted on."""
+    spy = mocker.Mock(return_value=["my_schema"])
     inspector = MockSaInspector()
-    inspector.get_schema_names = mocker.Mock(return_value=["my_schema"])  # type: ignore[method-assign]
+    inspector.get_schema_names = spy  # type: ignore[method-assign] # FIXME CoP
     mocker.patch("sqlalchemy.inspect").return_value = inspector
-    return inspector.get_schema_names
+    return spy
 
 
 @pytest.mark.postgresql


### PR DESCRIPTION
## Summary

`TableAsset.test_connection()` listed every schema on the server *before* probing the table, then used the result solely to pick between two error messages. This moves that listing onto the failure path, where it is the only place it was ever needed.

On backends where listing schemas is cheap, the cost is invisible. On others it is a server-wide metadata operation whose cost scales with the entire instance rather than with the table being tested. A connection test that should cost one trivial query instead costs a full metadata scan — and inherits that scan's failure modes.

The concrete case that surfaced this: on a BigQuery project holding many thousands of datasets, `Inspector.get_schema_names()` resolves to a `datasets.list` call that makes the backend enumerate and authorize across every dataset in the project before filtering to what the caller can see. Measured against such a project, a single `add_table_asset()` took **~52s**, against **1.22s** for a trivial query on the same connection — and the API returned enough `503`s that some calls exhausted the client's 600s retry deadline and failed outright. Narrowing the credential does not help, because the caller's visibility is applied *after* the enumeration.

Nothing about that is BigQuery-specific in kind, only in degree, so the fix is in shared SQL code and needs no per-dialect special-casing.

## What changed

- The probe query runs first. The schema listing happens only if the probe fails, to refine the error message.
- Both error messages are byte-for-byte unchanged.
- Extracted `_schema_exists()` for the failure-path lookup.

## Deliberate consequences

1. **The probe query, not the schema listing, is now the authority on reachability.** Previously a schema that existed but did not match the normalized output of `get_schema_names()` — quoting or case differences on some dialects — was rejected even though the table was perfectly accessible. Those configurations now succeed. This is a fixed false negative, not a relaxation: the probe is the stronger test, since it verifies the caller can actually select from the table.

2. **A failing schema listing can no longer mask the probe failure that preceded it.** It is logged at info level and the generic query-failure message is raised. A diagnostic must never replace the fault it was meant to explain.